### PR TITLE
cleanup: replace String.data(using: .utf8)! with Data(String.utf8)

### DIFF
--- a/Tests/Any/AnyForGeneratedMessages.swift
+++ b/Tests/Any/AnyForGeneratedMessages.swift
@@ -30,7 +30,7 @@ struct WrappedAny: Codable {
 func testDecodingGetSecretRequestMessage() throws {
   let jsonString =
     #"{"value":{"@type":"type.googleapis.com/google.cloud.secretmanager.v1.GetSecretRequest","name":"projects/test-project/secrets/my-secret"}}"#
-  let data = jsonString.data(using: .utf8)!
+  let data = Data(jsonString.utf8)
   let decoder = JSONDecoder()
   let wrapped = try decoder.decode(WrappedAny.self, from: data)
   let any = wrapped.value
@@ -59,7 +59,7 @@ func testEncodingGetSecretRequestMessage() throws {
 func testDecodingListSecretVersionsRequestMessage() throws {
   let jsonString =
     #"{"value":{"@type":"type.googleapis.com/google.cloud.secretmanager.v1.ListSecretVersionsRequest","filter":"state:ENABLED","pageSize":10,"pageToken":"token123","parent":"projects/test-project/secrets/my-secret"}}"#
-  let data = jsonString.data(using: .utf8)!
+  let data = Data(jsonString.utf8)
   let decoder = JSONDecoder()
   let wrapped = try decoder.decode(WrappedAny.self, from: data)
   let any = wrapped.value

--- a/Tests/Discovery/DiscoveryBytes.swift
+++ b/Tests/Discovery/DiscoveryBytes.swift
@@ -46,7 +46,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 

--- a/Tests/ProtoBasedClient/GlobalEndpoint.swift
+++ b/Tests/ProtoBasedClient/GlobalEndpoint.swift
@@ -19,6 +19,7 @@ import GoogleCloudWkt
 import GoogleIamV1
 import CryptoSwift
 import Logging
+import Foundation
 
 /// Run tests for the global endpoint.
 public enum GlobalEndpoint {

--- a/Tests/ProtoBasedClient/GlobalEndpoint.swift
+++ b/Tests/ProtoBasedClient/GlobalEndpoint.swift
@@ -90,7 +90,7 @@ public enum GlobalEndpoint {
     async throws
   {
     logger.info("\nTesting secret version CRUD")
-    let data = "the quick brown fox jumps over the lazy dog".data(using: .utf8)!
+    let data = Data("the quick brown fox jumps over the lazy dog".utf8)
     let checksum = CryptoSwift.Checksum.crc32c(data.byteArray)
     let version = try await client.addSecretVersion(
       request: .init().with {

--- a/Tests/ProtoJSON/FieldsBool.swift
+++ b/Tests/ProtoJSON/FieldsBool.swift
@@ -41,7 +41,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 

--- a/Tests/ProtoJSON/FieldsBoolValue.swift
+++ b/Tests/ProtoJSON/FieldsBoolValue.swift
@@ -33,7 +33,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsBytes.swift
+++ b/Tests/ProtoJSON/FieldsBytes.swift
@@ -36,7 +36,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsBytesValue.swift
+++ b/Tests/ProtoJSON/FieldsBytesValue.swift
@@ -31,7 +31,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsDouble.swift
+++ b/Tests/ProtoJSON/FieldsDouble.swift
@@ -42,7 +42,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 
@@ -69,7 +69,7 @@ import GoogleCloudWkt
     ]
   ) func deserializeNaN(input: String, value: @Sendable (T) -> Float64?) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(value(got).map({ $0.isNaN }) ?? false, "got=\(got)")
   }
 }

--- a/Tests/ProtoJSON/FieldsDoubleValue.swift
+++ b/Tests/ProtoJSON/FieldsDoubleValue.swift
@@ -33,7 +33,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsEnum.swift
+++ b/Tests/ProtoJSON/FieldsEnum.swift
@@ -44,7 +44,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: MessageWithEnum) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(MessageWithEnum.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(MessageWithEnum.self, from: Data(input.utf8))
     #expect(got == want)
   }
 
@@ -116,7 +116,7 @@ import GoogleCloudWkt
   @Test("Use enum with @unknown")
   func useEnum() throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(MessageWithEnum.self, from: "{}".data(using: .utf8)!)
+    let got = try decoder.decode(MessageWithEnum.self, from: Data("{}".utf8))
     #expect(got.singular == .unspecified)
     switch got.singular {
     case .unspecified:

--- a/Tests/ProtoJSON/FieldsFieldMask.swift
+++ b/Tests/ProtoJSON/FieldsFieldMask.swift
@@ -46,7 +46,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsFloat.swift
+++ b/Tests/ProtoJSON/FieldsFloat.swift
@@ -42,7 +42,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 
@@ -69,7 +69,7 @@ import GoogleCloudWkt
     ]
   ) func deserializeNaN(input: String, value: @Sendable (T) -> Float32?) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(value(got).map({ $0.isNaN }) ?? false, "got=\(got)")
   }
 }

--- a/Tests/ProtoJSON/FieldsFloatValue.swift
+++ b/Tests/ProtoJSON/FieldsFloatValue.swift
@@ -33,7 +33,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsInt32.swift
+++ b/Tests/ProtoJSON/FieldsInt32.swift
@@ -44,7 +44,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 

--- a/Tests/ProtoJSON/FieldsInt32Value.swift
+++ b/Tests/ProtoJSON/FieldsInt32Value.swift
@@ -33,7 +33,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsInt64.swift
+++ b/Tests/ProtoJSON/FieldsInt64.swift
@@ -44,7 +44,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 

--- a/Tests/ProtoJSON/FieldsInt64Value.swift
+++ b/Tests/ProtoJSON/FieldsInt64Value.swift
@@ -33,7 +33,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsListValue.swift
+++ b/Tests/ProtoJSON/FieldsListValue.swift
@@ -38,7 +38,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsNullValue.swift
+++ b/Tests/ProtoJSON/FieldsNullValue.swift
@@ -32,7 +32,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsRecursion.swift
+++ b/Tests/ProtoJSON/FieldsRecursion.swift
@@ -99,7 +99,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: MessageWithRecursion) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(MessageWithRecursion.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(MessageWithRecursion.self, from: Data(input.utf8))
     #expect(got == want)
   }
 

--- a/Tests/ProtoJSON/FieldsString.swift
+++ b/Tests/ProtoJSON/FieldsString.swift
@@ -41,7 +41,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 

--- a/Tests/ProtoJSON/FieldsStringValue.swift
+++ b/Tests/ProtoJSON/FieldsStringValue.swift
@@ -30,7 +30,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsStruct.swift
+++ b/Tests/ProtoJSON/FieldsStruct.swift
@@ -36,7 +36,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsUInt32.swift
+++ b/Tests/ProtoJSON/FieldsUInt32.swift
@@ -44,7 +44,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 

--- a/Tests/ProtoJSON/FieldsUInt32Value.swift
+++ b/Tests/ProtoJSON/FieldsUInt32Value.swift
@@ -33,7 +33,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsUInt64.swift
+++ b/Tests/ProtoJSON/FieldsUInt64.swift
@@ -44,7 +44,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 

--- a/Tests/ProtoJSON/FieldsUInt64Value.swift
+++ b/Tests/ProtoJSON/FieldsUInt64Value.swift
@@ -33,7 +33,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/FieldsValue.swift
+++ b/Tests/ProtoJSON/FieldsValue.swift
@@ -42,7 +42,7 @@ import GoogleCloudWkt
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(T.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
 }

--- a/Tests/ProtoJSON/OneOfsTest.swift
+++ b/Tests/ProtoJSON/OneOfsTest.swift
@@ -133,7 +133,7 @@ import GoogleCloudWkt
   func useOneof() throws {
     let decoder = _ProtoJSONDecoder()
     let got = try decoder.decode(
-      MessageWithOneOf.self, from: #"{"stringContents":"test"}"#.data(using: .utf8)!)
+      MessageWithOneOf.self, from: Data(#"{"stringContents":"test"}"#.utf8))
     #expect(got.singleString == .stringContents("test"))
     switch got.singleString! {
     case .stringContents(let s):

--- a/Tests/QueryParameter/QueryParameterTest.swift
+++ b/Tests/QueryParameter/QueryParameterTest.swift
@@ -82,7 +82,7 @@ struct WellKnown: Encodable {
     $0.externalAccountKey = ExternalAccountKey().with {
       $0.name = "my-key"
       $0.keyId = "my-key-id"
-      $0.b64MacKey = "abc".data(using: .utf8)!
+      $0.b64MacKey = Data("abc".utf8)
     }
   }
 

--- a/packages/auth/Tests/CredentialsTest.swift
+++ b/packages/auth/Tests/CredentialsTest.swift
@@ -50,7 +50,7 @@ import Testing
         "type": "authorized_user"
       }
       """
-    let dataData = mockJSON.data(using: .utf8)!
+    let dataData = Data(mockJSON.utf8)
 
     let credentials = try Credentials(configuration: .user(keyJSON: dataData))
 

--- a/packages/auth/Tests/Http/AuthHTTPClientTest.swift
+++ b/packages/auth/Tests/Http/AuthHTTPClientTest.swift
@@ -156,7 +156,7 @@ private final class MockURLProtocol: URLProtocol {
   @Test func clientPerformsGetAndReturnsPlainTextString() async throws {
     let targetURL = URL(string: "http://metadata.google.internal/email")!
     let mockEmail = "test-service-account@google.com"
-    let mockData = mockEmail.data(using: .utf8)!
+    let mockData = Data(mockEmail.utf8)
 
     MockURLProtocol.requestHandler = { (request: URLRequest) in
       #expect(request.url == targetURL)

--- a/packages/auth/Tests/Http/AuthHTTPErrorTest.swift
+++ b/packages/auth/Tests/Http/AuthHTTPErrorTest.swift
@@ -32,7 +32,7 @@ import Testing
       headerFields: ["X-Custom-Header": "CustomValue"]
     )!
     let bodyString = "Forbidden Access"
-    let data = bodyString.data(using: .utf8)!
+    let data = Data(bodyString.utf8)
 
     let error = AuthHTTPError.unsuccessfulResponse(response: response, data: data)
 
@@ -59,7 +59,7 @@ import Testing
       String.self,
       DecodingError.Context(codingPath: [], debugDescription: "Test")
     )
-    let testData = "Invalid JSON".data(using: .utf8)!
+    let testData = Data("Invalid JSON".utf8)
     let error = AuthHTTPError.decodingError(error: decodingError, data: testData)
 
     #expect(error.urlError == nil)

--- a/packages/auth/Tests/ServiceAccountTests.swift
+++ b/packages/auth/Tests/ServiceAccountTests.swift
@@ -134,7 +134,8 @@ struct ServiceAccountTests {
       """
     let escapedPEM = pkcs1PEM.replacingOccurrences(of: "\n", with: "\\n")
 
-    let pkcs1KeyJSON = Data("""
+    let pkcs1KeyJSON = Data(
+      """
       {
         "type": "service_account",
         "project_id": "test-project-id",
@@ -232,7 +233,8 @@ struct ServiceAccountTests {
 
   @Test("Service Account JWS signing fails gracefully when given invalid private key PEM format")
   func invalidKeySigningFailure() async throws {
-    let badKeyJSON = Data("""
+    let badKeyJSON = Data(
+      """
       {
         "type": "service_account",
         "project_id": "test-project-id",

--- a/packages/auth/Tests/ServiceAccountTests.swift
+++ b/packages/auth/Tests/ServiceAccountTests.swift
@@ -134,7 +134,7 @@ struct ServiceAccountTests {
       """
     let escapedPEM = pkcs1PEM.replacingOccurrences(of: "\n", with: "\\n")
 
-    let pkcs1KeyJSON = """
+    let pkcs1KeyJSON = Data("""
       {
         "type": "service_account",
         "project_id": "test-project-id",
@@ -143,7 +143,7 @@ struct ServiceAccountTests {
         "client_email": "test-client-email@gserviceaccount.com",
         "universe_domain": "test-universe-domain"
       }
-      """.data(using: .utf8)!
+      """.utf8)
 
     let credentials = try ServiceAccountCredentials(keyJSON: pkcs1KeyJSON)
     do {
@@ -232,7 +232,7 @@ struct ServiceAccountTests {
 
   @Test("Service Account JWS signing fails gracefully when given invalid private key PEM format")
   func invalidKeySigningFailure() async throws {
-    let badKeyJSON = """
+    let badKeyJSON = Data("""
       {
         "type": "service_account",
         "project_id": "test-project-id",
@@ -241,7 +241,7 @@ struct ServiceAccountTests {
         "client_email": "test-client-email@gserviceaccount.com",
         "universe_domain": "test-universe-domain"
       }
-      """.data(using: .utf8)!
+      """.utf8)
 
     let credentials = try ServiceAccountCredentials(keyJSON: badKeyJSON)
     do {
@@ -254,7 +254,7 @@ struct ServiceAccountTests {
 
   @Test("Service Account credentials initialization throws decoding error when given invalid JSON")
   func invalidJSONParsingFailure() async throws {
-    let invalidJSON = "{ \"invalid\": \"json\" }".data(using: .utf8)!
+    let invalidJSON = Data("{ \"invalid\": \"json\" }".utf8)
     let error = #expect(throws: CredentialsError.self) {
       _ = try ServiceAccountCredentials(keyJSON: invalidJSON)
     }

--- a/packages/auth/Tests/UserCredentialsTest.swift
+++ b/packages/auth/Tests/UserCredentialsTest.swift
@@ -39,7 +39,7 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
         httpVersion: nil as String?,
         headerFields: ["Content-Type": "application/json"]
       )!
-      return (response, "{}".data(using: .utf8)!)
+      return (response, Data("{}".utf8))
     }
 
     let mockData = UserAccountData(
@@ -257,7 +257,7 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
   @Test func tokenProviderMalformedResponseIsNonretryable() async throws {
     let targetURL = URL(string: "https://oauth2.googleapis.com/token")!
     let malformedPayload = "invalid-json"
-    let encodedData = malformedPayload.data(using: .utf8)!
+    let encodedData = Data(malformedPayload.utf8)
 
     MockURLProtocol.requestHandler = { (request: URLRequest) in
       let response = HTTPURLResponse(
@@ -297,7 +297,7 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
         "type": "authorized_user"
       }
       """
-    let dataData = malformedJSON.data(using: .utf8)!
+    let dataData = Data(malformedJSON.utf8)
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
 
@@ -394,7 +394,7 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
         httpVersion: nil as String?,
         headerFields: nil as [String: String]?
       )!
-      let errorPayload = "{\"error\": \"invalid_grant\"}".data(using: .utf8)!
+      let errorPayload = Data("{\"error\": \"invalid_grant\"}".utf8)
       return (response, errorPayload)
     }
 

--- a/packages/gax/Tests/ErrorWrapperTest.swift
+++ b/packages/gax/Tests/ErrorWrapperTest.swift
@@ -22,7 +22,7 @@ import GoogleRpc
 
 @Suite struct ErrorWrapperTests {
   @Test func validStatus() throws {
-    let json = """
+    let json = Data("""
       {
         "error": {
           "code": 400,
@@ -31,7 +31,7 @@ import GoogleRpc
           "details": []
         }
       }
-      """.data(using: .utf8)!
+      """.utf8)
 
     let response = HTTPURLResponse(
       url: URL(string: "http://example.com")!, statusCode: 400, httpVersion: nil, headerFields: nil)!
@@ -47,7 +47,7 @@ import GoogleRpc
   }
 
   @Test func nilStatus() throws {
-    let json = """
+    let json = Data("""
       {
         "error": {
           "code": 500,
@@ -55,7 +55,7 @@ import GoogleRpc
           "details": []
         }
       }
-      """.data(using: .utf8)!
+      """.utf8)
 
     let response = HTTPURLResponse(
       url: URL(string: "http://example.com")!, statusCode: 500, httpVersion: nil, headerFields: nil)!
@@ -71,7 +71,7 @@ import GoogleRpc
   }
 
   @Test func unknownStatus() throws {
-    let json = """
+    let json = Data("""
       {
         "error": {
           "code": 500,
@@ -80,7 +80,7 @@ import GoogleRpc
           "details": []
         }
       }
-      """.data(using: .utf8)!
+      """.utf8)
 
     let response = HTTPURLResponse(
       url: URL(string: "http://example.com")!, statusCode: 500, httpVersion: nil, headerFields: nil)!
@@ -96,7 +96,7 @@ import GoogleRpc
   }
 
   @Test func missingDetails() throws {
-    let json = """
+    let json = Data("""
       {
         "error": {
           "code": 400,
@@ -104,7 +104,7 @@ import GoogleRpc
           "message": "missing details message"
         }
       }
-      """.data(using: .utf8)!
+      """.utf8)
 
     let response = HTTPURLResponse(
       url: URL(string: "http://example.com")!, statusCode: 400, httpVersion: nil, headerFields: nil)!
@@ -121,7 +121,7 @@ import GoogleRpc
   }
 
   @Test func withHelpDetails() throws {
-    let json = """
+    let json = Data("""
       {
         "error": {
           "code": 400,
@@ -140,7 +140,7 @@ import GoogleRpc
           ]
         }
       }
-      """.data(using: .utf8)!
+      """.utf8)
 
     let response = HTTPURLResponse(
       url: URL(string: "http://example.com")!, statusCode: 400, httpVersion: nil, headerFields: nil)!

--- a/packages/gax/Tests/ErrorWrapperTest.swift
+++ b/packages/gax/Tests/ErrorWrapperTest.swift
@@ -22,7 +22,8 @@ import GoogleRpc
 
 @Suite struct ErrorWrapperTests {
   @Test func validStatus() throws {
-    let json = Data("""
+    let json = Data(
+      """
       {
         "error": {
           "code": 400,
@@ -47,7 +48,8 @@ import GoogleRpc
   }
 
   @Test func nilStatus() throws {
-    let json = Data("""
+    let json = Data(
+      """
       {
         "error": {
           "code": 500,
@@ -71,7 +73,8 @@ import GoogleRpc
   }
 
   @Test func unknownStatus() throws {
-    let json = Data("""
+    let json = Data(
+      """
       {
         "error": {
           "code": 500,
@@ -96,7 +99,8 @@ import GoogleRpc
   }
 
   @Test func missingDetails() throws {
-    let json = Data("""
+    let json = Data(
+      """
       {
         "error": {
           "code": 400,
@@ -121,7 +125,8 @@ import GoogleRpc
   }
 
   @Test func withHelpDetails() throws {
-    let json = Data("""
+    let json = Data(
+      """
       {
         "error": {
           "code": 400,

--- a/packages/gax/Tests/HttpClientTest.swift
+++ b/packages/gax/Tests/HttpClientTest.swift
@@ -128,7 +128,7 @@ import GoogleRpc
 
       let response = HTTPURLResponse(
         url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
-      let responseData = "{}".data(using: .utf8)!
+      let responseData = Data("{}".utf8)
       return (response, responseData)
     }
 
@@ -163,7 +163,7 @@ import GoogleRpc
       let response = HTTPURLResponse(
         url: request.url!, statusCode: 403, httpVersion: nil,
         headerFields: ["Content-Type": "application/json; charset=UTF-8"])!
-      let responseData = errorResponseWithDetails.data(using: .utf8)!
+      let responseData = Data(errorResponseWithDetails.utf8)
       return (response, responseData)
     }
 

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -315,18 +315,18 @@ extension HTTPClient {
     request.setValue("multipart/related; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
     var body = Data()
-    body.append("--\(boundary)\r\n".data(using: .utf8)!)
-    body.append("Content-Type: application/json; charset=UTF-8\r\n\r\n".data(using: .utf8)!)
+    body.append(Data("--\(boundary)\r\n".utf8))
+    body.append(Data("Content-Type: application/json; charset=UTF-8\r\n\r\n".utf8))
     let metadataJson = try JSONEncoder().encode(metadata ?? UploadMetadata())
     body.append(metadataJson)
-    body.append("\r\n".data(using: .utf8)!)
+    body.append(Data("\r\n".utf8))
 
-    body.append("--\(boundary)\r\n".data(using: .utf8)!)
-    body.append("Content-Type: application/octet-stream\r\n\r\n".data(using: .utf8)!)
+    body.append(Data("--\(boundary)\r\n".utf8))
+    body.append(Data("Content-Type: application/octet-stream\r\n\r\n".utf8))
     body.append(data)
-    body.append("\r\n".data(using: .utf8)!)
+    body.append(Data("\r\n".utf8))
 
-    body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+    body.append(Data("--\(boundary)--\r\n".utf8))
 
     request.httpBody = body
     return request

--- a/packages/storage/Tests/ChecksumTests.swift
+++ b/packages/storage/Tests/ChecksumTests.swift
@@ -22,8 +22,8 @@ import Testing
 
 @Suite struct ChecksumTests {
   @Test func testChecksummedSourceCRC32C() async throws {
-    let data1 = "Hello, ".data(using: .utf8)!
-    let data2 = "World!".data(using: .utf8)!
+    let data1 = Data("Hello, ".utf8)
+    let data2 = Data("World!".utf8)
     let combinedData = data1 + data2
 
     let source = BytesSource(data: combinedData)
@@ -48,8 +48,8 @@ import Testing
   }
 
   @Test func testChecksummedSourceMD5() async throws {
-    let data1 = "Hello, ".data(using: .utf8)!
-    let data2 = "World!".data(using: .utf8)!
+    let data1 = Data("Hello, ".utf8)
+    let data2 = Data("World!".utf8)
     let combinedData = data1 + data2
 
     let source = BytesSource(data: combinedData)
@@ -93,7 +93,7 @@ import Testing
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
     let objectName = "test-object"
-    let data = "Small payload".data(using: .utf8)!
+    let data = Data("Small payload".utf8)
     let source = BytesSource(data: data)
 
     let uploadUrl = registry.url(
@@ -103,7 +103,7 @@ import Testing
       "Provided CRC32C \"invalid_crc\" doesn't match calculated CRC32C \"valid_crc\""
     registry.register(
       response: .success(
-        statusCode: 400, data: errorMessage.data(using: .utf8)!,
+        statusCode: 400, data: Data(errorMessage.utf8),
         headers: nil),
       for: uploadUrl)
 
@@ -151,7 +151,7 @@ import Testing
       for: startUrl)
     registry.register(
       response: .success(
-        statusCode: 400, data: errorMessage.data(using: .utf8)!,
+        statusCode: 400, data: Data(errorMessage.utf8),
         headers: nil),
       for: chunkUrl)
 
@@ -180,8 +180,8 @@ import Testing
   }
 
   @Test func testChecksummedSourceMultipleAuto() async throws {
-    let data1 = "Hello, ".data(using: .utf8)!
-    let data2 = "World!".data(using: .utf8)!
+    let data1 = Data("Hello, ".utf8)
+    let data2 = Data("World!".utf8)
     let combinedData = data1 + data2
 
     let source = BytesSource(data: combinedData)
@@ -197,7 +197,7 @@ import Testing
   }
 
   @Test func testChecksummedSourceUserProvidedValues() async throws {
-    let source = BytesSource(data: "Some data".data(using: .utf8)!)
+    let source = BytesSource(data: Data("Some data".utf8))
     let checksums = ChecksumOptions(crc32c: "PRE_CRC", md5: "PRE_MD5")
     var checksummedSource = ChecksummedSource(source: source, options: checksums)
 
@@ -209,7 +209,7 @@ import Testing
   }
 
   @Test func testChecksummedSourceMixedAutoAndUserProvided() async throws {
-    let data = "Hello, World!".data(using: .utf8)!
+    let data = Data("Hello, World!".utf8)
     let source = BytesSource(data: data)
     let checksums = ChecksumOptions(crc32c: .auto, md5: "CUSTOM_MD5")
     var checksummedSource = ChecksummedSource(source: source, options: checksums)

--- a/packages/storage/Tests/ResumableUploadTests.swift
+++ b/packages/storage/Tests/ResumableUploadTests.swift
@@ -52,7 +52,7 @@ import Testing
       for: startUrl)
     registry.register(
       response: .success(
-        statusCode: 200, data: objectJSON.data(using: .utf8)!,
+        statusCode: 200, data: Data(objectJSON.utf8),
         headers: nil),
       for: chunkUrl)
 
@@ -166,7 +166,7 @@ import Testing
       for: startUrl)
     registry.register(
       response: .success(
-        statusCode: 500, data: "Internal Server Error".data(using: .utf8)!,
+        statusCode: 500, data: Data("Internal Server Error".utf8),
         headers: nil),
       for: chunkUrl)
 
@@ -224,7 +224,7 @@ import Testing
       for: queryUrl)
     registry.register(
       response: .success(
-        statusCode: 200, data: objectJSON.data(using: .utf8)!,
+        statusCode: 200, data: Data(objectJSON.utf8),
         headers: nil),
       for: queryUrl)
 
@@ -434,7 +434,7 @@ import Testing
 
     registry.register(
       response: .success(
-        statusCode: 404, data: "Upload session expired".data(using: .utf8)!,
+        statusCode: 404, data: Data("Upload session expired".utf8),
         headers: nil),
       for: queryUrl)
 
@@ -516,7 +516,7 @@ import Testing
 
     registry.register(
       response: .success(
-        statusCode: 499, data: "Client Closed Request".data(using: .utf8)!,
+        statusCode: 499, data: Data("Client Closed Request".utf8),
         headers: nil),
       for: queryUrl)
 

--- a/packages/storage/Tests/SimpleUploadTests.swift
+++ b/packages/storage/Tests/SimpleUploadTests.swift
@@ -133,7 +133,7 @@ import Testing
 
     registry.register(
       response: .success(
-        statusCode: 500, data: "Internal Server Error".data(using: .utf8)!,
+        statusCode: 500, data: Data("Internal Server Error".utf8),
         headers: nil),
       for: simpleUploadUrl)
 
@@ -175,7 +175,7 @@ import Testing
 
     registry.register(
       response: .success(
-        statusCode: 200, data: "invalid json content".data(using: .utf8)!,
+        statusCode: 200, data: Data("invalid json content".utf8),
         headers: nil),
       for: simpleUploadUrl)
 

--- a/packages/storage/Tests/UrlMocks.swift
+++ b/packages/storage/Tests/UrlMocks.swift
@@ -78,7 +78,7 @@ public func makeObjectJSON(
       "storageClass": "STANDARD"
     }
     """
-  return json.data(using: .utf8)!
+  return Data(json.utf8)
 }
 
 /// Helper to assert that an async action throws an error of type `E` and returns the caught error.

--- a/packages/wkt/Tests/Any/BasicMessage.swift
+++ b/packages/wkt/Tests/Any/BasicMessage.swift
@@ -25,7 +25,7 @@ extension AnyTests {
   @Test func decodeBasicMessage() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/test.BasicMessage","field0":"0","field1":"1"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedAny.self, from: data)
     let any = wrapped.content
@@ -38,7 +38,7 @@ extension AnyTests {
   @Test func decodeBasicMessageMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","field0":"0","field1":"1"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedAny.self, from: data)
     let any = wrapped.content
@@ -51,7 +51,7 @@ extension AnyTests {
   @Test func decodeBasicMessageMissing() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/test.BasicMessage","field0":"0"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/AnyTest.swift
+++ b/packages/wkt/Tests/AnyTest.swift
@@ -26,7 +26,7 @@ import Testing
   func testDecodingAny() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.Any","value":{"@type":"type.googleapis.com/google.protobuf.Duration","value":"123.450s"}}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedAny.self, from: data)
     let any = wrapped.content
@@ -43,7 +43,7 @@ import Testing
   @Test func testDecodingAnyMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":{"@type":"type.googleapis.com/google.protobuf.Duration","value":"123.450s"}}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/BoolValueTest.swift
+++ b/packages/wkt/Tests/BoolValueTest.swift
@@ -55,7 +55,7 @@ import Testing
       ("{\"value\":false}", false),
     ])
   func decodeJSON(_ args: (String, Bool)) throws {
-    let data = args.0.data(using: .utf8)!
+    let data = Data(args.0.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedBoolValueDecode.self, from: data)
     #expect(wrapped.value == args.1)
@@ -63,7 +63,7 @@ import Testing
 
   @Test("BoolValue JSON Decoding unset")
   func decodeJSONUnset() throws {
-    let data = "{}".data(using: .utf8)!
+    let data = Data("{}".utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedBoolValueDecode.self, from: data)
     #expect(wrapped.value == nil)
@@ -77,7 +77,7 @@ import Testing
   func boolValueAnyUnpack() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.BoolValue","value":true}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(BoolValueTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -91,7 +91,7 @@ import Testing
   @Test func boolValueAnyUnpackMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":true}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(BoolValueTests.WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/BytesValueTest.swift
+++ b/packages/wkt/Tests/BytesValueTest.swift
@@ -55,7 +55,7 @@ import Testing
       ("{\"value\":\"\"}", ""),
     ])
   func decodeJSON(_ args: (String, String)) throws {
-    let data = args.0.data(using: .utf8)!
+    let data = Data(args.0.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedBytesValueDecode.self, from: data)
     #expect(wrapped.value == Data(args.1.utf8))
@@ -63,7 +63,7 @@ import Testing
 
   @Test("BytesValue JSON Decoding unset")
   func decodeJSONUnset() throws {
-    let data = "{}".data(using: .utf8)!
+    let data = Data("{}".utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedBytesValueDecode.self, from: data)
     #expect(wrapped.value == nil)
@@ -77,7 +77,7 @@ import Testing
   func bytesValueAnyUnpack() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.BytesValue","value":"aGVsbG8="}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(BytesValueTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -91,7 +91,7 @@ import Testing
   @Test func bytesValueAnyUnpackMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":"aGVsbG8="}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(BytesValueTests.WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/DoubleValueTest.swift
+++ b/packages/wkt/Tests/DoubleValueTest.swift
@@ -55,7 +55,7 @@ import Testing
       ("{\"value\":0}", 0),
     ])
   func decodeJSON(_ args: (String, Double)) throws {
-    let data = args.0.data(using: .utf8)!
+    let data = Data(args.0.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedDoubleValueDecode.self, from: data)
     #expect(wrapped.value == args.1)
@@ -64,7 +64,7 @@ import Testing
   @Test(
     "DoubleValue JSON Decoding unset")
   func decodeJSONUnset() throws {
-    let data = "{}".data(using: .utf8)!
+    let data = Data("{}".utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedDoubleValueDecode.self, from: data)
     #expect(wrapped.value == nil)
@@ -78,7 +78,7 @@ import Testing
   func doubleValueAnyUnpack() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.DoubleValue","value":123.45}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(DoubleValueTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -92,7 +92,7 @@ import Testing
   @Test func doubleValueAnyUnpackMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":123.45}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(DoubleValueTests.WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/DurationTest.swift
+++ b/packages/wkt/Tests/DurationTest.swift
@@ -121,7 +121,7 @@ import Testing
       ("{\"value\":\"-315576000000.999999999s\"}", -315_576_000_000, -999_999_999),
     ])
   func decodeJSON(_ args: (String, Int64, Int64)) throws {
-    let data = args.0.data(using: .utf8)!
+    let data = Data(args.0.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedDurationDecode.self, from: data)
     #expect(wrapped.value.seconds == args.1)
@@ -132,7 +132,7 @@ import Testing
   func durationAnyUnpack() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.Duration","value":"123.45s"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -146,7 +146,7 @@ import Testing
   @Test func durationAnyUnpackMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":"123.45s"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/EmptyTest.swift
+++ b/packages/wkt/Tests/EmptyTest.swift
@@ -37,7 +37,7 @@ import Testing
   @Test("Empty JSON Decoding")
   func decodingJSON() throws {
     let jsonString = "{\"value\":{}}"
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedEmptyDecode.self, from: data)
     #expect(wrapped.value == Empty())
@@ -47,7 +47,7 @@ import Testing
   func emptyAnyUnpack() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.Empty","value":{}}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -61,7 +61,7 @@ import Testing
   func emptyAnyUnpackNoValue() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.Empty"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -74,7 +74,7 @@ import Testing
   @Test func emptyAnyUnpackMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":{}}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/FieldMaskTest.swift
+++ b/packages/wkt/Tests/FieldMaskTest.swift
@@ -53,7 +53,7 @@ import Testing
       ("{\"value\":\"authorProfile.avatarUrl\"}", ["author_profile.avatar_url"]),
     ])
   func decodeJSON(_ json: String, _ expected: [String]) throws {
-    let data = json.data(using: .utf8)!
+    let data = Data(json.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedFieldMaskDecode.self, from: data)
     #expect(wrapped.value.paths == expected)
@@ -63,7 +63,7 @@ import Testing
   func fieldMaskAnyUnpack() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.FieldMask","value":"a,b,cD"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -77,7 +77,7 @@ import Testing
   @Test func fieldMaskAnyUnpackMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":"a,b,cD"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/FloatValueTest.swift
+++ b/packages/wkt/Tests/FloatValueTest.swift
@@ -55,7 +55,7 @@ import Testing
       ("{\"value\":0}", 0.0),
     ])
   func decodeJSON(_ args: (String, Float)) throws {
-    let data = args.0.data(using: .utf8)!
+    let data = Data(args.0.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedFloatValueDecode.self, from: data)
     #expect(wrapped.value == args.1)
@@ -63,7 +63,7 @@ import Testing
 
   @Test("FloatValue JSON Decoding unset")
   func decodeJSONUnset() throws {
-    let data = "{}".data(using: .utf8)!
+    let data = Data("{}".utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedFloatValueDecode.self, from: data)
     #expect(wrapped.value == nil)
@@ -77,7 +77,7 @@ import Testing
   func floatValueAnyUnpack() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.FloatValue","value":123.45}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(FloatValueTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -91,7 +91,7 @@ import Testing
   @Test func floatValueAnyUnpackMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":123.45}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(FloatValueTests.WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/Int32ValueTest.swift
+++ b/packages/wkt/Tests/Int32ValueTest.swift
@@ -55,7 +55,7 @@ import Testing
       ("{\"value\":0}", 0),
     ])
   func decodeJSON(_ args: (String, Int32)) throws {
-    let data = args.0.data(using: .utf8)!
+    let data = Data(args.0.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedInt32ValueDecode.self, from: data)
     #expect(wrapped.value == args.1)
@@ -63,7 +63,7 @@ import Testing
 
   @Test("Int32Value JSON Decoding unset")
   func decodeJSONUnset() throws {
-    let data = "{}".data(using: .utf8)!
+    let data = Data("{}".utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedInt32ValueDecode.self, from: data)
     #expect(wrapped.value == nil)
@@ -77,7 +77,7 @@ import Testing
   func int32ValueAnyUnpack() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":123}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(Int32ValueTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -91,7 +91,7 @@ import Testing
   @Test func int32ValueAnyUnpackMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":123}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(Int32ValueTests.WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/Int64ValueTest.swift
+++ b/packages/wkt/Tests/Int64ValueTest.swift
@@ -55,7 +55,7 @@ import Testing
       ("{\"value\":0}", 0),
     ])
   func decodeJSON(_ args: (String, Int64)) throws {
-    let data = args.0.data(using: .utf8)!
+    let data = Data(args.0.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedInt64ValueDecode.self, from: data)
     #expect(wrapped.value == args.1)
@@ -63,7 +63,7 @@ import Testing
 
   @Test("Int64Value JSON Decoding unset")
   func decodeJSONUnset() throws {
-    let data = "{}".data(using: .utf8)!
+    let data = Data("{}".utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedInt64ValueDecode.self, from: data)
     #expect(wrapped.value == nil)
@@ -77,7 +77,7 @@ import Testing
   func int64ValueAnyUnpack() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int64Value","value":123}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(Int64ValueTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -91,7 +91,7 @@ import Testing
   @Test func int64ValueAnyUnpackMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":123}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(Int64ValueTests.WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/ProtoJSONDecoder.swift
+++ b/packages/wkt/Tests/ProtoJSONDecoder.swift
@@ -24,7 +24,7 @@ import GoogleCloudWkt
       }
       """
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(MessageWithRepeated.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(MessageWithRepeated.self, from: Data(input.utf8))
     let want = MessageWithRepeated(
       repeatedMessage: [
         MapPrimitives(),

--- a/packages/wkt/Tests/ProtoJSONDecoder/MapPrimitives.swift
+++ b/packages/wkt/Tests/ProtoJSONDecoder/MapPrimitives.swift
@@ -81,7 +81,7 @@ extension ProtoJSONDecoderTest {
     ])
   func decodeRepeated(input: String, want: MapPrimitives) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(MapPrimitives.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(MapPrimitives.self, from: Data(input.utf8))
     #expect(got == want)
   }
 
@@ -102,7 +102,7 @@ extension ProtoJSONDecoderTest {
   func decodeMapBad(input: String) throws {
     let decoder = _ProtoJSONDecoder()
     let error = #expect(throws: DecodingError.self) {
-      try decoder.decode(MapPrimitives.self, from: input.data(using: .utf8)!)
+      try decoder.decode(MapPrimitives.self, from: Data(input.utf8))
     }
     #expect({ if case .dataCorrupted = error { true } else { false } }())
   }
@@ -111,7 +111,7 @@ extension ProtoJSONDecoderTest {
     let input = #"{"fieldData":   {"a": 42} }"#
     let decoder = _ProtoJSONDecoder()
     let error = #expect(throws: DecodingError.self) {
-      try decoder.decode(MapPrimitives.self, from: input.data(using: .utf8)!)
+      try decoder.decode(MapPrimitives.self, from: Data(input.utf8))
     }
     #expect({ if case .typeMismatch = error { true } else { false } }())
   }

--- a/packages/wkt/Tests/ProtoJSONDecoder/OptionalPrimitives.swift
+++ b/packages/wkt/Tests/ProtoJSONDecoder/OptionalPrimitives.swift
@@ -82,7 +82,7 @@ extension ProtoJSONDecoderTest {
     ])
   func decodeOptionals(input: String, want: OptionalPrimitives) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(OptionalPrimitives.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(OptionalPrimitives.self, from: Data(input.utf8))
     #expect(got == want)
   }
 
@@ -104,7 +104,7 @@ extension ProtoJSONDecoderTest {
   func decodeOptionalBad(input: String) throws {
     let decoder = _ProtoJSONDecoder()
     let error = #expect(throws: DecodingError.self) {
-      try decoder.decode(OptionalPrimitives.self, from: input.data(using: .utf8)!)
+      try decoder.decode(OptionalPrimitives.self, from: Data(input.utf8))
     }
     #expect({ if case .dataCorrupted = error { true } else { false } }(), "\(error)")
   }
@@ -113,7 +113,7 @@ extension ProtoJSONDecoderTest {
     let input = #"{"fieldString": 42 }"#
     let decoder = _ProtoJSONDecoder()
     let error = #expect(throws: DecodingError.self) {
-      try decoder.decode(OptionalPrimitives.self, from: input.data(using: .utf8)!)
+      try decoder.decode(OptionalPrimitives.self, from: Data(input.utf8))
     }
     #expect({ if case .typeMismatch = error { true } else { false } }())
   }

--- a/packages/wkt/Tests/ProtoJSONDecoder/RepeatedPrimitives.swift
+++ b/packages/wkt/Tests/ProtoJSONDecoder/RepeatedPrimitives.swift
@@ -81,7 +81,7 @@ extension ProtoJSONDecoderTest {
     ])
   func decodeRepeated(input: String, want: RepeatedPrimitives) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(RepeatedPrimitives.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(RepeatedPrimitives.self, from: Data(input.utf8))
     #expect(got == want)
   }
 
@@ -102,7 +102,7 @@ extension ProtoJSONDecoderTest {
   func decodeRepeatedBad(input: String) throws {
     let decoder = _ProtoJSONDecoder()
     let error = #expect(throws: DecodingError.self) {
-      try decoder.decode(RepeatedPrimitives.self, from: input.data(using: .utf8)!)
+      try decoder.decode(RepeatedPrimitives.self, from: Data(input.utf8))
     }
     #expect({ if case .dataCorrupted = error { true } else { false } }())
   }
@@ -111,7 +111,7 @@ extension ProtoJSONDecoderTest {
     let input = #"{"fieldData":   [42] }"#
     let decoder = _ProtoJSONDecoder()
     let error = #expect(throws: DecodingError.self) {
-      try decoder.decode(RepeatedPrimitives.self, from: input.data(using: .utf8)!)
+      try decoder.decode(RepeatedPrimitives.self, from: Data(input.utf8))
     }
     #expect({ if case .typeMismatch = error { true } else { false } }())
   }

--- a/packages/wkt/Tests/ProtoJSONDecoder/RequiredPrimitives.swift
+++ b/packages/wkt/Tests/ProtoJSONDecoder/RequiredPrimitives.swift
@@ -71,7 +71,7 @@ extension ProtoJSONDecoderTest {
     ])
   func decodeRequired(input: String, want: RequiredPrimitives) throws {
     let decoder = _ProtoJSONDecoder()
-    let got = try decoder.decode(RequiredPrimitives.self, from: input.data(using: .utf8)!)
+    let got = try decoder.decode(RequiredPrimitives.self, from: Data(input.utf8))
     #expect(got == want)
   }
 
@@ -93,7 +93,7 @@ extension ProtoJSONDecoderTest {
   func decodeRequiredBad(input: String) throws {
     let decoder = _ProtoJSONDecoder()
     let error = #expect(throws: DecodingError.self) {
-      try decoder.decode(RequiredPrimitives.self, from: input.data(using: .utf8)!)
+      try decoder.decode(RequiredPrimitives.self, from: Data(input.utf8))
     }
     #expect({ if case .dataCorrupted = error { true } else { false } }())
   }
@@ -102,7 +102,7 @@ extension ProtoJSONDecoderTest {
     let input = #"{"fieldString": 42 }"#
     let decoder = _ProtoJSONDecoder()
     let error = #expect(throws: DecodingError.self) {
-      try decoder.decode(OptionalPrimitives.self, from: input.data(using: .utf8)!)
+      try decoder.decode(OptionalPrimitives.self, from: Data(input.utf8))
     }
     #expect({ if case .typeMismatch = error { true } else { false } }())
   }

--- a/packages/wkt/Tests/RecursiveTest.swift
+++ b/packages/wkt/Tests/RecursiveTest.swift
@@ -66,7 +66,7 @@ import Testing
   @Test("JSON Decoding")
   func testJSONDecoding() throws {
     let jsonString = #"{"name":"A"}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
 
     let decoder = JSONDecoder()
     let decoded = try decoder.decode(Recursive<DummyNode>.self, from: data)

--- a/packages/wkt/Tests/StringValueTest.swift
+++ b/packages/wkt/Tests/StringValueTest.swift
@@ -55,7 +55,7 @@ import Testing
       ("{\"value\":\"\"}", ""),
     ])
   func decodeJSON(_ args: (String, String)) throws {
-    let data = args.0.data(using: .utf8)!
+    let data = Data(args.0.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedStringValueDecode.self, from: data)
     #expect(wrapped.value == args.1)
@@ -63,7 +63,7 @@ import Testing
 
   @Test("StringValue JSON Decoding unset")
   func decodeJSONUnset() throws {
-    let data = "{}".data(using: .utf8)!
+    let data = Data("{}".utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedStringValueDecode.self, from: data)
     #expect(wrapped.value == nil)
@@ -77,7 +77,7 @@ import Testing
   func stringValueAnyUnpack() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.StringValue","value":"hello"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(StringValueTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -91,7 +91,7 @@ import Testing
   @Test func stringValueAnyUnpackMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":"hello"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(StringValueTests.WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/TimestampTest.swift
+++ b/packages/wkt/Tests/TimestampTest.swift
@@ -146,7 +146,7 @@ import Testing
   func timestampAnyUnpack() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.Timestamp","value":"2026-04-21T12:34:56.789123456Z"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -160,7 +160,7 @@ import Testing
   @Test func timestampAnyUnpackMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":"2026-04-21T12:34:56.789123456Z"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -216,7 +216,7 @@ import Testing
     ]
   )
   func decodeJSON(_ args: (String, Int64, Int64)) throws {
-    let data = args.0.data(using: .utf8)!
+    let data = Data(args.0.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedTimestampDecode.self, from: data)
     #expect(wrapped.value.seconds == args.1)

--- a/packages/wkt/Tests/UInt32ValueTest.swift
+++ b/packages/wkt/Tests/UInt32ValueTest.swift
@@ -55,7 +55,7 @@ import Testing
       ("{\"value\":0}", 0),
     ])
   func decodeJSON(_ args: (String, UInt32)) throws {
-    let data = args.0.data(using: .utf8)!
+    let data = Data(args.0.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedUInt32ValueDecode.self, from: data)
     #expect(wrapped.value == args.1)
@@ -63,7 +63,7 @@ import Testing
 
   @Test("UInt32Value JSON Decoding unset")
   func decodeJSONUnset() throws {
-    let data = "{}".data(using: .utf8)!
+    let data = Data("{}".utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedUInt32ValueDecode.self, from: data)
     #expect(wrapped.value == nil)
@@ -77,7 +77,7 @@ import Testing
   func uint32ValueAnyUnpack() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":123}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(UInt32ValueTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -91,7 +91,7 @@ import Testing
   @Test func uint32ValueAnyUnpackMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":123}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(UInt32ValueTests.WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/UInt64ValueTest.swift
+++ b/packages/wkt/Tests/UInt64ValueTest.swift
@@ -55,7 +55,7 @@ import Testing
       ("{\"value\":0}", 0),
     ])
   func decodeJSON(_ args: (String, UInt64)) throws {
-    let data = args.0.data(using: .utf8)!
+    let data = Data(args.0.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedUInt64ValueDecode.self, from: data)
     #expect(wrapped.value == args.1)
@@ -63,7 +63,7 @@ import Testing
 
   @Test("UInt64Value JSON Decoding unset")
   func decodeJSONUnset() throws {
-    let data = "{}".data(using: .utf8)!
+    let data = Data("{}".utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(WrappedUInt64ValueDecode.self, from: data)
     #expect(wrapped.value == nil)
@@ -77,7 +77,7 @@ import Testing
   func uint64ValueAnyUnpack() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":123}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(UInt64ValueTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -91,7 +91,7 @@ import Testing
   @Test func uint64ValueAnyUnpackMismatchedUrl() throws {
     let jsonString =
       #"{"content":{"@type":"bad","value":123}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(UInt64ValueTests.WrappedAny.self, from: data)
     let any = wrapped.content

--- a/packages/wkt/Tests/ValueTest.swift
+++ b/packages/wkt/Tests/ValueTest.swift
@@ -115,7 +115,7 @@ import Testing
       ("{\"value\":[1,2]}", Value.array([.number(1), .number(2)])),
     ])
   func decodeValue(json: String, expected: Value) throws {
-    let data = json.data(using: .utf8)!
+    let data = Data(json.utf8)
     let decoder = JSONDecoder()
     let got = try decoder.decode(WrappedValue.self, from: data)
     #expect(got.value == expected)
@@ -135,7 +135,7 @@ import Testing
   func valueAnyUnpack(fragment: String, want: Value) throws {
     let expectedUrl = "type.googleapis.com/google.protobuf.Value"
     let jsonString = "{\"content\":{\"@type\":\"\(expectedUrl)\",\(fragment)}}"
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -147,7 +147,7 @@ import Testing
 
   @Test func valueAnyUnpackMismatchedUrl() throws {
     let jsonString = #"{"content":{"@type":"bad","value":"unused"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -193,7 +193,7 @@ import Testing
   func structAnyUnpack(fragment: String, want: Struct) throws {
     let expectedUrl = "type.googleapis.com/google.protobuf.Struct"
     let jsonString = "{\"content\":{\"@type\":\"\(expectedUrl)\",\(fragment)}}"
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -205,7 +205,7 @@ import Testing
 
   @Test func structAnyUnpackMismatchedUrl() throws {
     let jsonString = #"{"content":{"@type":"bad","value":"unused"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -249,7 +249,7 @@ import Testing
   func listValueAnyUnpack(fragment: String, want: ListValue) throws {
     let expectedUrl = "type.googleapis.com/google.protobuf.ListValue"
     let jsonString = "{\"content\":{\"@type\":\"\(expectedUrl)\",\(fragment)}}"
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -261,7 +261,7 @@ import Testing
 
   @Test func listValueAnyUnpackMismatchedUrl() throws {
     let jsonString = #"{"content":{"@type":"bad","value":"unused"}}"#
-    let data = jsonString.data(using: .utf8)!
+    let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(AnyTests.WrappedAny.self, from: data)
     let any = wrapped.content
@@ -300,7 +300,7 @@ import Testing
   @Test("NullValue decoding")
   func decodeNullValue() throws {
     let json = "{\"value\": null}"
-    let data = json.data(using: .utf8)!
+    let data = Data(json.utf8)
     let decoder = JSONDecoder()
     let got = try decoder.decode(WrappedNull.self, from: data)
     #expect(got.value == NullValue())
@@ -308,7 +308,7 @@ import Testing
 
   @Test("NullValue decoding failure", arguments: ["{\"value\": 123}", "{\"value\": \"foo\"}"])
   func decodeNullValueFailure(json: String) throws {
-    let data = json.data(using: .utf8)!
+    let data = Data(json.utf8)
     let decoder = JSONDecoder()
     #expect(throws: (any Error).self) {
       _ = try decoder.decode(WrappedNull.self, from: data)


### PR DESCRIPTION
## Summary
- Replace `String.data(using: .utf8)!` with non-force-unwrapping `Data(String.utf8)` across 64 files (162 call sites).
- Standardize UTF-8 `Data` construction in tests and Storage multipart body assembly.