### PR TITLE
chore: update librarian circa 2026-07-24

### DIFF
--- a/generated/google-api-apikeys-v2/Sources/GoogleApiApikeysV2/ApiKeys+Logging.swift
+++ b/generated/google-api-apikeys-v2/Sources/GoogleApiApikeysV2/ApiKeys+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ApiKeysStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleApiApikeysV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-api-apikeys-v2"
       logger[metadataKey: "gcp.client.service"] = "apikeys"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ApiKeys"
       self.inner = inner

--- a/generated/google-api-cloudquotas-v1/Sources/GoogleApiCloudquotasV1/CloudQuotas+Logging.swift
+++ b/generated/google-api-cloudquotas-v1/Sources/GoogleApiCloudquotasV1/CloudQuotas+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any CloudQuotasStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleApiCloudquotasV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-api-cloudquotas-v1"
       logger[metadataKey: "gcp.client.service"] = "cloudquotas"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CloudQuotas"
       self.inner = inner

--- a/generated/google-api-cloudquotas-v1/Sources/GoogleApiCloudquotasV1/QuotaAdjusterSettingsManager+Logging.swift
+++ b/generated/google-api-cloudquotas-v1/Sources/GoogleApiCloudquotasV1/QuotaAdjusterSettingsManager+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any QuotaAdjusterSettingsManagerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleApiCloudquotasV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-api-cloudquotas-v1"
       logger[metadataKey: "gcp.client.service"] = "cloudquotas"
       logger[metadataKey: "gcp.experimental.swift.client"] = "QuotaAdjusterSettingsManager"
       self.inner = inner

--- a/generated/google-api-servicecontrol-v1/Sources/GoogleApiServicecontrolV1/QuotaController+Logging.swift
+++ b/generated/google-api-servicecontrol-v1/Sources/GoogleApiServicecontrolV1/QuotaController+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any QuotaControllerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleApiServicecontrolV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-api-servicecontrol-v1"
       logger[metadataKey: "gcp.client.service"] = "servicecontrol"
       logger[metadataKey: "gcp.experimental.swift.client"] = "QuotaController"
       self.inner = inner

--- a/generated/google-api-servicecontrol-v1/Sources/GoogleApiServicecontrolV1/ServiceController+Logging.swift
+++ b/generated/google-api-servicecontrol-v1/Sources/GoogleApiServicecontrolV1/ServiceController+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any ServiceControllerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleApiServicecontrolV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-api-servicecontrol-v1"
       logger[metadataKey: "gcp.client.service"] = "servicecontrol"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ServiceController"
       self.inner = inner

--- a/generated/google-api-servicecontrol-v2/Sources/GoogleApiServicecontrolV2/ServiceController+Logging.swift
+++ b/generated/google-api-servicecontrol-v2/Sources/GoogleApiServicecontrolV2/ServiceController+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any ServiceControllerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleApiServicecontrolV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-api-servicecontrol-v2"
       logger[metadataKey: "gcp.client.service"] = "servicecontrol"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ServiceController"
       self.inner = inner

--- a/generated/google-api-servicemanagement-v1/Sources/GoogleApiServicemanagementV1/ServiceManager+Logging.swift
+++ b/generated/google-api-servicemanagement-v1/Sources/GoogleApiServicemanagementV1/ServiceManager+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any ServiceManagerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleApiServicemanagementV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-api-servicemanagement-v1"
       logger[metadataKey: "gcp.client.service"] = "servicemanagement"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ServiceManager"
       self.inner = inner

--- a/generated/google-api-serviceusage-v1/Sources/GoogleApiServiceusageV1/ServiceUsage+Logging.swift
+++ b/generated/google-api-serviceusage-v1/Sources/GoogleApiServiceusageV1/ServiceUsage+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ServiceUsageStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleApiServiceusageV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-api-serviceusage-v1"
       logger[metadataKey: "gcp.client.service"] = "serviceusage"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ServiceUsage"
       self.inner = inner

--- a/generated/google-appengine-v1/Sources/GoogleAppengineV1/Applications+Logging.swift
+++ b/generated/google-appengine-v1/Sources/GoogleAppengineV1/Applications+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ApplicationsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleAppengineV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-appengine-v1"
       logger[metadataKey: "gcp.client.service"] = "appengine"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Applications"
       self.inner = inner

--- a/generated/google-appengine-v1/Sources/GoogleAppengineV1/AuthorizedCertificates+Logging.swift
+++ b/generated/google-appengine-v1/Sources/GoogleAppengineV1/AuthorizedCertificates+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any AuthorizedCertificatesStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleAppengineV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-appengine-v1"
       logger[metadataKey: "gcp.client.service"] = "appengine"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AuthorizedCertificates"
       self.inner = inner

--- a/generated/google-appengine-v1/Sources/GoogleAppengineV1/AuthorizedDomains+Logging.swift
+++ b/generated/google-appengine-v1/Sources/GoogleAppengineV1/AuthorizedDomains+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any AuthorizedDomainsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleAppengineV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-appengine-v1"
       logger[metadataKey: "gcp.client.service"] = "appengine"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AuthorizedDomains"
       self.inner = inner

--- a/generated/google-appengine-v1/Sources/GoogleAppengineV1/DomainMappings+Logging.swift
+++ b/generated/google-appengine-v1/Sources/GoogleAppengineV1/DomainMappings+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any DomainMappingsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleAppengineV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-appengine-v1"
       logger[metadataKey: "gcp.client.service"] = "appengine"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DomainMappings"
       self.inner = inner

--- a/generated/google-appengine-v1/Sources/GoogleAppengineV1/Firewall+Logging.swift
+++ b/generated/google-appengine-v1/Sources/GoogleAppengineV1/Firewall+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any FirewallStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleAppengineV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-appengine-v1"
       logger[metadataKey: "gcp.client.service"] = "appengine"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Firewall"
       self.inner = inner

--- a/generated/google-appengine-v1/Sources/GoogleAppengineV1/Instances+Logging.swift
+++ b/generated/google-appengine-v1/Sources/GoogleAppengineV1/Instances+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any InstancesStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleAppengineV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-appengine-v1"
       logger[metadataKey: "gcp.client.service"] = "appengine"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Instances"
       self.inner = inner

--- a/generated/google-appengine-v1/Sources/GoogleAppengineV1/Services+Logging.swift
+++ b/generated/google-appengine-v1/Sources/GoogleAppengineV1/Services+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ServicesStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleAppengineV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-appengine-v1"
       logger[metadataKey: "gcp.client.service"] = "appengine"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Services"
       self.inner = inner

--- a/generated/google-appengine-v1/Sources/GoogleAppengineV1/Versions+Logging.swift
+++ b/generated/google-appengine-v1/Sources/GoogleAppengineV1/Versions+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any VersionsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleAppengineV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-appengine-v1"
       logger[metadataKey: "gcp.client.service"] = "appengine"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Versions"
       self.inner = inner

--- a/generated/google-bigtable-admin-v2/Sources/GoogleBigtableAdminV2/BigtableInstanceAdmin+Logging.swift
+++ b/generated/google-bigtable-admin-v2/Sources/GoogleBigtableAdminV2/BigtableInstanceAdmin+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any BigtableInstanceAdminStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleBigtableAdminV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-bigtable-admin-v2"
       logger[metadataKey: "gcp.client.service"] = "bigtableadmin"
       logger[metadataKey: "gcp.experimental.swift.client"] = "BigtableInstanceAdmin"
       self.inner = inner

--- a/generated/google-bigtable-admin-v2/Sources/GoogleBigtableAdminV2/BigtableTableAdmin+Logging.swift
+++ b/generated/google-bigtable-admin-v2/Sources/GoogleBigtableAdminV2/BigtableTableAdmin+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any BigtableTableAdminStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleBigtableAdminV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-bigtable-admin-v2"
       logger[metadataKey: "gcp.client.service"] = "bigtableadmin"
       logger[metadataKey: "gcp.experimental.swift.client"] = "BigtableTableAdmin"
       self.inner = inner

--- a/generated/google-cloud-accessapproval-v1/Sources/GoogleCloudAccessapprovalV1/AccessApproval+Logging.swift
+++ b/generated/google-cloud-accessapproval-v1/Sources/GoogleCloudAccessapprovalV1/AccessApproval+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any AccessApprovalStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAccessapprovalV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-accessapproval-v1"
       logger[metadataKey: "gcp.client.service"] = "accessapproval"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AccessApproval"
       self.inner = inner

--- a/generated/google-cloud-advisorynotifications-v1/Sources/GoogleCloudAdvisorynotificationsV1/AdvisoryNotificationsService+Logging.swift
+++ b/generated/google-cloud-advisorynotifications-v1/Sources/GoogleCloudAdvisorynotificationsV1/AdvisoryNotificationsService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any AdvisoryNotificationsServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAdvisorynotificationsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-advisorynotifications-v1"
       logger[metadataKey: "gcp.client.service"] = "advisorynotifications"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AdvisoryNotificationsService"
       self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/DataFoundryService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/DataFoundryService+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any DataFoundryServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "DataFoundryService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/DatasetService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/DatasetService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any DatasetServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "DatasetService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/DeploymentResourcePoolService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/DeploymentResourcePoolService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any DeploymentResourcePoolServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "DeploymentResourcePoolService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/EndpointService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/EndpointService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any EndpointServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "EndpointService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/EvaluationService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/EvaluationService+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any EvaluationServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "EvaluationService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/FeatureOnlineStoreAdminService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/FeatureOnlineStoreAdminService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any FeatureOnlineStoreAdminServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "FeatureOnlineStoreAdminService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/FeatureOnlineStoreService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/FeatureOnlineStoreService+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any FeatureOnlineStoreServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "FeatureOnlineStoreService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/FeatureRegistryService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/FeatureRegistryService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any FeatureRegistryServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "FeatureRegistryService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/FeaturestoreOnlineServingService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/FeaturestoreOnlineServingService+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any FeaturestoreOnlineServingServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "FeaturestoreOnlineServingService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/FeaturestoreService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/FeaturestoreService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any FeaturestoreServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "FeaturestoreService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/GenAiCacheService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/GenAiCacheService+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any GenAiCacheServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "GenAiCacheService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/GenAiTuningService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/GenAiTuningService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any GenAiTuningServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "GenAiTuningService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/IndexEndpointService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/IndexEndpointService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any IndexEndpointServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "IndexEndpointService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/IndexService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/IndexService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any IndexServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "IndexService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/JobService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/JobService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any JobServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "JobService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/LlmUtilityService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/LlmUtilityService+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any LlmUtilityServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "LlmUtilityService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/MatchService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/MatchService+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any MatchServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "MatchService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/MetadataService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/MetadataService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any MetadataServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "MetadataService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/MigrationService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/MigrationService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any MigrationServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "MigrationService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/ModelGardenService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/ModelGardenService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any ModelGardenServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ModelGardenService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/ModelService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/ModelService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any ModelServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ModelService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/NotebookService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/NotebookService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any NotebookServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "NotebookService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/PersistentResourceService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/PersistentResourceService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any PersistentResourceServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "PersistentResourceService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/PipelineService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/PipelineService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any PipelineServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "PipelineService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/PredictionService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/PredictionService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any PredictionServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "PredictionService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/ReasoningEngineExecutionService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/ReasoningEngineExecutionService+Logging.swift
@@ -35,7 +35,7 @@
 
       public init(_ inner: any ReasoningEngineExecutionServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ReasoningEngineExecutionService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/ReasoningEngineService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/ReasoningEngineService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any ReasoningEngineServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ReasoningEngineService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/ScheduleService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/ScheduleService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any ScheduleServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ScheduleService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/SessionService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/SessionService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any SessionServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SessionService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/SpecialistPoolService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/SpecialistPoolService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any SpecialistPoolServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SpecialistPoolService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/TensorboardService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/TensorboardService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any TensorboardServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "TensorboardService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/VertexRagDataService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/VertexRagDataService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any VertexRagDataServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "VertexRagDataService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/VertexRagService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/VertexRagService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any VertexRagServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "VertexRagService"
         self.inner = inner

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/VizierService+Logging.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAiplatformV1/VizierService+Logging.swift
@@ -34,7 +34,7 @@
 
       public init(_ inner: any VizierServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAiplatformV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-aiplatform-v1"
         logger[metadataKey: "gcp.client.service"] = "aiplatform"
         logger[metadataKey: "gcp.experimental.swift.client"] = "VizierService"
         self.inner = inner

--- a/generated/google-cloud-alloydb-v1/Sources/GoogleCloudAlloydbV1/AlloyDBAdmin+Logging.swift
+++ b/generated/google-cloud-alloydb-v1/Sources/GoogleCloudAlloydbV1/AlloyDBAdmin+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any AlloyDBAdminStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAlloydbV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-alloydb-v1"
       logger[metadataKey: "gcp.client.service"] = "alloydb"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AlloyDBAdmin"
       self.inner = inner

--- a/generated/google-cloud-alloydb-v1/Sources/GoogleCloudAlloydbV1/AlloyDBCSQLAdmin+Logging.swift
+++ b/generated/google-cloud-alloydb-v1/Sources/GoogleCloudAlloydbV1/AlloyDBCSQLAdmin+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any AlloyDBCSQLAdminStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAlloydbV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-alloydb-v1"
       logger[metadataKey: "gcp.client.service"] = "alloydb"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AlloyDBCSQLAdmin"
       self.inner = inner

--- a/generated/google-cloud-apigateway-v1/Sources/GoogleCloudApigatewayV1/ApiGatewayService+Logging.swift
+++ b/generated/google-cloud-apigateway-v1/Sources/GoogleCloudApigatewayV1/ApiGatewayService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ApiGatewayServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudApigatewayV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-apigateway-v1"
       logger[metadataKey: "gcp.client.service"] = "apigateway"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ApiGatewayService"
       self.inner = inner

--- a/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/ApiHub+Logging.swift
+++ b/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/ApiHub+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ApiHubStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudApihubV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-apihub-v1"
       logger[metadataKey: "gcp.client.service"] = "apihub"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ApiHub"
       self.inner = inner

--- a/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/ApiHubCollect+Logging.swift
+++ b/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/ApiHubCollect+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any ApiHubCollectStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudApihubV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-apihub-v1"
       logger[metadataKey: "gcp.client.service"] = "apihub"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ApiHubCollect"
       self.inner = inner

--- a/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/ApiHubCurate+Logging.swift
+++ b/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/ApiHubCurate+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ApiHubCurateStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudApihubV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-apihub-v1"
       logger[metadataKey: "gcp.client.service"] = "apihub"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ApiHubCurate"
       self.inner = inner

--- a/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/ApiHubDependencies+Logging.swift
+++ b/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/ApiHubDependencies+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ApiHubDependenciesStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudApihubV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-apihub-v1"
       logger[metadataKey: "gcp.client.service"] = "apihub"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ApiHubDependencies"
       self.inner = inner

--- a/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/ApiHubDiscovery+Logging.swift
+++ b/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/ApiHubDiscovery+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ApiHubDiscoveryStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudApihubV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-apihub-v1"
       logger[metadataKey: "gcp.client.service"] = "apihub"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ApiHubDiscovery"
       self.inner = inner

--- a/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/ApiHubPlugin+Logging.swift
+++ b/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/ApiHubPlugin+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any ApiHubPluginStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudApihubV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-apihub-v1"
       logger[metadataKey: "gcp.client.service"] = "apihub"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ApiHubPlugin"
       self.inner = inner

--- a/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/HostProjectRegistrationService+Logging.swift
+++ b/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/HostProjectRegistrationService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any HostProjectRegistrationServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudApihubV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-apihub-v1"
       logger[metadataKey: "gcp.client.service"] = "apihub"
       logger[metadataKey: "gcp.experimental.swift.client"] = "HostProjectRegistrationService"
       self.inner = inner

--- a/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/LintingService+Logging.swift
+++ b/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/LintingService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any LintingServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudApihubV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-apihub-v1"
       logger[metadataKey: "gcp.client.service"] = "apihub"
       logger[metadataKey: "gcp.experimental.swift.client"] = "LintingService"
       self.inner = inner

--- a/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/Provisioning+Logging.swift
+++ b/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/Provisioning+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any ProvisioningStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudApihubV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-apihub-v1"
       logger[metadataKey: "gcp.client.service"] = "apihub"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Provisioning"
       self.inner = inner

--- a/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/RuntimeProjectAttachmentService+Logging.swift
+++ b/generated/google-cloud-apihub-v1/Sources/GoogleCloudApihubV1/RuntimeProjectAttachmentService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any RuntimeProjectAttachmentServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudApihubV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-apihub-v1"
       logger[metadataKey: "gcp.client.service"] = "apihub"
       logger[metadataKey: "gcp.experimental.swift.client"] = "RuntimeProjectAttachmentService"
       self.inner = inner

--- a/generated/google-cloud-apiregistry-v1/Sources/GoogleCloudApiregistryV1/CloudApiRegistry+Logging.swift
+++ b/generated/google-cloud-apiregistry-v1/Sources/GoogleCloudApiregistryV1/CloudApiRegistry+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any CloudApiRegistryStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudApiregistryV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-apiregistry-v1"
       logger[metadataKey: "gcp.client.service"] = "cloudapiregistry"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CloudApiRegistry"
       self.inner = inner

--- a/generated/google-cloud-apphub-v1/Sources/GoogleCloudApphubV1/AppHub+Logging.swift
+++ b/generated/google-cloud-apphub-v1/Sources/GoogleCloudApphubV1/AppHub+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any AppHubStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudApphubV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-apphub-v1"
       logger[metadataKey: "gcp.client.service"] = "apphub"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AppHub"
       self.inner = inner

--- a/generated/google-cloud-asset-v1/Sources/GoogleCloudAssetV1/AssetService+Logging.swift
+++ b/generated/google-cloud-asset-v1/Sources/GoogleCloudAssetV1/AssetService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any AssetServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAssetV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-asset-v1"
       logger[metadataKey: "gcp.client.service"] = "cloudasset"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AssetService"
       self.inner = inner

--- a/generated/google-cloud-assuredworkloads-v1/Sources/GoogleCloudAssuredworkloadsV1/AssuredWorkloadsService+Logging.swift
+++ b/generated/google-cloud-assuredworkloads-v1/Sources/GoogleCloudAssuredworkloadsV1/AssuredWorkloadsService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any AssuredWorkloadsServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAssuredworkloadsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-assuredworkloads-v1"
       logger[metadataKey: "gcp.client.service"] = "assuredworkloads"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AssuredWorkloadsService"
       self.inner = inner

--- a/generated/google-cloud-auditmanager-v1/Sources/GoogleCloudAuditmanagerV1/AuditManager+Logging.swift
+++ b/generated/google-cloud-auditmanager-v1/Sources/GoogleCloudAuditmanagerV1/AuditManager+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any AuditManagerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudAuditmanagerV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-auditmanager-v1"
       logger[metadataKey: "gcp.client.service"] = "auditmanager"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AuditManager"
       self.inner = inner

--- a/generated/google-cloud-baremetalsolution-v2/Sources/GoogleCloudBaremetalsolutionV2/BareMetalSolution+Logging.swift
+++ b/generated/google-cloud-baremetalsolution-v2/Sources/GoogleCloudBaremetalsolutionV2/BareMetalSolution+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any BareMetalSolutionStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBaremetalsolutionV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-baremetalsolution-v2"
       logger[metadataKey: "gcp.client.service"] = "baremetalsolution"
       logger[metadataKey: "gcp.experimental.swift.client"] = "BareMetalSolution"
       self.inner = inner

--- a/generated/google-cloud-batch-v1/Sources/GoogleCloudBatchV1/BatchService+Logging.swift
+++ b/generated/google-cloud-batch-v1/Sources/GoogleCloudBatchV1/BatchService+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any BatchServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBatchV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-batch-v1"
       logger[metadataKey: "gcp.client.service"] = "batch"
       logger[metadataKey: "gcp.experimental.swift.client"] = "BatchService"
       self.inner = inner

--- a/generated/google-cloud-beyondcorp-appconnections-v1/Sources/GoogleCloudBeyondcorpAppconnectionsV1/AppConnectionsService+Logging.swift
+++ b/generated/google-cloud-beyondcorp-appconnections-v1/Sources/GoogleCloudBeyondcorpAppconnectionsV1/AppConnectionsService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any AppConnectionsServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBeyondcorpAppconnectionsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-beyondcorp-appconnections-v1"
       logger[metadataKey: "gcp.client.service"] = "beyondcorp"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AppConnectionsService"
       self.inner = inner

--- a/generated/google-cloud-beyondcorp-appconnectors-v1/Sources/GoogleCloudBeyondcorpAppconnectorsV1/AppConnectorsService+Logging.swift
+++ b/generated/google-cloud-beyondcorp-appconnectors-v1/Sources/GoogleCloudBeyondcorpAppconnectorsV1/AppConnectorsService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any AppConnectorsServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBeyondcorpAppconnectorsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-beyondcorp-appconnectors-v1"
       logger[metadataKey: "gcp.client.service"] = "beyondcorp"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AppConnectorsService"
       self.inner = inner

--- a/generated/google-cloud-beyondcorp-appgateways-v1/Sources/GoogleCloudBeyondcorpAppgatewaysV1/AppGatewaysService+Logging.swift
+++ b/generated/google-cloud-beyondcorp-appgateways-v1/Sources/GoogleCloudBeyondcorpAppgatewaysV1/AppGatewaysService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any AppGatewaysServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBeyondcorpAppgatewaysV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-beyondcorp-appgateways-v1"
       logger[metadataKey: "gcp.client.service"] = "beyondcorp"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AppGatewaysService"
       self.inner = inner

--- a/generated/google-cloud-beyondcorp-clientconnectorservices-v1/Sources/GoogleCloudBeyondcorpClientconnectorservicesV1/ClientConnectorServicesService+Logging.swift
+++ b/generated/google-cloud-beyondcorp-clientconnectorservices-v1/Sources/GoogleCloudBeyondcorpClientconnectorservicesV1/ClientConnectorServicesService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any ClientConnectorServicesServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBeyondcorpClientconnectorservicesV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-beyondcorp-clientconnectorservices-v1"
       logger[metadataKey: "gcp.client.service"] = "beyondcorp"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ClientConnectorServicesService"
       self.inner = inner

--- a/generated/google-cloud-beyondcorp-clientgateways-v1/Sources/GoogleCloudBeyondcorpClientgatewaysV1/ClientGatewaysService+Logging.swift
+++ b/generated/google-cloud-beyondcorp-clientgateways-v1/Sources/GoogleCloudBeyondcorpClientgatewaysV1/ClientGatewaysService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any ClientGatewaysServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBeyondcorpClientgatewaysV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-beyondcorp-clientgateways-v1"
       logger[metadataKey: "gcp.client.service"] = "beyondcorp"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ClientGatewaysService"
       self.inner = inner

--- a/generated/google-cloud-biglake-v1/Sources/GoogleCloudBiglakeV1/IcebergCatalogService+Logging.swift
+++ b/generated/google-cloud-biglake-v1/Sources/GoogleCloudBiglakeV1/IcebergCatalogService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any IcebergCatalogServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBiglakeV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-biglake-v1"
       logger[metadataKey: "gcp.client.service"] = "biglake"
       logger[metadataKey: "gcp.experimental.swift.client"] = "IcebergCatalogService"
       self.inner = inner

--- a/generated/google-cloud-bigquery-analyticshub-v1/Sources/GoogleCloudBigqueryAnalyticshubV1/AnalyticsHubService+Logging.swift
+++ b/generated/google-cloud-bigquery-analyticshub-v1/Sources/GoogleCloudBigqueryAnalyticshubV1/AnalyticsHubService+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any AnalyticsHubServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBigqueryAnalyticshubV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-bigquery-analyticshub-v1"
       logger[metadataKey: "gcp.client.service"] = "analyticshub"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AnalyticsHubService"
       self.inner = inner

--- a/generated/google-cloud-bigquery-connection-v1/Sources/GoogleCloudBigqueryConnectionV1/ConnectionService+Logging.swift
+++ b/generated/google-cloud-bigquery-connection-v1/Sources/GoogleCloudBigqueryConnectionV1/ConnectionService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any ConnectionServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBigqueryConnectionV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-bigquery-connection-v1"
       logger[metadataKey: "gcp.client.service"] = "bigqueryconnection"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ConnectionService"
       self.inner = inner

--- a/generated/google-cloud-bigquery-datapolicies-v1/Sources/GoogleCloudBigqueryDatapoliciesV1/DataPolicyService+Logging.swift
+++ b/generated/google-cloud-bigquery-datapolicies-v1/Sources/GoogleCloudBigqueryDatapoliciesV1/DataPolicyService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any DataPolicyServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBigqueryDatapoliciesV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-bigquery-datapolicies-v1"
       logger[metadataKey: "gcp.client.service"] = "bigquerydatapolicy"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DataPolicyService"
       self.inner = inner

--- a/generated/google-cloud-bigquery-datapolicies-v2/Sources/GoogleCloudBigqueryDatapoliciesV2/DataPolicyService+Logging.swift
+++ b/generated/google-cloud-bigquery-datapolicies-v2/Sources/GoogleCloudBigqueryDatapoliciesV2/DataPolicyService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any DataPolicyServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBigqueryDatapoliciesV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-bigquery-datapolicies-v2"
       logger[metadataKey: "gcp.client.service"] = "bigquerydatapolicy"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DataPolicyService"
       self.inner = inner

--- a/generated/google-cloud-bigquery-datatransfer-v1/Sources/GoogleCloudBigqueryDatatransferV1/DataTransferService+Logging.swift
+++ b/generated/google-cloud-bigquery-datatransfer-v1/Sources/GoogleCloudBigqueryDatatransferV1/DataTransferService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any DataTransferServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBigqueryDatatransferV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-bigquery-datatransfer-v1"
       logger[metadataKey: "gcp.client.service"] = "bigquerydatatransfer"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DataTransferService"
       self.inner = inner

--- a/generated/google-cloud-billing-budgets-v1/Sources/GoogleCloudBillingBudgetsV1/BudgetService+Logging.swift
+++ b/generated/google-cloud-billing-budgets-v1/Sources/GoogleCloudBillingBudgetsV1/BudgetService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any BudgetServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBillingBudgetsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-billing-budgets-v1"
       logger[metadataKey: "gcp.client.service"] = "billingbudgets"
       logger[metadataKey: "gcp.experimental.swift.client"] = "BudgetService"
       self.inner = inner

--- a/generated/google-cloud-billing-v1/Sources/GoogleCloudBillingV1/CloudBilling+Logging.swift
+++ b/generated/google-cloud-billing-v1/Sources/GoogleCloudBillingV1/CloudBilling+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any CloudBillingStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBillingV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-billing-v1"
       logger[metadataKey: "gcp.client.service"] = "cloudbilling"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CloudBilling"
       self.inner = inner

--- a/generated/google-cloud-billing-v1/Sources/GoogleCloudBillingV1/CloudCatalog+Logging.swift
+++ b/generated/google-cloud-billing-v1/Sources/GoogleCloudBillingV1/CloudCatalog+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any CloudCatalogStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBillingV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-billing-v1"
       logger[metadataKey: "gcp.client.service"] = "cloudbilling"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CloudCatalog"
       self.inner = inner

--- a/generated/google-cloud-binaryauthorization-v1/Sources/GoogleCloudBinaryauthorizationV1/BinauthzManagementServiceV1+Logging.swift
+++ b/generated/google-cloud-binaryauthorization-v1/Sources/GoogleCloudBinaryauthorizationV1/BinauthzManagementServiceV1+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any BinauthzManagementServiceV1Stub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBinaryauthorizationV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-binaryauthorization-v1"
       logger[metadataKey: "gcp.client.service"] = "binaryauthorization"
       logger[metadataKey: "gcp.experimental.swift.client"] = "BinauthzManagementServiceV1"
       self.inner = inner

--- a/generated/google-cloud-binaryauthorization-v1/Sources/GoogleCloudBinaryauthorizationV1/SystemPolicyV1+Logging.swift
+++ b/generated/google-cloud-binaryauthorization-v1/Sources/GoogleCloudBinaryauthorizationV1/SystemPolicyV1+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any SystemPolicyV1Stub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBinaryauthorizationV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-binaryauthorization-v1"
       logger[metadataKey: "gcp.client.service"] = "binaryauthorization"
       logger[metadataKey: "gcp.experimental.swift.client"] = "SystemPolicyV1"
       self.inner = inner

--- a/generated/google-cloud-binaryauthorization-v1/Sources/GoogleCloudBinaryauthorizationV1/ValidationHelperV1+Logging.swift
+++ b/generated/google-cloud-binaryauthorization-v1/Sources/GoogleCloudBinaryauthorizationV1/ValidationHelperV1+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any ValidationHelperV1Stub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBinaryauthorizationV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-binaryauthorization-v1"
       logger[metadataKey: "gcp.client.service"] = "binaryauthorization"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ValidationHelperV1"
       self.inner = inner

--- a/generated/google-cloud-blockchainnodeengine-v1/Sources/GoogleCloudBlockchainnodeengineV1/BlockchainNodeEngine+Logging.swift
+++ b/generated/google-cloud-blockchainnodeengine-v1/Sources/GoogleCloudBlockchainnodeengineV1/BlockchainNodeEngine+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any BlockchainNodeEngineStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudBlockchainnodeengineV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-blockchainnodeengine-v1"
       logger[metadataKey: "gcp.client.service"] = "blockchainnodeengine"
       logger[metadataKey: "gcp.experimental.swift.client"] = "BlockchainNodeEngine"
       self.inner = inner

--- a/generated/google-cloud-certificatemanager-v1/Sources/GoogleCloudCertificatemanagerV1/CertificateManager+Logging.swift
+++ b/generated/google-cloud-certificatemanager-v1/Sources/GoogleCloudCertificatemanagerV1/CertificateManager+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any CertificateManagerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudCertificatemanagerV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-certificatemanager-v1"
       logger[metadataKey: "gcp.client.service"] = "certificatemanager"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CertificateManager"
       self.inner = inner

--- a/generated/google-cloud-ces-v1/Sources/GoogleCloudCesV1/AgentService+Logging.swift
+++ b/generated/google-cloud-ces-v1/Sources/GoogleCloudCesV1/AgentService+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any AgentServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudCesV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-ces-v1"
       logger[metadataKey: "gcp.client.service"] = "ces"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AgentService"
       self.inner = inner

--- a/generated/google-cloud-ces-v1/Sources/GoogleCloudCesV1/SessionService+Logging.swift
+++ b/generated/google-cloud-ces-v1/Sources/GoogleCloudCesV1/SessionService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any SessionServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudCesV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-ces-v1"
       logger[metadataKey: "gcp.client.service"] = "ces"
       logger[metadataKey: "gcp.experimental.swift.client"] = "SessionService"
       self.inner = inner

--- a/generated/google-cloud-ces-v1/Sources/GoogleCloudCesV1/ToolService+Logging.swift
+++ b/generated/google-cloud-ces-v1/Sources/GoogleCloudCesV1/ToolService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ToolServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudCesV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-ces-v1"
       logger[metadataKey: "gcp.client.service"] = "ces"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ToolService"
       self.inner = inner

--- a/generated/google-cloud-ces-v1/Sources/GoogleCloudCesV1/WidgetService+Logging.swift
+++ b/generated/google-cloud-ces-v1/Sources/GoogleCloudCesV1/WidgetService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any WidgetServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudCesV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-ces-v1"
       logger[metadataKey: "gcp.client.service"] = "ces"
       logger[metadataKey: "gcp.experimental.swift.client"] = "WidgetService"
       self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/acceleratorTypes+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/acceleratorTypes+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any AcceleratorTypesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "AcceleratorTypes"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/addresses+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/addresses+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any AddressesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Addresses"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/advice+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/advice+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any AdviceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Advice"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/autoscalers+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/autoscalers+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any AutoscalersStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Autoscalers"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/backendBuckets+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/backendBuckets+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any BackendBucketsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "BackendBuckets"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/backendServices+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/backendServices+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any BackendServicesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "BackendServices"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/crossSiteNetworks+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/crossSiteNetworks+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any CrossSiteNetworksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "CrossSiteNetworks"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/diskTypes+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/diskTypes+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any DiskTypesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "DiskTypes"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/disks+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/disks+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any DisksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Disks"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/externalVpnGateways+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/externalVpnGateways+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ExternalVpnGatewaysStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ExternalVpnGateways"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/firewallPolicies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/firewallPolicies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any FirewallPoliciesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "FirewallPolicies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/firewalls+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/firewalls+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any FirewallsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Firewalls"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/forwardingRules+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/forwardingRules+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ForwardingRulesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ForwardingRules"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/futureReservations+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/futureReservations+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any FutureReservationsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "FutureReservations"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalAddresses+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalAddresses+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any GlobalAddressesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "GlobalAddresses"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalForwardingRules+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalForwardingRules+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any GlobalForwardingRulesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "GlobalForwardingRules"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalNetworkEndpointGroups+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalNetworkEndpointGroups+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any GlobalNetworkEndpointGroupsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "GlobalNetworkEndpointGroups"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalOperations+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalOperations+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any GlobalOperationsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "GlobalOperations"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalOrganizationOperations+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalOrganizationOperations+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any GlobalOrganizationOperationsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "GlobalOrganizationOperations"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalPublicDelegatedPrefixes+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalPublicDelegatedPrefixes+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any GlobalPublicDelegatedPrefixesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "GlobalPublicDelegatedPrefixes"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalVmExtensionPolicies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/globalVmExtensionPolicies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any GlobalVmExtensionPoliciesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "GlobalVmExtensionPolicies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/healthChecks+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/healthChecks+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any HealthChecksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "HealthChecks"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/httpHealthChecks+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/httpHealthChecks+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any HttpHealthChecksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "HttpHealthChecks"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/httpsHealthChecks+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/httpsHealthChecks+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any HttpsHealthChecksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "HttpsHealthChecks"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/imageFamilyViews+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/imageFamilyViews+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ImageFamilyViewsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ImageFamilyViews"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/images+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/images+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ImagesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Images"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instanceGroupManagerResizeRequests+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instanceGroupManagerResizeRequests+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InstanceGroupManagerResizeRequestsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "InstanceGroupManagerResizeRequests"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instanceGroupManagers+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instanceGroupManagers+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InstanceGroupManagersStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "InstanceGroupManagers"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instanceGroups+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instanceGroups+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InstanceGroupsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "InstanceGroups"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instanceSettings+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instanceSettings+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InstanceSettingsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "InstanceSettings"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instanceTemplates+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instanceTemplates+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InstanceTemplatesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "InstanceTemplates"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instances+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instances+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InstancesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Instances"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instantSnapshotGroups+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instantSnapshotGroups+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InstantSnapshotGroupsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "InstantSnapshotGroups"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instantSnapshots+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/instantSnapshots+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InstantSnapshotsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "InstantSnapshots"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/interconnectAttachmentGroups+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/interconnectAttachmentGroups+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InterconnectAttachmentGroupsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "InterconnectAttachmentGroups"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/interconnectAttachments+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/interconnectAttachments+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InterconnectAttachmentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "InterconnectAttachments"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/interconnectGroups+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/interconnectGroups+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InterconnectGroupsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "InterconnectGroups"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/interconnectLocations+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/interconnectLocations+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InterconnectLocationsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "InterconnectLocations"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/interconnectRemoteLocations+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/interconnectRemoteLocations+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InterconnectRemoteLocationsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "InterconnectRemoteLocations"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/interconnects+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/interconnects+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any InterconnectsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Interconnects"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/licenseCodes+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/licenseCodes+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any LicenseCodesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "LicenseCodes"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/licenses+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/licenses+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any LicensesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Licenses"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/machineImages+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/machineImages+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any MachineImagesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "MachineImages"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/machineTypes+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/machineTypes+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any MachineTypesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "MachineTypes"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/networkAttachments+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/networkAttachments+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any NetworkAttachmentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "NetworkAttachments"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/networkEdgeSecurityServices+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/networkEdgeSecurityServices+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any NetworkEdgeSecurityServicesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "NetworkEdgeSecurityServices"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/networkEndpointGroups+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/networkEndpointGroups+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any NetworkEndpointGroupsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "NetworkEndpointGroups"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/networkFirewallPolicies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/networkFirewallPolicies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any NetworkFirewallPoliciesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "NetworkFirewallPolicies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/networkProfiles+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/networkProfiles+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any NetworkProfilesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "NetworkProfiles"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/networks+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/networks+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any NetworksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Networks"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/nodeGroups+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/nodeGroups+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any NodeGroupsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "NodeGroups"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/nodeTemplates+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/nodeTemplates+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any NodeTemplatesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "NodeTemplates"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/nodeTypes+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/nodeTypes+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any NodeTypesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "NodeTypes"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/organizationSecurityPolicies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/organizationSecurityPolicies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any OrganizationSecurityPoliciesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "OrganizationSecurityPolicies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/packetMirrorings+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/packetMirrorings+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any PacketMirroringsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "PacketMirrorings"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/previewFeatures+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/previewFeatures+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any PreviewFeaturesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "PreviewFeatures"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/projects+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/projects+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ProjectsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Projects"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/publicAdvertisedPrefixes+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/publicAdvertisedPrefixes+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any PublicAdvertisedPrefixesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "PublicAdvertisedPrefixes"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/publicDelegatedPrefixes+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/publicDelegatedPrefixes+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any PublicDelegatedPrefixesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "PublicDelegatedPrefixes"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionAutoscalers+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionAutoscalers+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionAutoscalersStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionAutoscalers"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionBackendBuckets+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionBackendBuckets+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionBackendBucketsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionBackendBuckets"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionBackendServices+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionBackendServices+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionBackendServicesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionBackendServices"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionCommitments+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionCommitments+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionCommitmentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionCommitments"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionCompositeHealthChecks+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionCompositeHealthChecks+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionCompositeHealthChecksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionCompositeHealthChecks"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionDiskTypes+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionDiskTypes+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionDiskTypesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionDiskTypes"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionDisks+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionDisks+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionDisksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionDisks"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionHealthAggregationPolicies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionHealthAggregationPolicies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionHealthAggregationPoliciesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionHealthAggregationPolicies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionHealthCheckServices+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionHealthCheckServices+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionHealthCheckServicesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionHealthCheckServices"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionHealthChecks+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionHealthChecks+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionHealthChecksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionHealthChecks"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionHealthSources+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionHealthSources+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionHealthSourcesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionHealthSources"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstanceGroupManagerResizeRequests+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstanceGroupManagerResizeRequests+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any RegionInstanceGroupManagerResizeRequestsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] =
           "RegionInstanceGroupManagerResizeRequests"

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstanceGroupManagers+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstanceGroupManagers+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionInstanceGroupManagersStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionInstanceGroupManagers"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstanceGroups+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstanceGroups+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionInstanceGroupsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionInstanceGroups"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstanceTemplates+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstanceTemplates+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionInstanceTemplatesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionInstanceTemplates"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstances+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstances+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionInstancesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionInstances"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstantSnapshotGroups+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstantSnapshotGroups+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionInstantSnapshotGroupsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionInstantSnapshotGroups"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstantSnapshots+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionInstantSnapshots+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionInstantSnapshotsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionInstantSnapshots"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionNetworkEndpointGroups+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionNetworkEndpointGroups+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionNetworkEndpointGroupsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionNetworkEndpointGroups"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionNetworkFirewallPolicies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionNetworkFirewallPolicies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionNetworkFirewallPoliciesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionNetworkFirewallPolicies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionNotificationEndpoints+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionNotificationEndpoints+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionNotificationEndpointsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionNotificationEndpoints"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionOperations+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionOperations+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionOperationsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionOperations"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionSecurityPolicies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionSecurityPolicies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionSecurityPoliciesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionSecurityPolicies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionSnapshotSettings+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionSnapshotSettings+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionSnapshotSettingsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionSnapshotSettings"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionSnapshots+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionSnapshots+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionSnapshotsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionSnapshots"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionSslCertificates+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionSslCertificates+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionSslCertificatesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionSslCertificates"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionSslPolicies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionSslPolicies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionSslPoliciesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionSslPolicies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionTargetHttpProxies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionTargetHttpProxies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionTargetHttpProxiesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionTargetHttpProxies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionTargetHttpsProxies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionTargetHttpsProxies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionTargetHttpsProxiesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionTargetHttpsProxies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionTargetTcpProxies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionTargetTcpProxies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionTargetTcpProxiesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionTargetTcpProxies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionUrlMaps+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionUrlMaps+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionUrlMapsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionUrlMaps"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionZones+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regionZones+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionZonesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RegionZones"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regions+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/regions+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RegionsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Regions"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/reservationBlocks+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/reservationBlocks+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ReservationBlocksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ReservationBlocks"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/reservationSlots+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/reservationSlots+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ReservationSlotsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ReservationSlots"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/reservationSubBlocks+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/reservationSubBlocks+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ReservationSubBlocksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ReservationSubBlocks"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/reservations+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/reservations+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ReservationsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Reservations"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/resourcePolicies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/resourcePolicies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ResourcePoliciesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ResourcePolicies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/rolloutPlans+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/rolloutPlans+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RolloutPlansStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RolloutPlans"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/rollouts+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/rollouts+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RolloutsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Rollouts"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/routers+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/routers+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RoutersStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Routers"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/routes+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/routes+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any RoutesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Routes"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/securityPolicies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/securityPolicies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SecurityPoliciesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SecurityPolicies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/serviceAttachments+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/serviceAttachments+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ServiceAttachmentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ServiceAttachments"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/snapshotSettings+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/snapshotSettings+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SnapshotSettingsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SnapshotSettings"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/snapshots+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/snapshots+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SnapshotsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Snapshots"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/sslCertificates+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/sslCertificates+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SslCertificatesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SslCertificates"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/sslPolicies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/sslPolicies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SslPoliciesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SslPolicies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/storagePoolTypes+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/storagePoolTypes+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any StoragePoolTypesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "StoragePoolTypes"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/storagePools+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/storagePools+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any StoragePoolsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "StoragePools"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/subnetworks+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/subnetworks+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SubnetworksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Subnetworks"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetGrpcProxies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetGrpcProxies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any TargetGrpcProxiesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "TargetGrpcProxies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetHttpProxies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetHttpProxies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any TargetHttpProxiesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "TargetHttpProxies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetHttpsProxies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetHttpsProxies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any TargetHttpsProxiesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "TargetHttpsProxies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetInstances+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetInstances+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any TargetInstancesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "TargetInstances"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetPools+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetPools+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any TargetPoolsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "TargetPools"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetSslProxies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetSslProxies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any TargetSslProxiesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "TargetSslProxies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetTcpProxies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetTcpProxies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any TargetTcpProxiesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "TargetTcpProxies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetVpnGateways+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/targetVpnGateways+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any TargetVpnGatewaysStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "TargetVpnGateways"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/urlMaps+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/urlMaps+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any UrlMapsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "UrlMaps"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/vpnGateways+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/vpnGateways+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any VpnGatewaysStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "VpnGateways"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/vpnTunnels+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/vpnTunnels+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any VpnTunnelsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "VpnTunnels"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/wireGroups+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/wireGroups+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any WireGroupsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "WireGroups"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/zoneOperations+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/zoneOperations+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ZoneOperationsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ZoneOperations"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/zoneVmExtensionPolicies+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/zoneVmExtensionPolicies+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ZoneVmExtensionPoliciesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ZoneVmExtensionPolicies"
         self.inner = inner

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/zones+Logging.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/zones+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any ZonesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudComputeV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-compute-v1"
         logger[metadataKey: "gcp.client.service"] = "compute"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Zones"
         self.inner = inner

--- a/generated/google-cloud-confidentialcomputing-v1/Sources/GoogleCloudConfidentialcomputingV1/ConfidentialComputing+Logging.swift
+++ b/generated/google-cloud-confidentialcomputing-v1/Sources/GoogleCloudConfidentialcomputingV1/ConfidentialComputing+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any ConfidentialComputingStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudConfidentialcomputingV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-confidentialcomputing-v1"
       logger[metadataKey: "gcp.client.service"] = "confidentialcomputing"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ConfidentialComputing"
       self.inner = inner

--- a/generated/google-cloud-config-v1/Sources/GoogleCloudConfigV1/Config+Logging.swift
+++ b/generated/google-cloud-config-v1/Sources/GoogleCloudConfigV1/Config+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any ConfigStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudConfigV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-config-v1"
       logger[metadataKey: "gcp.client.service"] = "config"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Config"
       self.inner = inner

--- a/generated/google-cloud-configdelivery-v1/Sources/GoogleCloudConfigdeliveryV1/ConfigDelivery+Logging.swift
+++ b/generated/google-cloud-configdelivery-v1/Sources/GoogleCloudConfigdeliveryV1/ConfigDelivery+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any ConfigDeliveryStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudConfigdeliveryV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-configdelivery-v1"
       logger[metadataKey: "gcp.client.service"] = "configdelivery"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ConfigDelivery"
       self.inner = inner

--- a/generated/google-cloud-connectors-v1/Sources/GoogleCloudConnectorsV1/Connectors+Logging.swift
+++ b/generated/google-cloud-connectors-v1/Sources/GoogleCloudConnectorsV1/Connectors+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any ConnectorsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudConnectorsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-connectors-v1"
       logger[metadataKey: "gcp.client.service"] = "connectors"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Connectors"
       self.inner = inner

--- a/generated/google-cloud-datacatalog-v1/Sources/GoogleCloudDatacatalogV1/DataCatalog+Logging.swift
+++ b/generated/google-cloud-datacatalog-v1/Sources/GoogleCloudDatacatalogV1/DataCatalog+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any DataCatalogStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDatacatalogV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-datacatalog-v1"
       logger[metadataKey: "gcp.client.service"] = "datacatalog"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DataCatalog"
       self.inner = inner

--- a/generated/google-cloud-datacatalog-v1/Sources/GoogleCloudDatacatalogV1/PolicyTagManager+Logging.swift
+++ b/generated/google-cloud-datacatalog-v1/Sources/GoogleCloudDatacatalogV1/PolicyTagManager+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any PolicyTagManagerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDatacatalogV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-datacatalog-v1"
       logger[metadataKey: "gcp.client.service"] = "datacatalog"
       logger[metadataKey: "gcp.experimental.swift.client"] = "PolicyTagManager"
       self.inner = inner

--- a/generated/google-cloud-datacatalog-v1/Sources/GoogleCloudDatacatalogV1/PolicyTagManagerSerialization+Logging.swift
+++ b/generated/google-cloud-datacatalog-v1/Sources/GoogleCloudDatacatalogV1/PolicyTagManagerSerialization+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any PolicyTagManagerSerializationStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDatacatalogV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-datacatalog-v1"
       logger[metadataKey: "gcp.client.service"] = "datacatalog"
       logger[metadataKey: "gcp.experimental.swift.client"] = "PolicyTagManagerSerialization"
       self.inner = inner

--- a/generated/google-cloud-dataform-v1/Sources/GoogleCloudDataformV1/Dataform+Logging.swift
+++ b/generated/google-cloud-dataform-v1/Sources/GoogleCloudDataformV1/Dataform+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any DataformStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDataformV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dataform-v1"
       logger[metadataKey: "gcp.client.service"] = "dataform"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Dataform"
       self.inner = inner

--- a/generated/google-cloud-datafusion-v1/Sources/GoogleCloudDatafusionV1/DataFusion+Logging.swift
+++ b/generated/google-cloud-datafusion-v1/Sources/GoogleCloudDatafusionV1/DataFusion+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any DataFusionStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDatafusionV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-datafusion-v1"
       logger[metadataKey: "gcp.client.service"] = "datafusion"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DataFusion"
       self.inner = inner

--- a/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/BusinessGlossaryService+Logging.swift
+++ b/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/BusinessGlossaryService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any BusinessGlossaryServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDataplexV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dataplex-v1"
       logger[metadataKey: "gcp.client.service"] = "dataplex"
       logger[metadataKey: "gcp.experimental.swift.client"] = "BusinessGlossaryService"
       self.inner = inner

--- a/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/CatalogService+Logging.swift
+++ b/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/CatalogService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any CatalogServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDataplexV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dataplex-v1"
       logger[metadataKey: "gcp.client.service"] = "dataplex"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CatalogService"
       self.inner = inner

--- a/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/CmekService+Logging.swift
+++ b/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/CmekService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any CmekServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDataplexV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dataplex-v1"
       logger[metadataKey: "gcp.client.service"] = "dataplex"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CmekService"
       self.inner = inner

--- a/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/ContentService+Logging.swift
+++ b/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/ContentService+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any ContentServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDataplexV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dataplex-v1"
       logger[metadataKey: "gcp.client.service"] = "dataplex"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ContentService"
       self.inner = inner

--- a/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/DataProductService+Logging.swift
+++ b/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/DataProductService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any DataProductServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDataplexV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dataplex-v1"
       logger[metadataKey: "gcp.client.service"] = "dataplex"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DataProductService"
       self.inner = inner

--- a/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/DataScanService+Logging.swift
+++ b/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/DataScanService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any DataScanServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDataplexV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dataplex-v1"
       logger[metadataKey: "gcp.client.service"] = "dataplex"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DataScanService"
       self.inner = inner

--- a/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/DataTaxonomyService+Logging.swift
+++ b/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/DataTaxonomyService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any DataTaxonomyServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDataplexV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dataplex-v1"
       logger[metadataKey: "gcp.client.service"] = "dataplex"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DataTaxonomyService"
       self.inner = inner

--- a/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/DataplexService+Logging.swift
+++ b/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/DataplexService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any DataplexServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDataplexV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dataplex-v1"
       logger[metadataKey: "gcp.client.service"] = "dataplex"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DataplexService"
       self.inner = inner

--- a/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/MetadataService+Logging.swift
+++ b/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/MetadataService+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any MetadataServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDataplexV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dataplex-v1"
       logger[metadataKey: "gcp.client.service"] = "dataplex"
       logger[metadataKey: "gcp.experimental.swift.client"] = "MetadataService"
       self.inner = inner

--- a/generated/google-cloud-deploy-v1/Sources/GoogleCloudDeployV1/CloudDeploy+Logging.swift
+++ b/generated/google-cloud-deploy-v1/Sources/GoogleCloudDeployV1/CloudDeploy+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any CloudDeployStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDeployV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-deploy-v1"
       logger[metadataKey: "gcp.client.service"] = "clouddeploy"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CloudDeploy"
       self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Agents+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Agents+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any AgentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Agents"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Changelogs+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Changelogs+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any ChangelogsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Changelogs"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Deployments+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Deployments+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any DeploymentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Deployments"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/EntityTypes+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/EntityTypes+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any EntityTypesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "EntityTypes"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Environments+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Environments+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any EnvironmentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Environments"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Examples+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Examples+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any ExamplesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Examples"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Experiments+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Experiments+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any ExperimentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Experiments"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Flows+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Flows+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any FlowsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Flows"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Generators+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Generators+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any GeneratorsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Generators"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Intents+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Intents+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any IntentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Intents"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Pages+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Pages+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any PagesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Pages"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Playbooks+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Playbooks+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any PlaybooksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Playbooks"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/SecuritySettingsService+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/SecuritySettingsService+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any SecuritySettingsServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SecuritySettingsService"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/SessionEntityTypes+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/SessionEntityTypes+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any SessionEntityTypesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SessionEntityTypes"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Sessions+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Sessions+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any SessionsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Sessions"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/TestCases+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/TestCases+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any TestCasesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "TestCases"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Tools+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Tools+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any ToolsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Tools"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/TransitionRouteGroups+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/TransitionRouteGroups+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any TransitionRouteGroupsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "TransitionRouteGroups"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Versions+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Versions+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any VersionsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Versions"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Webhooks+Logging.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCxV3/Webhooks+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any WebhooksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowCxV3"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-cx-v3"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Webhooks"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Agents+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Agents+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any AgentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Agents"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/AnswerRecords+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/AnswerRecords+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any AnswerRecordsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "AnswerRecords"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Contexts+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Contexts+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any ContextsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Contexts"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/ConversationDatasets+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/ConversationDatasets+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any ConversationDatasetsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ConversationDatasets"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/ConversationModels+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/ConversationModels+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any ConversationModelsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ConversationModels"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/ConversationProfiles+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/ConversationProfiles+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any ConversationProfilesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ConversationProfiles"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Conversations+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Conversations+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any ConversationsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Conversations"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Documents+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Documents+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any DocumentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Documents"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/EncryptionSpecService+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/EncryptionSpecService+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any EncryptionSpecServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "EncryptionSpecService"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/EntityTypes+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/EntityTypes+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any EntityTypesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "EntityTypes"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Environments+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Environments+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any EnvironmentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Environments"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Fulfillments+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Fulfillments+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any FulfillmentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Fulfillments"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/GeneratorEvaluations+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/GeneratorEvaluations+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any GeneratorEvaluationsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "GeneratorEvaluations"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Generators+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Generators+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any GeneratorsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Generators"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Intents+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Intents+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any IntentsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Intents"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/KnowledgeBases+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/KnowledgeBases+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any KnowledgeBasesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "KnowledgeBases"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Participants+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Participants+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any ParticipantsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Participants"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/SessionEntityTypes+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/SessionEntityTypes+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any SessionEntityTypesStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SessionEntityTypes"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Sessions+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Sessions+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any SessionsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Sessions"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/SipTrunks+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/SipTrunks+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any SipTrunksStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SipTrunks"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Tools+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Tools+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any ToolsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Tools"
         self.inner = inner

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Versions+Logging.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Versions+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any VersionsStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDialogflowV2"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-dialogflow-v2"
         logger[metadataKey: "gcp.client.service"] = "dialogflow"
         logger[metadataKey: "gcp.experimental.swift.client"] = "Versions"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/AssistantService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/AssistantService+Logging.swift
@@ -31,7 +31,7 @@
 
       public init(_ inner: any AssistantServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "AssistantService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/CmekConfigService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/CmekConfigService+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any CmekConfigServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "CmekConfigService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/CompletionService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/CompletionService+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any CompletionServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "CompletionService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/ControlService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/ControlService+Logging.swift
@@ -31,7 +31,7 @@
 
       public init(_ inner: any ControlServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ControlService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/ConversationalSearchService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/ConversationalSearchService+Logging.swift
@@ -31,7 +31,7 @@
 
       public init(_ inner: any ConversationalSearchServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ConversationalSearchService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/DataStoreService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/DataStoreService+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any DataStoreServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "DataStoreService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/DocumentService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/DocumentService+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any DocumentServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "DocumentService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/EngineService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/EngineService+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any EngineServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "EngineService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/GroundedGenerationService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/GroundedGenerationService+Logging.swift
@@ -31,7 +31,7 @@
 
       public init(_ inner: any GroundedGenerationServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "GroundedGenerationService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/IdentityMappingStoreService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/IdentityMappingStoreService+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any IdentityMappingStoreServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "IdentityMappingStoreService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/ProjectService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/ProjectService+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any ProjectServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ProjectService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/RankService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/RankService+Logging.swift
@@ -31,7 +31,7 @@
 
       public init(_ inner: any RankServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RankService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/RecommendationService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/RecommendationService+Logging.swift
@@ -31,7 +31,7 @@
 
       public init(_ inner: any RecommendationServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "RecommendationService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/SchemaService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/SchemaService+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any SchemaServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SchemaService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/SearchService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/SearchService+Logging.swift
@@ -31,7 +31,7 @@
 
       public init(_ inner: any SearchServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SearchService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/SearchTuningService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/SearchTuningService+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any SearchTuningServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SearchTuningService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/ServingConfigService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/ServingConfigService+Logging.swift
@@ -31,7 +31,7 @@
 
       public init(_ inner: any ServingConfigServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "ServingConfigService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/SessionService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/SessionService+Logging.swift
@@ -31,7 +31,7 @@
 
       public init(_ inner: any SessionServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SessionService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/SiteSearchEngineService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/SiteSearchEngineService+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any SiteSearchEngineServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SiteSearchEngineService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/UserEventService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/UserEventService+Logging.swift
@@ -33,7 +33,7 @@
 
       public init(_ inner: any UserEventServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "UserEventService"
         self.inner = inner

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/UserLicenseService+Logging.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryengineV1/UserLicenseService+Logging.swift
@@ -32,7 +32,7 @@
 
       public init(_ inner: any UserLicenseServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDiscoveryengineV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-discoveryengine-v1"
         logger[metadataKey: "gcp.client.service"] = "discoveryengine"
         logger[metadataKey: "gcp.experimental.swift.client"] = "UserLicenseService"
         self.inner = inner

--- a/generated/google-cloud-domains-v1/Sources/GoogleCloudDomainsV1/Domains+Logging.swift
+++ b/generated/google-cloud-domains-v1/Sources/GoogleCloudDomainsV1/Domains+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any DomainsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudDomainsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-domains-v1"
       logger[metadataKey: "gcp.client.service"] = "domains"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Domains"
       self.inner = inner

--- a/generated/google-cloud-edgecontainer-v1/Sources/GoogleCloudEdgecontainerV1/EdgeContainer+Logging.swift
+++ b/generated/google-cloud-edgecontainer-v1/Sources/GoogleCloudEdgecontainerV1/EdgeContainer+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any EdgeContainerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudEdgecontainerV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-edgecontainer-v1"
       logger[metadataKey: "gcp.client.service"] = "edgecontainer"
       logger[metadataKey: "gcp.experimental.swift.client"] = "EdgeContainer"
       self.inner = inner

--- a/generated/google-cloud-edgenetwork-v1/Sources/GoogleCloudEdgenetworkV1/EdgeNetwork+Logging.swift
+++ b/generated/google-cloud-edgenetwork-v1/Sources/GoogleCloudEdgenetworkV1/EdgeNetwork+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any EdgeNetworkStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudEdgenetworkV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-edgenetwork-v1"
       logger[metadataKey: "gcp.client.service"] = "edgenetwork"
       logger[metadataKey: "gcp.experimental.swift.client"] = "EdgeNetwork"
       self.inner = inner

--- a/generated/google-cloud-eventarc-v1/Sources/GoogleCloudEventarcV1/Eventarc+Logging.swift
+++ b/generated/google-cloud-eventarc-v1/Sources/GoogleCloudEventarcV1/Eventarc+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any EventarcStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudEventarcV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-eventarc-v1"
       logger[metadataKey: "gcp.client.service"] = "eventarc"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Eventarc"
       self.inner = inner

--- a/generated/google-cloud-filestore-v1/Sources/GoogleCloudFilestoreV1/CloudFilestoreManager+Logging.swift
+++ b/generated/google-cloud-filestore-v1/Sources/GoogleCloudFilestoreV1/CloudFilestoreManager+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any CloudFilestoreManagerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudFilestoreV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-filestore-v1"
       logger[metadataKey: "gcp.client.service"] = "file"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CloudFilestoreManager"
       self.inner = inner

--- a/generated/google-cloud-functions-v2/Sources/GoogleCloudFunctionsV2/FunctionService+Logging.swift
+++ b/generated/google-cloud-functions-v2/Sources/GoogleCloudFunctionsV2/FunctionService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any FunctionServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudFunctionsV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-functions-v2"
       logger[metadataKey: "gcp.client.service"] = "cloudfunctions"
       logger[metadataKey: "gcp.experimental.swift.client"] = "FunctionService"
       self.inner = inner

--- a/generated/google-cloud-gkehub-v1/Sources/GoogleCloudGkehubV1/GkeHub+Logging.swift
+++ b/generated/google-cloud-gkehub-v1/Sources/GoogleCloudGkehubV1/GkeHub+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any GkeHubStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudGkehubV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-gkehub-v1"
       logger[metadataKey: "gcp.client.service"] = "gkehub"
       logger[metadataKey: "gcp.experimental.swift.client"] = "GkeHub"
       self.inner = inner

--- a/generated/google-cloud-gkemulticloud-v1/Sources/GoogleCloudGkemulticloudV1/AttachedClusters+Logging.swift
+++ b/generated/google-cloud-gkemulticloud-v1/Sources/GoogleCloudGkemulticloudV1/AttachedClusters+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any AttachedClustersStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudGkemulticloudV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-gkemulticloud-v1"
       logger[metadataKey: "gcp.client.service"] = "gkemulticloud"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AttachedClusters"
       self.inner = inner

--- a/generated/google-cloud-gkemulticloud-v1/Sources/GoogleCloudGkemulticloudV1/AwsClusters+Logging.swift
+++ b/generated/google-cloud-gkemulticloud-v1/Sources/GoogleCloudGkemulticloudV1/AwsClusters+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any AwsClustersStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudGkemulticloudV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-gkemulticloud-v1"
       logger[metadataKey: "gcp.client.service"] = "gkemulticloud"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AwsClusters"
       self.inner = inner

--- a/generated/google-cloud-gkemulticloud-v1/Sources/GoogleCloudGkemulticloudV1/AzureClusters+Logging.swift
+++ b/generated/google-cloud-gkemulticloud-v1/Sources/GoogleCloudGkemulticloudV1/AzureClusters+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any AzureClustersStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudGkemulticloudV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-gkemulticloud-v1"
       logger[metadataKey: "gcp.client.service"] = "gkemulticloud"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AzureClusters"
       self.inner = inner

--- a/generated/google-cloud-kms-inventory-v1/Sources/GoogleCloudKmsInventoryV1/KeyDashboardService+Logging.swift
+++ b/generated/google-cloud-kms-inventory-v1/Sources/GoogleCloudKmsInventoryV1/KeyDashboardService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any KeyDashboardServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudKmsInventoryV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-kms-inventory-v1"
       logger[metadataKey: "gcp.client.service"] = "kmsinventory"
       logger[metadataKey: "gcp.experimental.swift.client"] = "KeyDashboardService"
       self.inner = inner

--- a/generated/google-cloud-kms-inventory-v1/Sources/GoogleCloudKmsInventoryV1/KeyTrackingService+Logging.swift
+++ b/generated/google-cloud-kms-inventory-v1/Sources/GoogleCloudKmsInventoryV1/KeyTrackingService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any KeyTrackingServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudKmsInventoryV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-kms-inventory-v1"
       logger[metadataKey: "gcp.client.service"] = "kmsinventory"
       logger[metadataKey: "gcp.experimental.swift.client"] = "KeyTrackingService"
       self.inner = inner

--- a/generated/google-cloud-kms-v1/Sources/GoogleCloudKmsV1/Autokey+Logging.swift
+++ b/generated/google-cloud-kms-v1/Sources/GoogleCloudKmsV1/Autokey+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any AutokeyStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudKmsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-kms-v1"
       logger[metadataKey: "gcp.client.service"] = "cloudkms"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Autokey"
       self.inner = inner

--- a/generated/google-cloud-kms-v1/Sources/GoogleCloudKmsV1/AutokeyAdmin+Logging.swift
+++ b/generated/google-cloud-kms-v1/Sources/GoogleCloudKmsV1/AutokeyAdmin+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any AutokeyAdminStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudKmsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-kms-v1"
       logger[metadataKey: "gcp.client.service"] = "cloudkms"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AutokeyAdmin"
       self.inner = inner

--- a/generated/google-cloud-kms-v1/Sources/GoogleCloudKmsV1/EkmService+Logging.swift
+++ b/generated/google-cloud-kms-v1/Sources/GoogleCloudKmsV1/EkmService+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any EkmServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudKmsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-kms-v1"
       logger[metadataKey: "gcp.client.service"] = "cloudkms"
       logger[metadataKey: "gcp.experimental.swift.client"] = "EkmService"
       self.inner = inner

--- a/generated/google-cloud-kms-v1/Sources/GoogleCloudKmsV1/HsmManagement+Logging.swift
+++ b/generated/google-cloud-kms-v1/Sources/GoogleCloudKmsV1/HsmManagement+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any HsmManagementStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudKmsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-kms-v1"
       logger[metadataKey: "gcp.client.service"] = "cloudkms"
       logger[metadataKey: "gcp.experimental.swift.client"] = "HsmManagement"
       self.inner = inner

--- a/generated/google-cloud-kms-v1/Sources/GoogleCloudKmsV1/KeyManagementService+Logging.swift
+++ b/generated/google-cloud-kms-v1/Sources/GoogleCloudKmsV1/KeyManagementService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any KeyManagementServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudKmsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-kms-v1"
       logger[metadataKey: "gcp.client.service"] = "cloudkms"
       logger[metadataKey: "gcp.experimental.swift.client"] = "KeyManagementService"
       self.inner = inner

--- a/generated/google-cloud-language-v2/Sources/GoogleCloudLanguageV2/LanguageService+Logging.swift
+++ b/generated/google-cloud-language-v2/Sources/GoogleCloudLanguageV2/LanguageService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any LanguageServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudLanguageV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-language-v2"
       logger[metadataKey: "gcp.client.service"] = "language"
       logger[metadataKey: "gcp.experimental.swift.client"] = "LanguageService"
       self.inner = inner

--- a/generated/google-cloud-licensemanager-v1/Sources/GoogleCloudLicensemanagerV1/LicenseManager+Logging.swift
+++ b/generated/google-cloud-licensemanager-v1/Sources/GoogleCloudLicensemanagerV1/LicenseManager+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any LicenseManagerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudLicensemanagerV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-licensemanager-v1"
       logger[metadataKey: "gcp.client.service"] = "licensemanager"
       logger[metadataKey: "gcp.experimental.swift.client"] = "LicenseManager"
       self.inner = inner

--- a/generated/google-cloud-location/Sources/GoogleCloudLocation/Locations+Logging.swift
+++ b/generated/google-cloud-location/Sources/GoogleCloudLocation/Locations+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any LocationsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudLocation"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-location"
       logger[metadataKey: "gcp.client.service"] = "cloud"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Locations"
       self.inner = inner

--- a/generated/google-cloud-locationfinder-v1/Sources/GoogleCloudLocationfinderV1/CloudLocationFinder+Logging.swift
+++ b/generated/google-cloud-locationfinder-v1/Sources/GoogleCloudLocationfinderV1/CloudLocationFinder+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any CloudLocationFinderStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudLocationfinderV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-locationfinder-v1"
       logger[metadataKey: "gcp.client.service"] = "cloudlocationfinder"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CloudLocationFinder"
       self.inner = inner

--- a/generated/google-cloud-memorystore-v1/Sources/GoogleCloudMemorystoreV1/Memorystore+Logging.swift
+++ b/generated/google-cloud-memorystore-v1/Sources/GoogleCloudMemorystoreV1/Memorystore+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any MemorystoreStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudMemorystoreV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-memorystore-v1"
       logger[metadataKey: "gcp.client.service"] = "memorystore"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Memorystore"
       self.inner = inner

--- a/generated/google-cloud-networkconnectivity-v1/Sources/GoogleCloudNetworkconnectivityV1/CrossNetworkAutomationService+Logging.swift
+++ b/generated/google-cloud-networkconnectivity-v1/Sources/GoogleCloudNetworkconnectivityV1/CrossNetworkAutomationService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any CrossNetworkAutomationServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudNetworkconnectivityV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-networkconnectivity-v1"
       logger[metadataKey: "gcp.client.service"] = "networkconnectivity"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CrossNetworkAutomationService"
       self.inner = inner

--- a/generated/google-cloud-networkconnectivity-v1/Sources/GoogleCloudNetworkconnectivityV1/DataTransferService+Logging.swift
+++ b/generated/google-cloud-networkconnectivity-v1/Sources/GoogleCloudNetworkconnectivityV1/DataTransferService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any DataTransferServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudNetworkconnectivityV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-networkconnectivity-v1"
       logger[metadataKey: "gcp.client.service"] = "networkconnectivity"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DataTransferService"
       self.inner = inner

--- a/generated/google-cloud-networkconnectivity-v1/Sources/GoogleCloudNetworkconnectivityV1/HubService+Logging.swift
+++ b/generated/google-cloud-networkconnectivity-v1/Sources/GoogleCloudNetworkconnectivityV1/HubService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any HubServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudNetworkconnectivityV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-networkconnectivity-v1"
       logger[metadataKey: "gcp.client.service"] = "networkconnectivity"
       logger[metadataKey: "gcp.experimental.swift.client"] = "HubService"
       self.inner = inner

--- a/generated/google-cloud-networkconnectivity-v1/Sources/GoogleCloudNetworkconnectivityV1/InternalRangeService+Logging.swift
+++ b/generated/google-cloud-networkconnectivity-v1/Sources/GoogleCloudNetworkconnectivityV1/InternalRangeService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any InternalRangeServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudNetworkconnectivityV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-networkconnectivity-v1"
       logger[metadataKey: "gcp.client.service"] = "networkconnectivity"
       logger[metadataKey: "gcp.experimental.swift.client"] = "InternalRangeService"
       self.inner = inner

--- a/generated/google-cloud-networkconnectivity-v1/Sources/GoogleCloudNetworkconnectivityV1/PolicyBasedRoutingService+Logging.swift
+++ b/generated/google-cloud-networkconnectivity-v1/Sources/GoogleCloudNetworkconnectivityV1/PolicyBasedRoutingService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any PolicyBasedRoutingServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudNetworkconnectivityV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-networkconnectivity-v1"
       logger[metadataKey: "gcp.client.service"] = "networkconnectivity"
       logger[metadataKey: "gcp.experimental.swift.client"] = "PolicyBasedRoutingService"
       self.inner = inner

--- a/generated/google-cloud-notebooks-v2/Sources/GoogleCloudNotebooksV2/NotebookService+Logging.swift
+++ b/generated/google-cloud-notebooks-v2/Sources/GoogleCloudNotebooksV2/NotebookService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any NotebookServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudNotebooksV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-notebooks-v2"
       logger[metadataKey: "gcp.client.service"] = "notebooks"
       logger[metadataKey: "gcp.experimental.swift.client"] = "NotebookService"
       self.inner = inner

--- a/generated/google-cloud-osconfig-v1/Sources/GoogleCloudOsconfigV1/OsConfigService+Logging.swift
+++ b/generated/google-cloud-osconfig-v1/Sources/GoogleCloudOsconfigV1/OsConfigService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any OsConfigServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudOsconfigV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-osconfig-v1"
       logger[metadataKey: "gcp.client.service"] = "osconfig"
       logger[metadataKey: "gcp.experimental.swift.client"] = "OsConfigService"
       self.inner = inner

--- a/generated/google-cloud-osconfig-v1/Sources/GoogleCloudOsconfigV1/OsConfigZonalService+Logging.swift
+++ b/generated/google-cloud-osconfig-v1/Sources/GoogleCloudOsconfigV1/OsConfigZonalService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any OsConfigZonalServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudOsconfigV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-osconfig-v1"
       logger[metadataKey: "gcp.client.service"] = "osconfig"
       logger[metadataKey: "gcp.experimental.swift.client"] = "OsConfigZonalService"
       self.inner = inner

--- a/generated/google-cloud-parallelstore-v1/Sources/GoogleCloudParallelstoreV1/Parallelstore+Logging.swift
+++ b/generated/google-cloud-parallelstore-v1/Sources/GoogleCloudParallelstoreV1/Parallelstore+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any ParallelstoreStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudParallelstoreV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-parallelstore-v1"
       logger[metadataKey: "gcp.client.service"] = "parallelstore"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Parallelstore"
       self.inner = inner

--- a/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/Folders+Logging.swift
+++ b/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/Folders+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any FoldersStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudResourcemanagerV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-resourcemanager-v3"
       logger[metadataKey: "gcp.client.service"] = "cloudresourcemanager"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Folders"
       self.inner = inner

--- a/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/Organizations+Logging.swift
+++ b/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/Organizations+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any OrganizationsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudResourcemanagerV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-resourcemanager-v3"
       logger[metadataKey: "gcp.client.service"] = "cloudresourcemanager"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Organizations"
       self.inner = inner

--- a/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/Projects+Logging.swift
+++ b/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/Projects+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any ProjectsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudResourcemanagerV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-resourcemanager-v3"
       logger[metadataKey: "gcp.client.service"] = "cloudresourcemanager"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Projects"
       self.inner = inner

--- a/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/TagBindings+Logging.swift
+++ b/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/TagBindings+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any TagBindingsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudResourcemanagerV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-resourcemanager-v3"
       logger[metadataKey: "gcp.client.service"] = "cloudresourcemanager"
       logger[metadataKey: "gcp.experimental.swift.client"] = "TagBindings"
       self.inner = inner

--- a/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/TagHolds+Logging.swift
+++ b/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/TagHolds+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any TagHoldsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudResourcemanagerV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-resourcemanager-v3"
       logger[metadataKey: "gcp.client.service"] = "cloudresourcemanager"
       logger[metadataKey: "gcp.experimental.swift.client"] = "TagHolds"
       self.inner = inner

--- a/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/TagKeys+Logging.swift
+++ b/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/TagKeys+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any TagKeysStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudResourcemanagerV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-resourcemanager-v3"
       logger[metadataKey: "gcp.client.service"] = "cloudresourcemanager"
       logger[metadataKey: "gcp.experimental.swift.client"] = "TagKeys"
       self.inner = inner

--- a/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/TagValues+Logging.swift
+++ b/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourcemanagerV3/TagValues+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any TagValuesStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudResourcemanagerV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-resourcemanager-v3"
       logger[metadataKey: "gcp.client.service"] = "cloudresourcemanager"
       logger[metadataKey: "gcp.experimental.swift.client"] = "TagValues"
       self.inner = inner

--- a/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/AnalyticsService+Logging.swift
+++ b/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/AnalyticsService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any AnalyticsServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRetailV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-retail-v2"
       logger[metadataKey: "gcp.client.service"] = "retail"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AnalyticsService"
       self.inner = inner

--- a/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/CatalogService+Logging.swift
+++ b/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/CatalogService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any CatalogServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRetailV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-retail-v2"
       logger[metadataKey: "gcp.client.service"] = "retail"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CatalogService"
       self.inner = inner

--- a/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/CompletionService+Logging.swift
+++ b/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/CompletionService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any CompletionServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRetailV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-retail-v2"
       logger[metadataKey: "gcp.client.service"] = "retail"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CompletionService"
       self.inner = inner

--- a/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/ControlService+Logging.swift
+++ b/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/ControlService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any ControlServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRetailV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-retail-v2"
       logger[metadataKey: "gcp.client.service"] = "retail"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ControlService"
       self.inner = inner

--- a/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/ConversationalSearchService+Logging.swift
+++ b/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/ConversationalSearchService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any ConversationalSearchServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRetailV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-retail-v2"
       logger[metadataKey: "gcp.client.service"] = "retail"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ConversationalSearchService"
       self.inner = inner

--- a/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/GenerativeQuestionService+Logging.swift
+++ b/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/GenerativeQuestionService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any GenerativeQuestionServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRetailV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-retail-v2"
       logger[metadataKey: "gcp.client.service"] = "retail"
       logger[metadataKey: "gcp.experimental.swift.client"] = "GenerativeQuestionService"
       self.inner = inner

--- a/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/ModelService+Logging.swift
+++ b/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/ModelService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ModelServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRetailV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-retail-v2"
       logger[metadataKey: "gcp.client.service"] = "retail"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ModelService"
       self.inner = inner

--- a/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/PredictionService+Logging.swift
+++ b/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/PredictionService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any PredictionServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRetailV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-retail-v2"
       logger[metadataKey: "gcp.client.service"] = "retail"
       logger[metadataKey: "gcp.experimental.swift.client"] = "PredictionService"
       self.inner = inner

--- a/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/ProductService+Logging.swift
+++ b/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/ProductService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ProductServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRetailV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-retail-v2"
       logger[metadataKey: "gcp.client.service"] = "retail"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ProductService"
       self.inner = inner

--- a/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/SearchService+Logging.swift
+++ b/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/SearchService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any SearchServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRetailV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-retail-v2"
       logger[metadataKey: "gcp.client.service"] = "retail"
       logger[metadataKey: "gcp.experimental.swift.client"] = "SearchService"
       self.inner = inner

--- a/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/ServingConfigService+Logging.swift
+++ b/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/ServingConfigService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any ServingConfigServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRetailV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-retail-v2"
       logger[metadataKey: "gcp.client.service"] = "retail"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ServingConfigService"
       self.inner = inner

--- a/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/UserEventService+Logging.swift
+++ b/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/UserEventService+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any UserEventServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRetailV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-retail-v2"
       logger[metadataKey: "gcp.client.service"] = "retail"
       logger[metadataKey: "gcp.experimental.swift.client"] = "UserEventService"
       self.inner = inner

--- a/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Builds+Logging.swift
+++ b/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Builds+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any BuildsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRunV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-run-v2"
       logger[metadataKey: "gcp.client.service"] = "run"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Builds"
       self.inner = inner

--- a/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Executions+Logging.swift
+++ b/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Executions+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ExecutionsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRunV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-run-v2"
       logger[metadataKey: "gcp.client.service"] = "run"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Executions"
       self.inner = inner

--- a/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Instances+Logging.swift
+++ b/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Instances+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any InstancesStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRunV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-run-v2"
       logger[metadataKey: "gcp.client.service"] = "run"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Instances"
       self.inner = inner

--- a/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Jobs+Logging.swift
+++ b/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Jobs+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any JobsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRunV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-run-v2"
       logger[metadataKey: "gcp.client.service"] = "run"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Jobs"
       self.inner = inner

--- a/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Revisions+Logging.swift
+++ b/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Revisions+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any RevisionsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRunV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-run-v2"
       logger[metadataKey: "gcp.client.service"] = "run"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Revisions"
       self.inner = inner

--- a/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Services+Logging.swift
+++ b/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Services+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any ServicesStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRunV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-run-v2"
       logger[metadataKey: "gcp.client.service"] = "run"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Services"
       self.inner = inner

--- a/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Tasks+Logging.swift
+++ b/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Tasks+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any TasksStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRunV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-run-v2"
       logger[metadataKey: "gcp.client.service"] = "run"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Tasks"
       self.inner = inner

--- a/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/WorkerPools+Logging.swift
+++ b/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/WorkerPools+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any WorkerPoolsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudRunV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-run-v2"
       logger[metadataKey: "gcp.client.service"] = "run"
       logger[metadataKey: "gcp.experimental.swift.client"] = "WorkerPools"
       self.inner = inner

--- a/generated/google-cloud-scheduler-v1/Sources/GoogleCloudSchedulerV1/CloudScheduler+Logging.swift
+++ b/generated/google-cloud-scheduler-v1/Sources/GoogleCloudSchedulerV1/CloudScheduler+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any CloudSchedulerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSchedulerV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-scheduler-v1"
       logger[metadataKey: "gcp.client.service"] = "cloudscheduler"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CloudScheduler"
       self.inner = inner

--- a/generated/google-cloud-secretmanager-v1/Sources/GoogleCloudSecretmanagerV1/SecretManagerService+Logging.swift
+++ b/generated/google-cloud-secretmanager-v1/Sources/GoogleCloudSecretmanagerV1/SecretManagerService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any SecretManagerServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSecretmanagerV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-secretmanager-v1"
       logger[metadataKey: "gcp.client.service"] = "secretmanager"
       logger[metadataKey: "gcp.experimental.swift.client"] = "SecretManagerService"
       self.inner = inner

--- a/generated/google-cloud-security-privateca-v1/Sources/GoogleCloudSecurityPrivatecaV1/CertificateAuthorityService+Logging.swift
+++ b/generated/google-cloud-security-privateca-v1/Sources/GoogleCloudSecurityPrivatecaV1/CertificateAuthorityService+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any CertificateAuthorityServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSecurityPrivatecaV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-security-privateca-v1"
       logger[metadataKey: "gcp.client.service"] = "privateca"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CertificateAuthorityService"
       self.inner = inner

--- a/generated/google-cloud-security-publicca-v1/Sources/GoogleCloudSecurityPubliccaV1/PublicCertificateAuthorityService+Logging.swift
+++ b/generated/google-cloud-security-publicca-v1/Sources/GoogleCloudSecurityPubliccaV1/PublicCertificateAuthorityService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any PublicCertificateAuthorityServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSecurityPubliccaV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-security-publicca-v1"
       logger[metadataKey: "gcp.client.service"] = "publicca"
       logger[metadataKey: "gcp.experimental.swift.client"] = "PublicCertificateAuthorityService"
       self.inner = inner

--- a/generated/google-cloud-speech-v2/Sources/GoogleCloudSpeechV2/Speech+Logging.swift
+++ b/generated/google-cloud-speech-v2/Sources/GoogleCloudSpeechV2/Speech+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any SpeechStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSpeechV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-speech-v2"
       logger[metadataKey: "gcp.client.service"] = "speech"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Speech"
       self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlAvailableDatabaseVersionsService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlAvailableDatabaseVersionsService+Logging.swift
@@ -31,7 +31,7 @@
 
       public init(_ inner: any SqlAvailableDatabaseVersionsServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlAvailableDatabaseVersionsService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlBackupRunsService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlBackupRunsService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlBackupRunsServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlBackupRunsService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlBackupsService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlBackupsService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlBackupsServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlBackupsService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlConnectService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlConnectService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlConnectServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlConnectService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlDatabasesService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlDatabasesService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlDatabasesServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlDatabasesService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlEventsService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlEventsService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlEventsServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlEventsService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlFeatureEligibilityService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlFeatureEligibilityService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlFeatureEligibilityServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlFeatureEligibilityService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlFlagsService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlFlagsService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlFlagsServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlFlagsService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlIamPoliciesService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlIamPoliciesService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlIamPoliciesServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlIamPoliciesService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlInstanceNamesService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlInstanceNamesService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlInstanceNamesServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlInstanceNamesService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlInstancesService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlInstancesService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlInstancesServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlInstancesService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlOperationsService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlOperationsService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlOperationsServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlOperationsService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlRegionsService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlRegionsService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlRegionsServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlRegionsService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlSslCertsService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlSslCertsService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlSslCertsServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlSslCertsService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlTiersService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlTiersService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlTiersServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlTiersService"
         self.inner = inner

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlUsersService+Logging.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/SqlUsersService+Logging.swift
@@ -30,7 +30,7 @@
 
       public init(_ inner: any SqlUsersServiceStub, logger: Logger) {
         var logger = logger
-        logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudSqlV1"
+        logger[metadataKey: "gcp.artifact.id"] = "google-cloud-sql-v1"
         logger[metadataKey: "gcp.client.service"] = "sqladmin"
         logger[metadataKey: "gcp.experimental.swift.client"] = "SqlUsersService"
         self.inner = inner

--- a/generated/google-cloud-storageinsights-v1/Sources/GoogleCloudStorageinsightsV1/StorageInsights+Logging.swift
+++ b/generated/google-cloud-storageinsights-v1/Sources/GoogleCloudStorageinsightsV1/StorageInsights+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any StorageInsightsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudStorageinsightsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-storageinsights-v1"
       logger[metadataKey: "gcp.client.service"] = "storageinsights"
       logger[metadataKey: "gcp.experimental.swift.client"] = "StorageInsights"
       self.inner = inner

--- a/generated/google-cloud-talent-v4/Sources/GoogleCloudTalentV4/CompanyService+Logging.swift
+++ b/generated/google-cloud-talent-v4/Sources/GoogleCloudTalentV4/CompanyService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any CompanyServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudTalentV4"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-talent-v4"
       logger[metadataKey: "gcp.client.service"] = "jobs"
       logger[metadataKey: "gcp.experimental.swift.client"] = "CompanyService"
       self.inner = inner

--- a/generated/google-cloud-talent-v4/Sources/GoogleCloudTalentV4/Completion+Logging.swift
+++ b/generated/google-cloud-talent-v4/Sources/GoogleCloudTalentV4/Completion+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any CompletionStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudTalentV4"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-talent-v4"
       logger[metadataKey: "gcp.client.service"] = "jobs"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Completion"
       self.inner = inner

--- a/generated/google-cloud-talent-v4/Sources/GoogleCloudTalentV4/EventService+Logging.swift
+++ b/generated/google-cloud-talent-v4/Sources/GoogleCloudTalentV4/EventService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any EventServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudTalentV4"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-talent-v4"
       logger[metadataKey: "gcp.client.service"] = "jobs"
       logger[metadataKey: "gcp.experimental.swift.client"] = "EventService"
       self.inner = inner

--- a/generated/google-cloud-talent-v4/Sources/GoogleCloudTalentV4/JobService+Logging.swift
+++ b/generated/google-cloud-talent-v4/Sources/GoogleCloudTalentV4/JobService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any JobServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudTalentV4"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-talent-v4"
       logger[metadataKey: "gcp.client.service"] = "jobs"
       logger[metadataKey: "gcp.experimental.swift.client"] = "JobService"
       self.inner = inner

--- a/generated/google-cloud-talent-v4/Sources/GoogleCloudTalentV4/TenantService+Logging.swift
+++ b/generated/google-cloud-talent-v4/Sources/GoogleCloudTalentV4/TenantService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any TenantServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudTalentV4"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-talent-v4"
       logger[metadataKey: "gcp.client.service"] = "jobs"
       logger[metadataKey: "gcp.experimental.swift.client"] = "TenantService"
       self.inner = inner

--- a/generated/google-cloud-telcoautomation-v1/Sources/GoogleCloudTelcoautomationV1/TelcoAutomation+Logging.swift
+++ b/generated/google-cloud-telcoautomation-v1/Sources/GoogleCloudTelcoautomationV1/TelcoAutomation+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any TelcoAutomationStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudTelcoautomationV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-telcoautomation-v1"
       logger[metadataKey: "gcp.client.service"] = "telcoautomation"
       logger[metadataKey: "gcp.experimental.swift.client"] = "TelcoAutomation"
       self.inner = inner

--- a/generated/google-cloud-texttospeech-v1/Sources/GoogleCloudTexttospeechV1/TextToSpeech+Logging.swift
+++ b/generated/google-cloud-texttospeech-v1/Sources/GoogleCloudTexttospeechV1/TextToSpeech+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any TextToSpeechStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudTexttospeechV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-texttospeech-v1"
       logger[metadataKey: "gcp.client.service"] = "texttospeech"
       logger[metadataKey: "gcp.experimental.swift.client"] = "TextToSpeech"
       self.inner = inner

--- a/generated/google-cloud-texttospeech-v1/Sources/GoogleCloudTexttospeechV1/TextToSpeechLongAudioSynthesize+Logging.swift
+++ b/generated/google-cloud-texttospeech-v1/Sources/GoogleCloudTexttospeechV1/TextToSpeechLongAudioSynthesize+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any TextToSpeechLongAudioSynthesizeStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudTexttospeechV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-texttospeech-v1"
       logger[metadataKey: "gcp.client.service"] = "texttospeech"
       logger[metadataKey: "gcp.experimental.swift.client"] = "TextToSpeechLongAudioSynthesize"
       self.inner = inner

--- a/generated/google-cloud-tpu-v2/Sources/GoogleCloudTpuV2/Tpu+Logging.swift
+++ b/generated/google-cloud-tpu-v2/Sources/GoogleCloudTpuV2/Tpu+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any TpuStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudTpuV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-tpu-v2"
       logger[metadataKey: "gcp.client.service"] = "tpu"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Tpu"
       self.inner = inner

--- a/generated/google-cloud-translate-v3/Sources/GoogleCloudTranslationV3/TranslationService+Logging.swift
+++ b/generated/google-cloud-translate-v3/Sources/GoogleCloudTranslationV3/TranslationService+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any TranslationServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudTranslationV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-translation-v3"
       logger[metadataKey: "gcp.client.service"] = "translate"
       logger[metadataKey: "gcp.experimental.swift.client"] = "TranslationService"
       self.inner = inner

--- a/generated/google-cloud-vision-v1/Sources/GoogleCloudVisionV1/ImageAnnotator+Logging.swift
+++ b/generated/google-cloud-vision-v1/Sources/GoogleCloudVisionV1/ImageAnnotator+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ImageAnnotatorStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudVisionV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-vision-v1"
       logger[metadataKey: "gcp.client.service"] = "vision"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ImageAnnotator"
       self.inner = inner

--- a/generated/google-cloud-vision-v1/Sources/GoogleCloudVisionV1/ProductSearch+Logging.swift
+++ b/generated/google-cloud-vision-v1/Sources/GoogleCloudVisionV1/ProductSearch+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ProductSearchStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudVisionV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-vision-v1"
       logger[metadataKey: "gcp.client.service"] = "vision"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ProductSearch"
       self.inner = inner

--- a/generated/google-cloud-workflows-executions-v1/Sources/GoogleCloudWorkflowsExecutionsV1/Executions+Logging.swift
+++ b/generated/google-cloud-workflows-executions-v1/Sources/GoogleCloudWorkflowsExecutionsV1/Executions+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any ExecutionsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudWorkflowsExecutionsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-workflows-executions-v1"
       logger[metadataKey: "gcp.client.service"] = "workflowexecutions"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Executions"
       self.inner = inner

--- a/generated/google-cloud-workflows-v1/Sources/GoogleCloudWorkflowsV1/Workflows+Logging.swift
+++ b/generated/google-cloud-workflows-v1/Sources/GoogleCloudWorkflowsV1/Workflows+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any WorkflowsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudWorkflowsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-workflows-v1"
       logger[metadataKey: "gcp.client.service"] = "workflows"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Workflows"
       self.inner = inner

--- a/generated/google-cloud-workloadmanager-v1/Sources/GoogleCloudWorkloadmanagerV1/WorkloadManager+Logging.swift
+++ b/generated/google-cloud-workloadmanager-v1/Sources/GoogleCloudWorkloadmanagerV1/WorkloadManager+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any WorkloadManagerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleCloudWorkloadmanagerV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-cloud-workloadmanager-v1"
       logger[metadataKey: "gcp.client.service"] = "workloadmanager"
       logger[metadataKey: "gcp.experimental.swift.client"] = "WorkloadManager"
       self.inner = inner

--- a/generated/google-container-v1/Sources/GoogleContainerV1/ClusterManager+Logging.swift
+++ b/generated/google-container-v1/Sources/GoogleContainerV1/ClusterManager+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any ClusterManagerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleContainerV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-container-v1"
       logger[metadataKey: "gcp.client.service"] = "container"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ClusterManager"
       self.inner = inner

--- a/generated/google-datastore-admin-v1/Sources/GoogleDatastoreAdminV1/DatastoreAdmin+Logging.swift
+++ b/generated/google-datastore-admin-v1/Sources/GoogleDatastoreAdminV1/DatastoreAdmin+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any DatastoreAdminStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleDatastoreAdminV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-datastore-admin-v1"
       logger[metadataKey: "gcp.client.service"] = "datastore"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DatastoreAdmin"
       self.inner = inner

--- a/generated/google-devtools-artifactregistry-v1/Sources/GoogleDevtoolsArtifactregistryV1/ArtifactRegistry+Logging.swift
+++ b/generated/google-devtools-artifactregistry-v1/Sources/GoogleDevtoolsArtifactregistryV1/ArtifactRegistry+Logging.swift
@@ -33,7 +33,7 @@ extension Clients {
 
     public init(_ inner: any ArtifactRegistryStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleDevtoolsArtifactregistryV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-devtools-artifactregistry-v1"
       logger[metadataKey: "gcp.client.service"] = "artifactregistry"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ArtifactRegistry"
       self.inner = inner

--- a/generated/google-devtools-cloudtrace-v2/Sources/GoogleDevtoolsCloudtraceV2/TraceService+Logging.swift
+++ b/generated/google-devtools-cloudtrace-v2/Sources/GoogleDevtoolsCloudtraceV2/TraceService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any TraceServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleDevtoolsCloudtraceV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-devtools-cloudtrace-v2"
       logger[metadataKey: "gcp.client.service"] = "cloudtrace"
       logger[metadataKey: "gcp.experimental.swift.client"] = "TraceService"
       self.inner = inner

--- a/generated/google-iam-admin-v1/Sources/GoogleIamAdminV1/IAM+Logging.swift
+++ b/generated/google-iam-admin-v1/Sources/GoogleIamAdminV1/IAM+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any IAMStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleIamAdminV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-iam-admin-v1"
       logger[metadataKey: "gcp.client.service"] = "iam"
       logger[metadataKey: "gcp.experimental.swift.client"] = "IAM"
       self.inner = inner

--- a/generated/google-iam-credentials-v1/Sources/GoogleIamCredentialsV1/IAMCredentials+Logging.swift
+++ b/generated/google-iam-credentials-v1/Sources/GoogleIamCredentialsV1/IAMCredentials+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any IAMCredentialsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleIamCredentialsV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-iam-credentials-v1"
       logger[metadataKey: "gcp.client.service"] = "iamcredentials"
       logger[metadataKey: "gcp.experimental.swift.client"] = "IAMCredentials"
       self.inner = inner

--- a/generated/google-iam-v1/Sources/GoogleIamV1/IAMPolicy+Logging.swift
+++ b/generated/google-iam-v1/Sources/GoogleIamV1/IAMPolicy+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any IAMPolicyStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleIamV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-iam-v1"
       logger[metadataKey: "gcp.client.service"] = "iam-meta-api"
       logger[metadataKey: "gcp.experimental.swift.client"] = "IAMPolicy"
       self.inner = inner

--- a/generated/google-iam-v2/Sources/GoogleIamV2/Policies+Logging.swift
+++ b/generated/google-iam-v2/Sources/GoogleIamV2/Policies+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any PoliciesStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleIamV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-iam-v2"
       logger[metadataKey: "gcp.client.service"] = "iam"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Policies"
       self.inner = inner

--- a/generated/google-iam-v3/Sources/GoogleIamV3/PolicyBindings+Logging.swift
+++ b/generated/google-iam-v3/Sources/GoogleIamV3/PolicyBindings+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any PolicyBindingsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleIamV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-iam-v3"
       logger[metadataKey: "gcp.client.service"] = "iam"
       logger[metadataKey: "gcp.experimental.swift.client"] = "PolicyBindings"
       self.inner = inner

--- a/generated/google-iam-v3/Sources/GoogleIamV3/PrincipalAccessBoundaryPolicies+Logging.swift
+++ b/generated/google-iam-v3/Sources/GoogleIamV3/PrincipalAccessBoundaryPolicies+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any PrincipalAccessBoundaryPoliciesStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleIamV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-iam-v3"
       logger[metadataKey: "gcp.client.service"] = "iam"
       logger[metadataKey: "gcp.experimental.swift.client"] = "PrincipalAccessBoundaryPolicies"
       self.inner = inner

--- a/generated/google-identity-accesscontextmanager-v1/Sources/GoogleIdentityAccesscontextmanagerV1/AccessContextManager+Logging.swift
+++ b/generated/google-identity-accesscontextmanager-v1/Sources/GoogleIdentityAccesscontextmanagerV1/AccessContextManager+Logging.swift
@@ -32,7 +32,7 @@ extension Clients {
 
     public init(_ inner: any AccessContextManagerStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleIdentityAccesscontextmanagerV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-identity-accesscontextmanager-v1"
       logger[metadataKey: "gcp.client.service"] = "accesscontextmanager"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AccessContextManager"
       self.inner = inner

--- a/generated/google-logging-v2/Sources/GoogleLoggingV2/ConfigServiceV2+Logging.swift
+++ b/generated/google-logging-v2/Sources/GoogleLoggingV2/ConfigServiceV2+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any ConfigServiceV2Stub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleLoggingV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-logging-v2"
       logger[metadataKey: "gcp.client.service"] = "logging"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ConfigServiceV2"
       self.inner = inner

--- a/generated/google-logging-v2/Sources/GoogleLoggingV2/LoggingServiceV2+Logging.swift
+++ b/generated/google-logging-v2/Sources/GoogleLoggingV2/LoggingServiceV2+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any LoggingServiceV2Stub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleLoggingV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-logging-v2"
       logger[metadataKey: "gcp.client.service"] = "logging"
       logger[metadataKey: "gcp.experimental.swift.client"] = "LoggingServiceV2"
       self.inner = inner

--- a/generated/google-logging-v2/Sources/GoogleLoggingV2/MetricsServiceV2+Logging.swift
+++ b/generated/google-logging-v2/Sources/GoogleLoggingV2/MetricsServiceV2+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any MetricsServiceV2Stub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleLoggingV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-logging-v2"
       logger[metadataKey: "gcp.client.service"] = "logging"
       logger[metadataKey: "gcp.experimental.swift.client"] = "MetricsServiceV2"
       self.inner = inner

--- a/generated/google-longrunning/Sources/GoogleLongrunning/Operations+Logging.swift
+++ b/generated/google-longrunning/Sources/GoogleLongrunning/Operations+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any OperationsStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleLongrunning"
+      logger[metadataKey: "gcp.artifact.id"] = "google-longrunning"
       logger[metadataKey: "gcp.client.service"] = "longrunning"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Operations"
       self.inner = inner

--- a/generated/google-monitoring-dashboard-v1/Sources/GoogleMonitoringDashboardV1/DashboardsService+Logging.swift
+++ b/generated/google-monitoring-dashboard-v1/Sources/GoogleMonitoringDashboardV1/DashboardsService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any DashboardsServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleMonitoringDashboardV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-monitoring-dashboard-v1"
       logger[metadataKey: "gcp.client.service"] = "monitoring"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DashboardsService"
       self.inner = inner

--- a/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/AlertPolicyService+Logging.swift
+++ b/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/AlertPolicyService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any AlertPolicyServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleMonitoringV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-monitoring-v3"
       logger[metadataKey: "gcp.client.service"] = "monitoring"
       logger[metadataKey: "gcp.experimental.swift.client"] = "AlertPolicyService"
       self.inner = inner

--- a/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/GroupService+Logging.swift
+++ b/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/GroupService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any GroupServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleMonitoringV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-monitoring-v3"
       logger[metadataKey: "gcp.client.service"] = "monitoring"
       logger[metadataKey: "gcp.experimental.swift.client"] = "GroupService"
       self.inner = inner

--- a/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/MetricService+Logging.swift
+++ b/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/MetricService+Logging.swift
@@ -30,7 +30,7 @@ extension Clients {
 
     public init(_ inner: any MetricServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleMonitoringV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-monitoring-v3"
       logger[metadataKey: "gcp.client.service"] = "monitoring"
       logger[metadataKey: "gcp.experimental.swift.client"] = "MetricService"
       self.inner = inner

--- a/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/NotificationChannelService+Logging.swift
+++ b/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/NotificationChannelService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any NotificationChannelServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleMonitoringV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-monitoring-v3"
       logger[metadataKey: "gcp.client.service"] = "monitoring"
       logger[metadataKey: "gcp.experimental.swift.client"] = "NotificationChannelService"
       self.inner = inner

--- a/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/QueryService+Logging.swift
+++ b/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/QueryService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any QueryServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleMonitoringV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-monitoring-v3"
       logger[metadataKey: "gcp.client.service"] = "monitoring"
       logger[metadataKey: "gcp.experimental.swift.client"] = "QueryService"
       self.inner = inner

--- a/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/ServiceMonitoringService+Logging.swift
+++ b/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/ServiceMonitoringService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any ServiceMonitoringServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleMonitoringV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-monitoring-v3"
       logger[metadataKey: "gcp.client.service"] = "monitoring"
       logger[metadataKey: "gcp.experimental.swift.client"] = "ServiceMonitoringService"
       self.inner = inner

--- a/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/SnoozeService+Logging.swift
+++ b/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/SnoozeService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any SnoozeServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleMonitoringV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-monitoring-v3"
       logger[metadataKey: "gcp.client.service"] = "monitoring"
       logger[metadataKey: "gcp.experimental.swift.client"] = "SnoozeService"
       self.inner = inner

--- a/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/UptimeCheckService+Logging.swift
+++ b/generated/google-monitoring-v3/Sources/GoogleMonitoringV3/UptimeCheckService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any UptimeCheckServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleMonitoringV3"
+      logger[metadataKey: "gcp.artifact.id"] = "google-monitoring-v3"
       logger[metadataKey: "gcp.client.service"] = "monitoring"
       logger[metadataKey: "gcp.experimental.swift.client"] = "UptimeCheckService"
       self.inner = inner

--- a/generated/google-privacy-dlp-v2/Sources/GooglePrivacyDlpV2/DlpService+Logging.swift
+++ b/generated/google-privacy-dlp-v2/Sources/GooglePrivacyDlpV2/DlpService+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any DlpServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GooglePrivacyDlpV2"
+      logger[metadataKey: "gcp.artifact.id"] = "google-privacy-dlp-v2"
       logger[metadataKey: "gcp.client.service"] = "dlp"
       logger[metadataKey: "gcp.experimental.swift.client"] = "DlpService"
       self.inner = inner

--- a/generated/google-storagetransfer-v1/Sources/GoogleStoragetransferV1/StorageTransferService+Logging.swift
+++ b/generated/google-storagetransfer-v1/Sources/GoogleStoragetransferV1/StorageTransferService+Logging.swift
@@ -31,7 +31,7 @@ extension Clients {
 
     public init(_ inner: any StorageTransferServiceStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleStoragetransferV1"
+      logger[metadataKey: "gcp.artifact.id"] = "google-storagetransfer-v1"
       logger[metadataKey: "gcp.client.service"] = "storagetransfer"
       logger[metadataKey: "gcp.experimental.swift.client"] = "StorageTransferService"
       self.inner = inner

--- a/generated/grafeas-v1/Sources/GoogleGrafeasV1/Grafeas+Logging.swift
+++ b/generated/grafeas-v1/Sources/GoogleGrafeasV1/Grafeas+Logging.swift
@@ -29,7 +29,7 @@ extension Clients {
 
     public init(_ inner: any GrafeasStub, logger: Logger) {
       var logger = logger
-      logger[metadataKey: "gcp.artifact.id"] = "GoogleGrafeasV1"
+      logger[metadataKey: "gcp.artifact.id"] = "grafeas-v1"
       logger[metadataKey: "gcp.client.service"] = "containeranalysis"
       logger[metadataKey: "gcp.experimental.swift.client"] = "Grafeas"
       self.inner = inner

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: swift
-version: v0.29.1
+version: v0.30.2-0.20260725001333-e34bcd1db87d
 repo: googleapis/google-cloud-swift
 sources:
   conformance:
@@ -567,6 +567,7 @@ libraries:
   - name: tests-discovery
     copyright_year: "2026"
     output: Tests/Discovery/generated
+    skip_generate: true
     roots:
       - Tests/Discovery/disco
     skip_release: true

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -567,7 +567,6 @@ libraries:
   - name: tests-discovery
     copyright_year: "2026"
     output: Tests/Discovery/generated
-    skip_generate: true
     roots:
       - Tests/Discovery/disco
     skip_release: true


### PR DESCRIPTION
Update the librarian version. In this version the `gcp.artifact.id` logging attribute is set to the package name, as it should be.

Temporarily suspended code generation for the discovery tests: I made a boo boo in the code generator, and the generator reports a spurious error in that module.

Towards googleapis/librarian#6229 