### PR TITLE
refactor(Gax)!: rename `RetryIO` to `ContinueOnIO`

### DIFF
--- a/packages/gax/Sources/GoogleCloudGax/BaseRetryPolicy.swift
+++ b/packages/gax/Sources/GoogleCloudGax/BaseRetryPolicy.swift
@@ -24,7 +24,7 @@ import GoogleRpc
 ///
 /// [AIP-194]: https://google.aip.dev/194
 final public class BaseRetryPolicy: RetryPolicy {
-  let inner: StrictIdempotency<RetryIO<Aip194>>
+  let inner: StrictIdempotency<ContinueOnIO<Aip194>>
 
   public init() {
     self.inner = Aip194().retryOnIO().strictIdempotency()

--- a/packages/gax/Sources/GoogleCloudGax/ContinueOnIO+RetryPolicy.swift
+++ b/packages/gax/Sources/GoogleCloudGax/ContinueOnIO+RetryPolicy.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extension RetryIO: RetryPolicy where P: RetryPolicy & Sendable {
+extension ContinueOnIO: RetryPolicy where P: RetryPolicy & Sendable {
   public func onError(state: RetryState, error: RequestError) -> RetryResult {
     if case .io = error {
       return .retry(error)
@@ -36,7 +36,7 @@ extension RetryPolicy {
   /// **if** the request is idempotent.
   ///
   /// For other errors it returns the same value as the inner policy.
-  public func retryOnIO() -> RetryIO<Self> {
-    RetryIO(inner: self)
+  public func retryOnIO() -> ContinueOnIO<Self> {
+    ContinueOnIO(inner: self)
   }
 }

--- a/packages/gax/Sources/GoogleCloudGax/ContinueOnIO.swift
+++ b/packages/gax/Sources/GoogleCloudGax/ContinueOnIO.swift
@@ -18,7 +18,7 @@ import Foundation
 ///
 /// This policy returns [.retry](``RetryResult.retry(_:)``) on [.io](``RequestError/io(_:)``)
 /// errors. Otherwise it returns the result from the inner retry policy.
-final public class RetryIO<P: Sendable>: Sendable {
+final public class ContinueOnIO<P: Sendable>: Sendable {
   let inner: P
 
   public init(inner: P) {

--- a/packages/gax/Tests/ContinueOnIORetryPolicyTest.swift
+++ b/packages/gax/Tests/ContinueOnIORetryPolicyTest.swift
@@ -16,7 +16,7 @@ import Foundation
 import GoogleCloudGax
 import Testing
 
-@Suite struct RetryIOTests {
+@Suite struct ContinueIOTests {
   @Test func retryIO() {
     let p = NeverRetry().retryOnIO()
 


### PR DESCRIPTION
This will make the name more consistent with the polling policy variant.

Towards #45 fixes #54 