### PR TITLE
fix: correct SwiftPM workspace ignore path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 # Swift creates many files:
 .build/
 Packages/*/.build/
-.swiftpm/xcode/package.xcworkspace/contents.xcwrappercontents
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .swiftpm/configuration/
 
 */**/Package.resolved


### PR DESCRIPTION
## Summary
- Fix the SwiftPM Xcode workspace path in `.gitignore` from the mistyped `contents.xcwrappercontents` to the correct `contents.xcworkspacedata`.