### PR TITLE
ci: better error formatting

### DIFF
--- a/ci/format.sh
+++ b/ci/format.sh
@@ -61,15 +61,15 @@ for dir in "${packages[@]}"; do
     count=$((count + 1))
 
     if swift-format format -i -r "${dir}/Sources" "${dir}/Tests"; then
-        echo "✓ ${dir} passed"
+        echo "::info:: ✓ ${dir} passed"
     else
-        echo "✗ ${dir} failed" >&2
+        echo "::error:: ✗ ${dir} failed" >&2
         errors=$((errors + 1))
     fi
 done
 
 echo ""
-echo "${count} package(s) formatted, ${errors} failure(s)."
+echo "::info:: ${count} package(s) formatted, ${errors} failure(s)."
 
 if [[ ${errors} -gt 0 ]]; then
     exit 1

--- a/ci/generated.sh
+++ b/ci/generated.sh
@@ -41,11 +41,13 @@ for dir in "${generated[@]}"; do
     [[ -f "${dir}/Package.swift" ]] || continue
     count=$((count + 1))
 
-    echo "--- Building ${dir} ---"
+    echo "::group:: --- Building ${dir} ---"
     if swift build --build-tests "${flags[@]}" --package-path "${dir}"; then
-        echo "✓ ${dir} built"
+        echo "::info:: ✓ ${dir} built"
+        echo "::endgroup::"
     else
-        echo "✗ ${dir} failed to build" >&2
+        echo "::endgroup::"
+        echo "::error:: ✗ ${dir} failed to build" >&2
         errors=$((errors + 1))
     fi
 done

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -60,20 +60,22 @@ for dir in "${packages[@]}"; do
     [[ -f "${dir}/Package.swift" ]] || continue
     count=$((count + 1))
 
-    echo "--- Linting ${dir} ---"
+    echo "::group:: --- Linting ${dir} ---"
 
     # For local packages, we run swift-format directly on the Sources and Tests directories
     # to avoid the SPM plugin forcefully feeding the generated Rust bridge files.
     if swift-format lint -r "${dir}/Sources" "${dir}/Tests"; then
-        echo "✓ ${dir} passed"
+        echo "::info:: ✓ ${dir} passed"
+        echo "::endgroup::"
     else
-        echo "✗ ${dir} failed" >&2
+        echo "::endgroup::"
+        echo "::error:: ✗ ${dir} failed" >&2
         errors=$((errors + 1))
     fi
 done
 
 echo ""
-echo "${count} local package(s) linted, ${errors} failure(s)."
+echo "::info:: ${count} local package(s) linted, ${errors} failure(s)."
 
 if [[ ${errors} -gt 0 ]]; then
     exit 1

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -46,27 +46,28 @@ for dir in "${packages[@]}"; do
 
     echo "::group::--- Building ${dir} ---"
     if swift build --build-tests "${flags[@]}" --package-path "${dir}"; then
-        echo "✓ ${dir} built"
+        echo "::info:: ✓ ${dir} built"
     else
-        echo "✗ ${dir} failed to build" >&2
         echo "::endgroup::"
+        echo "::error:: ✗ ${dir} failed to build" >&2
         errors=$((errors + 1))
         continue
     fi
 
     [[ -d "${dir}/Tests" ]] || continue
-    echo "--- Testing ${dir} ---"
+    echo "::info:: --- Testing ${dir} ---"
     if swift test "${flags[@]}" --quiet --package-path "${dir}"; then
-        echo "✓ ${dir} passed"
+        echo "::info:: ✓ ${dir} passed"
+        echo "::endgroup::"
     else
-        echo "✗ ${dir} failed" >&2
+        echo "::endgroup::"
+        echo "::error:: ✗ ${dir} failed" >&2
         errors=$((errors + 1))
     fi
-    echo "::endgroup::"
 done
 
 echo ""
-echo "${count} local package(s) tested, ${errors} failure(s)."
+echo "::info:: ${count} local package(s) tested, ${errors} failure(s)."
 
 if [[ ${errors} -gt 0 ]]; then
     exit 1


### PR DESCRIPTION
Use the GitHub Actions commands to propertly format errors and informational messages.

Group logs by target / package so the output is structured in folded region, and we can quickly scan the logs for the things that failed.

On failure, print the error message outside the folded region. On success, print the informational message inside the folded region.