### PR TITLE
impl(Gax): use polling policies in LROs

### DIFF
--- a/packages/gax/Sources/GoogleCloudGax/LongRunningOperations.swift
+++ b/packages/gax/Sources/GoogleCloudGax/LongRunningOperations.swift
@@ -60,7 +60,8 @@ public final class _PollableOperationImpl<ResponseType>: PollableOperation {
   private var state: State
   private let pollOp: Poll
   private let sleep: Sleep
-  private let backoffPolicy: BackoffPolicy = LinearBackoffPolicy()
+  private var backoffPolicy: BackoffPolicy = LinearBackoffPolicy()
+  private var pollingPolicy: PollingErrorPolicy = BasePollingPolicy()
 
   /// Initializes a new pollable operation implementation.
   ///
@@ -78,6 +79,13 @@ public final class _PollableOperationImpl<ResponseType>: PollableOperation {
     self.sleep = sleep
   }
 
+  public func withPolicies(polling: PollingErrorPolicy, backoff: BackoffPolicy) -> Self {
+    let copy = self
+    copy.pollingPolicy = polling
+    copy.backoffPolicy = backoff
+    return copy
+  }
+
   /// Waits for the long-running operation to complete.
   ///
   /// This method uses a simple loop that polls for the operation state at intervals determined
@@ -88,11 +96,24 @@ public final class _PollableOperationImpl<ResponseType>: PollableOperation {
   ///   - The underlying operation error if the operation failed.
   ///   - `RequestError.malformedResponse` if the operation completed successfully but returned no result.
   public func wait() async throws -> ResponseType {
-    let retryState = RetryState.init()
+    var pollingState = PollingState()
     while !state.done {
-      let delay = backoffPolicy.backoffDelay(for: retryState)
+      try pollingPolicy.onInProgress(state: pollingState, name: "")
+      let delay = backoffPolicy.backoffDelay(for: pollingState.asRetryState())
       try await sleep(delay)
-      state = try await pollOp()
+      pollingState.attemptCount += 1
+      do {
+        state = try await pollOp()
+      } catch {
+        let requestError = (error as? RequestError) ?? .unimplemented
+        let flow = pollingPolicy.onError(state: pollingState, error: requestError)
+        switch flow {
+        case .permanent(let e), .exhausted(let e):
+          throw e
+        case .retry:
+          continue
+        }
+      }
     }
 
     switch state.result {
@@ -102,6 +123,15 @@ public final class _PollableOperationImpl<ResponseType>: PollableOperation {
       throw error
     case .none:
       throw RequestError.malformedResponse("Operation completed but result was missing")
+    }
+  }
+}
+
+extension PollingState {
+  func asRetryState() -> RetryState {
+    RetryState(idempotent: false).with {
+      $0.attemptCount = self.attemptCount
+      $0.start = self.start
     }
   }
 }

--- a/packages/gax/Tests/LongRunningOperationsTest.swift
+++ b/packages/gax/Tests/LongRunningOperationsTest.swift
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 import Foundation
+import Synchronization
 import Testing
+import GoogleRpc
 
 @testable import GoogleCloudGax
 
@@ -23,12 +25,12 @@ import Testing
   }
 
   class MockPoller<ResponseType> {
-    public var responses: [_PollableOperationImpl<ResponseType>.State] = []
+    public var responses: [() throws -> _PollableOperationImpl<ResponseType>.State] = []
     public var pollCount = 0
 
     public func poll() async throws -> _PollableOperationImpl<ResponseType>.State {
       defer { pollCount += 1 }
-      return responses[pollCount]
+      return try responses[pollCount]()
     }
   }
 
@@ -40,8 +42,36 @@ import Testing
     }
   }
 
+  static func transient() -> RequestError {
+    .service(ServiceError(code: GoogleRpc.Code.unavailable, message: "UNAVAILABLE"))
+  }
+
+  static func httpError() -> RequestError {
+    .http(HTTPDetails(http_status_code: 404, headers: [:]))
+  }
+
+  static func pendingState() -> _PollableOperationImpl<String>.State {
+    .init(done: false, result: nil)
+  }
+
+  static func successState(_ value: String = "polling success") -> _PollableOperationImpl<String>.State {
+    .init(done: true, result: .success(value))
+  }
+
+  static func errorState(_ msg: String = "error") -> _PollableOperationImpl<String>.State {
+    .init(done: true, result: .failure(MockError(message: msg)))
+  }
+
+  static func pendingVoid() -> _PollableOperationImpl<Void>.State {
+    .init(done: false, result: nil)
+  }
+
+  static func successVoid() -> _PollableOperationImpl<Void>.State {
+    .init(done: true, result: .success(()))
+  }
+
   @Test func initialSuccess() async throws {
-    let state = _PollableOperationImpl<String>.State(done: true, result: .success("success"))
+    let state = Self.successState("success")
     let op: any PollableOperation<String> = _PollableOperationImpl(initialState: state) {
       return state
     }
@@ -50,8 +80,7 @@ import Testing
   }
 
   @Test func initialFailure() async throws {
-    let state = _PollableOperationImpl<String>.State(
-      done: true, result: .failure(MockError(message: "error")))
+    let state = Self.errorState()
     let op = _PollableOperationImpl(initialState: state) {
       return state
     }
@@ -74,14 +103,14 @@ import Testing
 
   @Test func waitLoopsUntilDone() async throws {
     let results = [
-      _PollableOperationImpl<String>.State(done: false, result: nil),
-      _PollableOperationImpl<String>.State(done: true, result: .success("polling success")),
+      { () in Self.pendingState() },
+      { () in Self.successState() },
     ]
     let pollProvider = MockPoller<String>()
     pollProvider.responses = results
     let sleepProvider = MockSleeper()
     let op = _PollableOperationImpl<String>(
-      initialState: _PollableOperationImpl<String>.State(done: false, result: nil),
+      initialState: Self.pendingState(),
       poll: pollProvider.poll, sleep: sleepProvider.sleep)
 
     let res = try await op.wait()
@@ -92,16 +121,15 @@ import Testing
 
   @Test func waitLoopsFailure() async throws {
     let results = [
-      _PollableOperationImpl<String>.State(done: false, result: nil),
-      _PollableOperationImpl<String>.State(done: false, result: nil),
-      _PollableOperationImpl<String>.State(
-        done: true, result: .failure(MockError(message: "intermediate error"))),
+      { () in Self.pendingState() },
+      { () in Self.pendingState() },
+      { () in Self.errorState("intermediate error") },
     ]
     let pollProvider = MockPoller<String>()
     pollProvider.responses = results
     let sleepProvider = MockSleeper()
     let op = _PollableOperationImpl<String>(
-      initialState: _PollableOperationImpl<String>.State(done: false, result: nil),
+      initialState: Self.pendingState(),
       poll: pollProvider.poll, sleep: sleepProvider.sleep)
 
     await #expect(throws: MockError(message: "intermediate error")) {
@@ -115,10 +143,10 @@ import Testing
     let sleepProvider = MockSleeper()
     var pollCount = 0
     let op = _PollableOperationImpl<String>(
-      initialState: _PollableOperationImpl<String>.State(done: false, result: nil),
+      initialState: Self.pendingState(),
       poll: {
         pollCount += 1
-        throw RequestError.http(HTTPDetails(http_status_code: 404, headers: [:]))
+        throw Self.httpError()
       },
       sleep: sleepProvider.sleep
     )
@@ -132,18 +160,93 @@ import Testing
 
   @Test func voidOperationPolling() async throws {
     let results = [
-      _PollableOperationImpl<Void>.State(done: false, result: nil),
-      _PollableOperationImpl<Void>.State(done: true, result: .success(())),
+      { () in Self.pendingVoid() },
+      { () in Self.successVoid() },
     ]
     let pollProvider = MockPoller<Void>()
     pollProvider.responses = results
     let sleepProvider = MockSleeper()
     let op = _PollableOperationImpl<Void>(
-      initialState: _PollableOperationImpl<Void>.State(done: false, result: nil),
+      initialState: Self.pendingVoid(),
       poll: pollProvider.poll, sleep: sleepProvider.sleep)
 
     try await op.wait()
     #expect(pollProvider.pollCount == 2)
     #expect(sleepProvider.sleepCount == 2)
+  }
+
+  @Test func continuesIfPolicyAllows() async throws {
+    let results = [
+      { () in Self.pendingState() },
+      { () throws in throw Self.transient() },
+      { () throws in throw Self.transient() },
+      { () throws in throw Self.transient() },
+      { () in Self.successState() },
+    ]
+    let pollProvider = MockPoller<String>()
+    pollProvider.responses = results
+    let sleepProvider = MockSleeper()
+
+    let inProgressCount = Atomic<Int>(0)
+    let onErrorCount = Atomic<Int>(0)
+    var pollingPolicy = MockPollingPolicy()
+    pollingPolicy.onError = { _, e in
+      onErrorCount.add(1, ordering: .sequentiallyConsistent)
+      return .retry(e)
+    }
+    pollingPolicy.onInProgress = { _, _ in
+      inProgressCount.add(1, ordering: .sequentiallyConsistent)
+    }
+
+    let backoffPolicy = MockBackoff()
+
+    let op = _PollableOperationImpl<String>(
+      initialState: Self.pendingState(),
+      poll: pollProvider.poll, sleep: sleepProvider.sleep
+    )
+    .withPolicies(polling: pollingPolicy, backoff: backoffPolicy)
+    let res = try await op.wait()
+    #expect(res == "polling success")
+    #expect(inProgressCount.load(ordering: .sequentiallyConsistent) == 5)
+    #expect(onErrorCount.load(ordering: .sequentiallyConsistent) == 3)
+  }
+
+  @Test func stopsIfPolicySaysSo() async throws {
+    let results = [
+      { () in Self.pendingState() },
+      { () throws in throw Self.transient() },
+      { () throws in throw Self.transient() },
+    ]
+    let pollProvider = MockPoller<String>()
+    pollProvider.responses = results
+    let sleepProvider = MockSleeper()
+
+    let inProgressCount = Atomic<Int>(0)
+    let onErrorCount = Atomic<Int>(0)
+    var pollingPolicy = MockPollingPolicy()
+    pollingPolicy.onError = { _, e in
+      let (_, newValue) = onErrorCount.add(1, ordering: .sequentiallyConsistent)
+      if newValue >= 2 {
+        return .exhausted(e)
+      }
+      return .retry(e)
+    }
+    pollingPolicy.onInProgress = { _, _ in
+      inProgressCount.add(1, ordering: .sequentiallyConsistent)
+    }
+
+    let backoffPolicy = MockBackoff()
+
+    let op = _PollableOperationImpl<String>(
+      initialState: Self.pendingState(),
+      poll: pollProvider.poll, sleep: sleepProvider.sleep
+    )
+    .withPolicies(polling: pollingPolicy, backoff: backoffPolicy)
+    let error = await #expect(throws: RequestError.self) {
+      try await op.wait()
+    }
+    #expect(error == Self.transient())
+    #expect(inProgressCount.load(ordering: .sequentiallyConsistent) == 3)
+    #expect(onErrorCount.load(ordering: .sequentiallyConsistent) == 2)
   }
 }

--- a/packages/gax/Tests/LongRunningOperationsTest.swift
+++ b/packages/gax/Tests/LongRunningOperationsTest.swift
@@ -54,7 +54,9 @@ import GoogleRpc
     .init(done: false, result: nil)
   }
 
-  static func successState(_ value: String = "polling success") -> _PollableOperationImpl<String>.State {
+  static func successState(_ value: String = "polling success")
+    -> _PollableOperationImpl<String>.State
+  {
     .init(done: true, result: .success(value))
   }
 


### PR DESCRIPTION
Change the LRO polling loop to use a polling policy. The policy can stop the iteration if the polling loop is exhausted or the error is not considered retryable.

Fixes #61 