### PR TITLE
cleanup: fix top-level package warnings 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "90fa710bd21ef8bffb940f025c3ea723ddc6b788c386e1faf2f1d9afa0322aab",
+  "originHash" : "2a4cefb42b761e69e9ae4cf3094fe5008ef1c4e9afb22d0a74ce38d0f3417147",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
-        "version" : "1.44.0"
+        "revision" : "45bdf670248be5f16ec0340e125dca285536f0fb",
+        "version" : "1.45.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,7 @@ let package = Package(
     .package(path: "./packages/test-helpers"),
     .package(path: "./packages/wkt"),
     .package(path: "./packages/storage"),
+    .package(path: "./guide"),
     .package(
       path: "./generated/google-cloud-compute-v1",
       traits: ["Instances", "Images", "ZoneOperations"]),
@@ -54,6 +55,9 @@ let package = Package(
       dependencies: [
         .product(name: "GoogleCloudAuth", package: "auth")
       ]),
+    // .testTarget(
+    //   name: "AllModules",
+    //   dependencies: [.product(name: "UserGuide", package: "guide")]),
     .testTarget(
       name: "Discovery",
       dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,6 @@ let package = Package(
     .package(path: "./packages/test-helpers"),
     .package(path: "./packages/wkt"),
     .package(path: "./packages/storage"),
-    .package(path: "./guide"),
     .package(
       path: "./generated/google-cloud-compute-v1",
       traits: ["Instances", "Images", "ZoneOperations"]),
@@ -50,7 +49,6 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-log", from: "1.12.0"),
   ],
   targets: [
-    .target(name: "UserGuide", dependencies: [.product(name: "UserGuide", package: "guide")]),
     .testTarget(
       name: "IntegrationTests",
       dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -55,9 +55,9 @@ let package = Package(
       dependencies: [
         .product(name: "GoogleCloudAuth", package: "auth")
       ]),
-    // .testTarget(
-    //   name: "AllModules",
-    //   dependencies: [.product(name: "UserGuide", package: "guide")]),
+    .testTarget(
+      name: "AllModules",
+      dependencies: [.product(name: "UserGuide", package: "guide")]),
     .testTarget(
       name: "Discovery",
       dependencies: [

--- a/Tests/AllModules/UserGuide.swift
+++ b/Tests/AllModules/UserGuide.swift
@@ -1,0 +1,23 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+
+// An empty test-suite to suppress unused dependency warnings.
+//
+// We want to generate documentation for the UserGuide package from the top-level directory. Without
+// a test or other target using the package we get an annoying warning:
+//     `dependency 'guide' is not used by any target'
+@Suite struct UserGuide {}

--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -245,7 +245,7 @@ env GOOGLE_CLOUD_PROJECT=${P_ID} GOOGLE_CLOUD_SWIFT_TEST_SERVICE_ACCOUNT=swift-s
 To preview the user guide use:
 
 ```bash
-swift package --package-path guide --disable-sandbox preview-documentation --target UserGuide
+swift package --disable-sandbox preview-documentation --target UserGuide
 ```
 
 To preview one of the hand-crated packages use:

--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -240,6 +240,29 @@ P_ID="$(gcloud config get project)"
 env GOOGLE_CLOUD_PROJECT=${P_ID} GOOGLE_CLOUD_SWIFT_TEST_SERVICE_ACCOUNT=swift-sdk-test@${P_ID}.iam.gserviceaccount.com swift test --traits IntegrationTests
 ```
 
+## Preview Documentation
+
+To preview the user guide use:
+
+```bash
+swift package --package-path guide --disable-sandbox preview-documentation --target UserGuide
+```
+
+To preview one of the hand-crated packages use:
+
+```bash
+swift package --disable-sandbox preview-documentation --target GoogleCloudAuth
+swift package --disable-sandbox preview-documentation --target GoogleCloudWkt
+swift package --disable-sandbox preview-documentation --target GoogleCloudGax
+```
+
+You can also preview the GAPICs used by the top-level tests, for example:
+
+```bash
+swift package --disable-sandbox preview-documentation --target GoogleCloudSecretmanagerV1
+swift package --disable-sandbox preview-documentation --target GoogleCloudComputeV1
+```
+
 ## Miscellaneous Tools
 
 We use a number of tools to format non-Swift code. The CI builds enforce

--- a/guide/Package.swift
+++ b/guide/Package.swift
@@ -29,7 +29,6 @@ let package = Package(
     .package(path: "../packages/auth"),
     .package(path: "../generated/google-cloud-secretmanager-v1"),
     .package(url: "https://github.com/apple/swift-log", from: "1.12.0"),
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
   ],
   targets: [
     .target(

--- a/guide/Package.swift
+++ b/guide/Package.swift
@@ -26,10 +26,10 @@ let package = Package(
   ],
   dependencies: [
     .package(path: "../packages/gax"),
-    .package(path: "../packages/wkt"),
     .package(path: "../packages/auth"),
     .package(path: "../generated/google-cloud-secretmanager-v1"),
     .package(url: "https://github.com/apple/swift-log", from: "1.12.0"),
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Fix warnings in the top-level package about the `guide/` directory. I
was trying to make it easier to use from the top-level directory, but it
was just too noisy.

Document how to preview the documentation.