### PR TITLE
impl(Gax): polling policies as options

### DIFF
--- a/packages/gax/Sources/GoogleCloudGax/BasePollingErrorPolicy.swift
+++ b/packages/gax/Sources/GoogleCloudGax/BasePollingErrorPolicy.swift
@@ -23,7 +23,7 @@ import GoogleRpc
 /// This policy only continues if the error is an I/O error, or a safe error code.
 ///
 /// [AIP-194]: https://google.aip.dev/194
-final public class BasePollingPolicy: PollingErrorPolicy {
+final public class BasePollingErrorPolicy: PollingErrorPolicy {
   let inner: TooManyRequests<ContinueOnIO<Aip194>>
 
   public init() {

--- a/packages/gax/Sources/GoogleCloudGax/ClientOptions.swift
+++ b/packages/gax/Sources/GoogleCloudGax/ClientOptions.swift
@@ -126,8 +126,9 @@ func defaultPollingErrorPolicy() -> some PollingErrorPolicy {
 }
 
 func defaultPollingBackoffPolicy() -> some BackoffPolicy {
-  try! ExponentialBackoff(config: ExponentialBackoffConfig().with {
-    $0.initialDelay = .seconds(1)
-    $0.maximumDelay = .seconds(300)
-  })
+  try! ExponentialBackoff(
+    config: ExponentialBackoffConfig().with {
+      $0.initialDelay = .seconds(1)
+      $0.maximumDelay = .seconds(300)
+    })
 }

--- a/packages/gax/Sources/GoogleCloudGax/ClientOptions.swift
+++ b/packages/gax/Sources/GoogleCloudGax/ClientOptions.swift
@@ -83,8 +83,8 @@ public struct ClientOptions: Sendable {
 
   /// Configures the client's retry policy.
   ///
-  /// ``BaseRetryPolicy`` with a limit of 60 seconds or 10 attempts. Whichever limit is reached
-  /// first stops the retry loop.
+  /// By default the clients use ``BaseRetryPolicy`` with a limit of 60 seconds or 10 attempts.
+  /// Whichever limit is reached first stops the retry loop.
   public var retryPolicy: any RetryPolicy = defaultRetryPolicy()
 
   /// Configures the client's backoff policy.
@@ -96,6 +96,17 @@ public struct ClientOptions: Sendable {
   ///
   /// By default the clients use an ``AdaptiveThrottler`` with the default configuration.
   public var retryThrottler: any RetryThrottler = defaultRetryThrottler()
+
+  /// Configures the client's polling error policy.
+  ///
+  /// By default the clients use ``BasePollingErrorPolicy`` with a limit of 30 minutes.
+  public var pollingErrorPolicy: any PollingErrorPolicy = defaultPollingErrorPolicy()
+
+  /// Configures the client's backoff policy.
+  ///
+  /// By default the clients use ``ExponentialBackoff`` with an initial backoff of 1 seconds,
+  /// doubling each time the default initialization.
+  public var pollingBackoffPolicy: any BackoffPolicy = defaultPollingBackoffPolicy()
 }
 
 func defaultRetryPolicy() -> any RetryPolicy {
@@ -108,4 +119,15 @@ func defaultBackoffPolicy() -> any BackoffPolicy {
 
 func defaultRetryThrottler() -> any RetryThrottler {
   AdaptiveThrottler()
+}
+
+func defaultPollingErrorPolicy() -> some PollingErrorPolicy {
+  BasePollingErrorPolicy().withTimeLimit(.seconds(30 * 60))
+}
+
+func defaultPollingBackoffPolicy() -> some BackoffPolicy {
+  try! ExponentialBackoff(config: ExponentialBackoffConfig().with {
+    $0.initialDelay = .seconds(1)
+    $0.maximumDelay = .seconds(300)
+  })
 }

--- a/packages/gax/Sources/GoogleCloudGax/LongRunningOperations.swift
+++ b/packages/gax/Sources/GoogleCloudGax/LongRunningOperations.swift
@@ -60,8 +60,8 @@ public final class _PollableOperationImpl<ResponseType>: PollableOperation {
   private var state: State
   private let pollOp: Poll
   private let sleep: Sleep
-  private var backoffPolicy: BackoffPolicy = LinearBackoffPolicy()
-  private var pollingPolicy: PollingErrorPolicy = BasePollingPolicy()
+  private let pollingPolicy: PollingErrorPolicy
+  private let backoffPolicy: BackoffPolicy
 
   /// Initializes a new pollable operation implementation.
   ///
@@ -77,13 +77,30 @@ public final class _PollableOperationImpl<ResponseType>: PollableOperation {
     self.state = initialState
     self.pollOp = poll
     self.sleep = sleep
+    self.pollingPolicy = defaultPollingErrorPolicy()
+    self.backoffPolicy = defaultPollingBackoffPolicy()
   }
 
-  public func withPolicies(polling: PollingErrorPolicy, backoff: BackoffPolicy) -> Self {
-    let copy = self
-    copy.pollingPolicy = polling
-    copy.backoffPolicy = backoff
-    return copy
+  /// Initializes a new pollable operation implementation.
+  ///
+  /// - Parameters:
+  ///   - initialState: The initial state of the operation, typically constructed from the initial response.
+  ///   - polling: The polling error policy, how the loop responds when `pollOp` throws an error.
+  ///   - backoff: The backoff policy, how long the loop waits after polling.
+  ///   - poll: A closure that fetches the latest state of the operation from the server.
+  ///   - sleep: A closure that suspends the current task. Defaults to using `Task.sleep(for:)`.
+  public init(
+    initialState: State,
+    polling: any PollingErrorPolicy,
+    backoff: any BackoffPolicy,
+    poll: @escaping Poll,
+    sleep: @escaping Sleep = { try await Task.sleep(for: $0) },
+  ) {
+    self.state = initialState
+    self.pollOp = poll
+    self.sleep = sleep
+    self.pollingPolicy = polling
+    self.backoffPolicy = backoff
   }
 
   /// Waits for the long-running operation to complete.

--- a/packages/gax/Sources/GoogleCloudGax/RequestOptions.swift
+++ b/packages/gax/Sources/GoogleCloudGax/RequestOptions.swift
@@ -58,4 +58,14 @@ public struct RequestOptions: Sendable {
   /// be when the requests may be logically grouped by some backend resource, say a database or
   /// storage system instance, where one may expect they suffer from independent overload conditions.
   public var retryThrottler: (any RetryThrottler)? = nil
+
+  /// Overrides the default polling error policy.
+  ///
+  /// Without an override, the request uses the polling error policy configured in the client.
+  public var pollingErrorPolicy: (any PollingErrorPolicy)? = nil
+
+  /// Overrides the default polling backoff policy.
+  ///
+  /// Without an override, the request uses the polling backoff policy configured in the client.
+  public var pollingBackoffPolicy: (any BackoffPolicy)? = nil
 }

--- a/packages/gax/Tests/LongRunningOperationsTest.swift
+++ b/packages/gax/Tests/LongRunningOperationsTest.swift
@@ -204,9 +204,11 @@ import GoogleRpc
 
     let op = _PollableOperationImpl<String>(
       initialState: Self.pendingState(),
-      poll: pollProvider.poll, sleep: sleepProvider.sleep
+      polling: pollingPolicy,
+      backoff: backoffPolicy,
+      poll: pollProvider.poll,
+      sleep: sleepProvider.sleep,
     )
-    .withPolicies(polling: pollingPolicy, backoff: backoffPolicy)
     let res = try await op.wait()
     #expect(res == "polling success")
     #expect(inProgressCount.load(ordering: .sequentiallyConsistent) == 5)
@@ -241,9 +243,11 @@ import GoogleRpc
 
     let op = _PollableOperationImpl<String>(
       initialState: Self.pendingState(),
-      poll: pollProvider.poll, sleep: sleepProvider.sleep
+      polling: pollingPolicy,
+      backoff: backoffPolicy,
+      poll: pollProvider.poll,
+      sleep: sleepProvider.sleep
     )
-    .withPolicies(polling: pollingPolicy, backoff: backoffPolicy)
     let error = await #expect(throws: RequestError.self) {
       try await op.wait()
     }


### PR DESCRIPTION
Add fields to `RequestOptions` and `ClientOptions` to hold the polling error and backoff policies.

Fixes #62 