### PR TITLE
cleanup(Gax): remove polling policy parameter

### DIFF
--- a/packages/gax/Sources/GoogleCloudGax/BasePollingErrorPolicy.swift
+++ b/packages/gax/Sources/GoogleCloudGax/BasePollingErrorPolicy.swift
@@ -34,7 +34,7 @@ final public class BasePollingPolicy: PollingErrorPolicy {
     self.inner.onError(state: state, error: error)
   }
 
-  public func onInProgress(state: PollingState, name: String) throws {
-    try self.inner.onInProgress(state: state, name: name)
+  public func onInProgress(state: PollingState) throws {
+    try self.inner.onInProgress(state: state)
   }
 }

--- a/packages/gax/Sources/GoogleCloudGax/ContinueOnIO+PollingErrorPolicy.swift
+++ b/packages/gax/Sources/GoogleCloudGax/ContinueOnIO+PollingErrorPolicy.swift
@@ -20,8 +20,8 @@ extension ContinueOnIO: PollingErrorPolicy where P: PollingErrorPolicy & Sendabl
     return inner.onError(state: state, error: error)
   }
 
-  public func onInProgress(state: PollingState, name: String) throws {
-    try inner.onInProgress(state: state, name: name)
+  public func onInProgress(state: PollingState) throws {
+    try inner.onInProgress(state: state)
   }
 }
 

--- a/packages/gax/Sources/GoogleCloudGax/LimitedAttemptCount+PollingErrorPolicy.swift
+++ b/packages/gax/Sources/GoogleCloudGax/LimitedAttemptCount+PollingErrorPolicy.swift
@@ -29,8 +29,8 @@ extension LimitedAttemptCount: PollingErrorPolicy where P: PollingErrorPolicy & 
     }
   }
 
-  public func onInProgress(state: PollingState, name: String) throws {
-    try inner.onInProgress(state: state, name: name)
+  public func onInProgress(state: PollingState) throws {
+    try inner.onInProgress(state: state)
   }
 }
 

--- a/packages/gax/Sources/GoogleCloudGax/LimitedElapsedTime+PollingErrorPolicy.swift
+++ b/packages/gax/Sources/GoogleCloudGax/LimitedElapsedTime+PollingErrorPolicy.swift
@@ -29,8 +29,8 @@ extension LimitedElapsedTime: PollingErrorPolicy where P: PollingErrorPolicy {
     }
   }
 
-  public func onInProgress(state: PollingState, name: String) throws {
-    try inner.onInProgress(state: state, name: name)
+  public func onInProgress(state: PollingState) throws {
+    try inner.onInProgress(state: state)
   }
 }
 

--- a/packages/gax/Sources/GoogleCloudGax/LongRunningOperations.swift
+++ b/packages/gax/Sources/GoogleCloudGax/LongRunningOperations.swift
@@ -98,7 +98,7 @@ public final class _PollableOperationImpl<ResponseType>: PollableOperation {
   public func wait() async throws -> ResponseType {
     var pollingState = PollingState()
     while !state.done {
-      try pollingPolicy.onInProgress(state: pollingState, name: "")
+      try pollingPolicy.onInProgress(state: pollingState)
       let delay = backoffPolicy.backoffDelay(for: pollingState.asRetryState())
       try await sleep(delay)
       pollingState.attemptCount += 1

--- a/packages/gax/Sources/GoogleCloudGax/PollingErrorPolicy.swift
+++ b/packages/gax/Sources/GoogleCloudGax/PollingErrorPolicy.swift
@@ -41,10 +41,10 @@ public protocol PollingErrorPolicy: Sendable {
   ///
   /// - Parameters
   /// - `state` - the current state of the polling loop.
-  func onInProgress(state: PollingState, name: String) throws
+  func onInProgress(state: PollingState) throws
 }
 
 extension PollingErrorPolicy {
   /// By default, this method is a no-op.
-  public func onInProgress(state: PollingState, name: String) throws {}
+  public func onInProgress(state: PollingState) throws {}
 }

--- a/packages/gax/Sources/GoogleCloudGax/TooManyRequests+PollingErrorPolicy.swift
+++ b/packages/gax/Sources/GoogleCloudGax/TooManyRequests+PollingErrorPolicy.swift
@@ -20,8 +20,8 @@ extension TooManyRequests: PollingErrorPolicy where P: PollingErrorPolicy {
     return inner.onError(state: state, error: error)
   }
 
-  public func onInProgress(state: PollingState, name: String) throws {
-    try inner.onInProgress(state: state, name: name)
+  public func onInProgress(state: PollingState) throws {
+    try inner.onInProgress(state: state)
   }
 }
 

--- a/packages/gax/Tests/Aip194PollingErrorPolicyTest.swift
+++ b/packages/gax/Tests/Aip194PollingErrorPolicyTest.swift
@@ -45,7 +45,7 @@ import Testing
   @Test("Verify Aip194 onInProgress is a no-op")
   func onInProgress() throws {
     let p: any PollingErrorPolicy = Aip194()
-    try p.onInProgress(state: PollingState(), name: "op-name")
+    try p.onInProgress(state: PollingState())
   }
 
   static func unavailable() -> RequestError {

--- a/packages/gax/Tests/AlwaysPollTest.swift
+++ b/packages/gax/Tests/AlwaysPollTest.swift
@@ -32,7 +32,7 @@ import Testing
 
   @Test func alwaysPollOnInProgress() throws {
     let p = AlwaysPoll()
-    try p.onInProgress(state: PollingState(), name: "op-name")
+    try p.onInProgress(state: PollingState())
   }
 
   // Helper functions

--- a/packages/gax/Tests/ContinueOnIOPollingErrorPolicyTest.swift
+++ b/packages/gax/Tests/ContinueOnIOPollingErrorPolicyTest.swift
@@ -31,12 +31,12 @@ import Testing
 
   @Test func continueIOOnInProgress() throws {
     let called = Mutex(false)
-    let mock = MockPollingPolicy(onInProgress: { _, _ in
+    let mock = MockPollingPolicy(onInProgress: { _ in
       called.withLock { $0 = true }
     })
     let policy = mock.continueOnIoErrors()
 
-    try policy.onInProgress(state: PollingState(), name: "op-name")
+    try policy.onInProgress(state: PollingState())
     #expect(called.withLock { $0 })
   }
 }

--- a/packages/gax/Tests/LimitedAttemptCountPollingErrorPolicyTest.swift
+++ b/packages/gax/Tests/LimitedAttemptCountPollingErrorPolicyTest.swift
@@ -52,12 +52,12 @@ import Testing
 
   @Test func testLimitedAttemptCountOnInProgress() throws {
     let called = Mutex(false)
-    let mock = MockPollingPolicy(onInProgress: { _, _ in
+    let mock = MockPollingPolicy(onInProgress: { _ in
       called.withLock { $0 = true }
     })
     let policy = mock.withAttemptLimit(2)
 
-    try policy.onInProgress(state: PollingState(), name: "op-name")
+    try policy.onInProgress(state: PollingState())
     #expect(called.withLock { $0 })
   }
 

--- a/packages/gax/Tests/LimitedElapsedTimePollingErrorPolicyTest.swift
+++ b/packages/gax/Tests/LimitedElapsedTimePollingErrorPolicyTest.swift
@@ -71,13 +71,13 @@ import Testing
 
   @Test func testLimitedTimeOnInProgress() throws {
     let called = Mutex(false)
-    let mock = MockPollingPolicy(onInProgress: { _, _ in
+    let mock = MockPollingPolicy(onInProgress: { _ in
       called.withLock { $0 = true }
     })
     let limit = Duration.seconds(60)
     let policy = mock.withTimeLimit(limit)
 
-    try policy.onInProgress(state: PollingState(), name: "op-name")
+    try policy.onInProgress(state: PollingState())
     #expect(called.withLock { $0 })
   }
 }

--- a/packages/gax/Tests/LongRunningOperationsTest.swift
+++ b/packages/gax/Tests/LongRunningOperationsTest.swift
@@ -196,7 +196,7 @@ import GoogleRpc
       onErrorCount.add(1, ordering: .sequentiallyConsistent)
       return .retry(e)
     }
-    pollingPolicy.onInProgress = { _, _ in
+    pollingPolicy.onInProgress = { _ in
       inProgressCount.add(1, ordering: .sequentiallyConsistent)
     }
 
@@ -233,7 +233,7 @@ import GoogleRpc
       }
       return .retry(e)
     }
-    pollingPolicy.onInProgress = { _, _ in
+    pollingPolicy.onInProgress = { _ in
       inProgressCount.add(1, ordering: .sequentiallyConsistent)
     }
 

--- a/packages/gax/Tests/MockPollingErrorPolicy.swift
+++ b/packages/gax/Tests/MockPollingErrorPolicy.swift
@@ -17,13 +17,13 @@ import GoogleCloudGax
 
 struct MockPollingPolicy: PollingErrorPolicy {
   var onError: @Sendable (PollingState, RequestError) -> PollingResult = { _, e in .permanent(e) }
-  var onInProgress: @Sendable (PollingState, String) throws -> Void = { _, _ in }
+  var onInProgress: @Sendable (PollingState) throws -> Void = { _ in }
 
   func onError(state: PollingState, error: RequestError) -> PollingResult {
     onError(state, error)
   }
 
-  func onInProgress(state: PollingState, name: String) throws {
-    try onInProgress(state, name)
+  func onInProgress(state: PollingState) throws {
+    try onInProgress(state)
   }
 }

--- a/packages/gax/Tests/TooManyRequestsPollingErrorPolicyTest.swift
+++ b/packages/gax/Tests/TooManyRequestsPollingErrorPolicyTest.swift
@@ -33,12 +33,12 @@ import Testing
 
   @Test func testTooManyRequestsOnInProgress() throws {
     let called = Mutex(false)
-    let mock = MockPollingPolicy(onInProgress: { _, _ in
+    let mock = MockPollingPolicy(onInProgress: { _ in
       called.withLock { $0 = true }
     })
     let policy = mock.continueOnTooManyRequests()
 
-    try policy.onInProgress(state: PollingState(), name: "op-name")
+    try policy.onInProgress(state: PollingState())
     #expect(called.withLock { $0 })
   }
 


### PR DESCRIPTION
I included a `name` parameter in `PollingErrorPolicy/onInProgress` but it was not available at the interesting call site and went unused. Removed.

Fixes #67 