### PR TITLE
docs(Gax): fix documentation warnings

### DIFF
--- a/packages/gax/Sources/GoogleCloudGax/AdaptiveThrottler.swift
+++ b/packages/gax/Sources/GoogleCloudGax/AdaptiveThrottler.swift
@@ -60,7 +60,7 @@ public final class AdaptiveThrottler: RetryThrottler, Sendable {
   ///
   /// - Parameter factor: A factor to adjust the relative weight of transient
   ///   failures vs. accepted requests.
-  /// - Throws: ``RetryThrottlerError/scalingOutOfRange`` if `factor` is negative.
+  /// - Throws: ``RetryThrottlerError/scalingOutOfRange(_:)`` if `factor` is negative.
   public init(factor: Double) throws {
     if factor < 0.0 {
       throw RetryThrottlerError.scalingOutOfRange(factor)

--- a/packages/gax/Sources/GoogleCloudGax/CircuitBreaker.swift
+++ b/packages/gax/Sources/GoogleCloudGax/CircuitBreaker.swift
@@ -62,7 +62,7 @@ public final class CircuitBreaker: RetryThrottler, Sendable {
   ///   - tokens: The initial number of tokens.
   ///   - minTokens: Stops accepting retry attempts when the number of tokens is at or below this value.
   ///   - errorCost: Decrease the token count by this value on failed request attempts.
-  /// - Throws: ``RetryThrottlerError/tooFewMinTokens`` if `minTokens` > `tokens`.
+  /// - Throws: ``RetryThrottlerError/tooFewMinTokens(min:initial:)`` if `minTokens` > `tokens`.
   public init(tokens: UInt64, minTokens: UInt64, errorCost: UInt64) throws {
     if minTokens > tokens {
       throw RetryThrottlerError.tooFewMinTokens(min: minTokens, initial: tokens)

--- a/packages/gax/Sources/GoogleCloudGax/ClientOptions.swift
+++ b/packages/gax/Sources/GoogleCloudGax/ClientOptions.swift
@@ -55,7 +55,7 @@ public struct ClientOptions: Sendable {
 
   /// Overrides the default credentials for the client.
   ///
-  /// ``Credentials`` defines how the client authenticates to Google Cloud APIs. Without an override, the client uses
+  /// `Credentials` defines how the client authenticates to Google Cloud APIs. Without an override, the client uses
   /// [Application Default Credentials]. This works well in most deployment and development environments, use this
   /// override if your application cannot use the default.
   ///

--- a/packages/gax/Sources/GoogleCloudGax/LimitedElapsedTime.swift
+++ b/packages/gax/Sources/GoogleCloudGax/LimitedElapsedTime.swift
@@ -17,8 +17,8 @@ import Foundation
 /// A retry policy decorator that limits the total time in the retry loop.
 ///
 /// If the time elapsed in the retry loop, including any backoff, is larger than the prescribed
-/// duration then the policy returns ``RetryResult/exhausted``. Otherwise, the policy returns the
-/// result from the inner policy.
+/// duration then the policy returns ``RetryResult/exhausted(_:)``. Otherwise, the policy returns
+/// the result from the inner policy.
 ///
 /// The `remainingTime()` method returns the remaining time. This is always zero after the
 /// policy's deadline is reached.

--- a/packages/gax/Sources/GoogleCloudGax/RequestError.swift
+++ b/packages/gax/Sources/GoogleCloudGax/RequestError.swift
@@ -36,8 +36,9 @@ public enum RequestError: Error {
   ///
   /// ## Troubleshooting
   ///
-  /// The client libraries expect ``HTTPURLResponse`` as responses from the ``URLSession`` calls. The most common cause
-  /// for this error is using an `ftp`, or `file` endpoint that just happens to work.
+  /// The client libraries expect `HTTPURLResponse` as responses from the `URLSession` calls. The
+  /// most common cause for this error is using an `ftp`, or `file` endpoint that just happens to
+  /// work.
   case badResponseType
 
   /// The request failed with some type of I/O error, before getting a status code.

--- a/packages/gax/Sources/GoogleCloudGax/RetryPolicy.swift
+++ b/packages/gax/Sources/GoogleCloudGax/RetryPolicy.swift
@@ -23,9 +23,9 @@ import Foundation
 /// The retry policy determines what errors are transient, and may limit the number of retry attempts.
 ///
 /// The client libraries offer a number of retry policy implementations, including ``AlwaysRetry``,
-/// ``Aip194Strict``, and ``NeverRetry``. In addition, the client libraries offer decorators, such
-/// as ``LimitedErrorCount`` and ``LimitedElapsedTime`` to constraint the number of retry attempts
-/// or the duration of the retry loop.
+/// ``Aip194``, and ``NeverRetry``. In addition, the client libraries offer decorators, such as
+/// ``LimitedAttemptCount`` and ``LimitedElapsedTime`` to constraint the number of retry attempts or
+/// the duration of the retry loop.
 ///
 /// Application developers may define their own policies if needed.
 ///


### PR DESCRIPTION
Mostly incomplete or invalid links. Notably, it is not possible to link external package symbols from the documentation.

Towards #12 