### PR TITLE
chore: update librarian circa 2027-07-29

### DIFF
--- a/generated/google-api-apikeys-v2/.repo-metadata.json
+++ b/generated/google-api-apikeys-v2/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Manages the API keys associated with developer projects.",
+    "api_id": "apikeys.googleapis.com",
+    "api_shortname": "apikeys",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-api-apikeys-v2/documentation",
+    "distribution_name": "google-api-apikeys-v2",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "apikeys",
+    "name_pretty": "API Keys",
+    "product_documentation": "https://cloud.google.com/api-keys/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-api-cloudquotas-v1/.repo-metadata.json
+++ b/generated/google-api-cloudquotas-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Cloud Quotas API provides Google Cloud service consumers with management\nand observability for resource usage, quotas, and restrictions of the\nservices they consume.",
+    "api_id": "cloudquotas.googleapis.com",
+    "api_shortname": "cloudquotas",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-api-cloudquotas-v1/documentation",
+    "distribution_name": "google-api-cloudquotas-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=445904",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "cloudquotas",
+    "name_pretty": "Cloud Quotas",
+    "product_documentation": "https://cloud.google.com/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-api-servicecontrol-v1/.repo-metadata.json
+++ b/generated/google-api-servicecontrol-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Provides admission control and telemetry reporting for services integrated\nwith Service Infrastructure.",
+    "api_id": "servicecontrol.googleapis.com",
+    "api_shortname": "servicecontrol",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-api-servicecontrol-v1/documentation",
+    "distribution_name": "google-api-servicecontrol-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "servicecontrol",
+    "name_pretty": "Service Control",
+    "product_documentation": "https://cloud.google.com/service-infrastructure/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-api-servicecontrol-v2/.repo-metadata.json
+++ b/generated/google-api-servicecontrol-v2/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Provides admission control and telemetry reporting for services integrated\nwith Service Infrastructure.",
+    "api_id": "servicecontrol.googleapis.com",
+    "api_shortname": "servicecontrol",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-api-servicecontrol-v2/documentation",
+    "distribution_name": "google-api-servicecontrol-v2",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "servicecontrol",
+    "name_pretty": "Service Control",
+    "product_documentation": "https://cloud.google.com/service-infrastructure/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-api-servicemanagement-v1/.repo-metadata.json
+++ b/generated/google-api-servicemanagement-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Google Service Management allows service producers to publish their\nservices on Google Cloud Platform so that they can be discovered and used\nby service consumers.",
+    "api_id": "servicemanagement.googleapis.com",
+    "api_shortname": "servicemanagement",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-api-servicemanagement-v1/documentation",
+    "distribution_name": "google-api-servicemanagement-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "servicemanagement",
+    "name_pretty": "Service Management",
+    "product_documentation": "https://cloud.google.com/service-infrastructure/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-api-serviceusage-v1/.repo-metadata.json
+++ b/generated/google-api-serviceusage-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Enables services that service consumers want to use on Google Cloud\nPlatform, lists the available or enabled services, or disables services\nthat service consumers no longer use.",
+    "api_id": "serviceusage.googleapis.com",
+    "api_shortname": "serviceusage",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-api-serviceusage-v1/documentation",
+    "distribution_name": "google-api-serviceusage-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "serviceusage",
+    "name_pretty": "Service Usage",
+    "product_documentation": "https://cloud.google.com/service-usage",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-appengine-v1/.repo-metadata.json
+++ b/generated/google-appengine-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Provisions and manages developers' App Engine applications.",
+    "api_id": "appengine.googleapis.com",
+    "api_shortname": "appengine",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-appengine-v1/documentation",
+    "distribution_name": "google-appengine-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "appengine",
+    "name_pretty": "App Engine Admin",
+    "product_documentation": "https://cloud.google.com/appengine/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-bigtable-admin-v2/.repo-metadata.json
+++ b/generated/google-bigtable-admin-v2/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Administer your Cloud Bigtable tables and instances.",
+    "api_id": "bigtableadmin.googleapis.com",
+    "api_shortname": "bigtableadmin",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-bigtable-admin-v2/documentation",
+    "distribution_name": "google-bigtable-admin-v2",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=127971",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "bigtableadmin",
+    "name_pretty": "Cloud Bigtable Admin",
+    "product_documentation": "https://cloud.google.com/bigtable/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-accessapproval-v1/.repo-metadata.json
+++ b/generated/google-cloud-accessapproval-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "An API for controlling access to data by Google personnel.",
+    "api_id": "accessapproval.googleapis.com",
+    "api_shortname": "accessapproval",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-accessapproval-v1/documentation",
+    "distribution_name": "google-cloud-accessapproval-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "accessapproval",
+    "name_pretty": "Access Approval",
+    "product_documentation": "https://cloud.google.com/access-approval/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-advisorynotifications-v1/.repo-metadata.json
+++ b/generated/google-cloud-advisorynotifications-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "An API for accessing Advisory Notifications in Google Cloud",
+    "api_id": "advisorynotifications.googleapis.com",
+    "api_shortname": "advisorynotifications",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-advisorynotifications-v1/documentation",
+    "distribution_name": "google-cloud-advisorynotifications-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1009495",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "advisorynotifications",
+    "name_pretty": "Advisory Notifications",
+    "product_documentation": "https://cloud.google.com/advisory-notifications/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-aiplatform-v1/.repo-metadata.json
+++ b/generated/google-cloud-aiplatform-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Train high-quality custom machine learning models with minimal machine\nlearning expertise and effort.",
+    "api_id": "aiplatform.googleapis.com",
+    "api_shortname": "aiplatform",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-aiplatform-v1/documentation",
+    "distribution_name": "google-cloud-aiplatform-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1130925\u0026template=1637248",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "aiplatform",
+    "name_pretty": "Vertex AI",
+    "product_documentation": "https://cloud.google.com/ai-platform/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-alloydb-v1/.repo-metadata.json
+++ b/generated/google-cloud-alloydb-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "AlloyDB for PostgreSQL is an open source-compatible database service that\nprovides a powerful option for migrating, modernizing, or building\ncommercial-grade applications. It offers full compatibility with standard\nPostgreSQL, and is more than 4x faster for transactional workloads and up\nto 100x faster for analytical queries than standard PostgreSQL in our\nperformance tests. AlloyDB for PostgreSQL offers a 99.99 percent\navailability SLA inclusive of maintenance. \u003cbr\u003e\u003cbr\u003e AlloyDB is optimized\nfor the most demanding use cases, allowing you to build new applications\nthat require high transaction throughput, large database sizes, or\nmultiple read resources; scale existing PostgreSQL workloads with no\napplication changes; and modernize legacy proprietary databases.",
+    "api_id": "alloydb.googleapis.com",
+    "api_shortname": "alloydb",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-alloydb-v1/documentation",
+    "distribution_name": "google-cloud-alloydb-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1194526\u0026template=1689942",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "alloydb",
+    "name_pretty": "AlloyDB",
+    "product_documentation": "https://cloud.google.com/alloydb/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-apigateway-v1/.repo-metadata.json
+++ b/generated/google-cloud-apigateway-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "API Gateway enables you to provide secure access to your backend services through a well-defined REST API that is consistent across all of your services, regardless of the service implementation.",
+    "api_id": "apigateway.googleapis.com",
+    "api_shortname": "apigateway",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-apigateway-v1/documentation",
+    "distribution_name": "google-cloud-apigateway-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "apigateway",
+    "name_pretty": "API Gateway",
+    "product_documentation": "https://cloud.google.com/api-gateway",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-apihub-v1/.repo-metadata.json
+++ b/generated/google-cloud-apihub-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_id": "apihub.googleapis.com",
+    "api_shortname": "apihub",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-apihub-v1/documentation",
+    "distribution_name": "google-cloud-apihub-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1447560",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "apihub",
+    "name_pretty": "API hub",
+    "product_documentation": "https://cloud.google.com/apigee/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-apiregistry-v1/.repo-metadata.json
+++ b/generated/google-cloud-apiregistry-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_id": "cloudapiregistry.googleapis.com",
+    "api_shortname": "cloudapiregistry",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-apiregistry-v1/documentation",
+    "distribution_name": "google-cloud-apiregistry-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1979613\u0026template=2231768",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "cloudapiregistry",
+    "name_pretty": "Cloud API Registry",
+    "product_documentation": "https://docs.cloud.google.com/api-registry/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-apphub-v1/.repo-metadata.json
+++ b/generated/google-cloud-apphub-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "App Hub acts as the foundational data model and central registry for your applications on Google Cloud.",
+    "api_id": "apphub.googleapis.com",
+    "api_shortname": "apphub",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-apphub-v1/documentation",
+    "distribution_name": "google-cloud-apphub-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1509913",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "apphub",
+    "name_pretty": "App Hub",
+    "product_documentation": "https://cloud.google.com/app-hub/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-asset-v1/.repo-metadata.json
+++ b/generated/google-cloud-asset-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "The Cloud Asset API manages the history and inventory of Google Cloud\nresources.",
+    "api_id": "cloudasset.googleapis.com",
+    "api_shortname": "cloudasset",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-asset-v1/documentation",
+    "distribution_name": "google-cloud-asset-v1",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559757",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "cloudasset",
+    "name_pretty": "Cloud Asset",
+    "product_documentation": "https://cloud.google.com/resource-manager/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-assuredworkloads-v1/.repo-metadata.json
+++ b/generated/google-cloud-assuredworkloads-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Assured Workloads lets you secure your workloads and accelerate your path to running compliant workloads on Google Cloud.",
+    "api_id": "assuredworkloads.googleapis.com",
+    "api_shortname": "assuredworkloads",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-assuredworkloads-v1/documentation",
+    "distribution_name": "google-cloud-assuredworkloads-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "assuredworkloads",
+    "name_pretty": "Assured Workloads",
+    "product_documentation": "https://cloud.google.com/assured-workloads/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-auditmanager-v1/.repo-metadata.json
+++ b/generated/google-cloud-auditmanager-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_id": "auditmanager.googleapis.com",
+    "api_shortname": "auditmanager",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-auditmanager-v1/documentation",
+    "distribution_name": "google-cloud-auditmanager-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1335397\u0026template=0",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "auditmanager",
+    "name_pretty": "Audit Manager",
+    "product_documentation": "https://cloud.google.com/audit-manager/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-baremetalsolution-v2/.repo-metadata.json
+++ b/generated/google-cloud-baremetalsolution-v2/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Provides ways to manage Bare Metal Solution hardware installed in a\nregional extension located near a Google Cloud data center.",
+    "api_id": "baremetalsolution.googleapis.com",
+    "api_shortname": "baremetalsolution",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-baremetalsolution-v2/documentation",
+    "distribution_name": "google-cloud-baremetalsolution-v2",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "baremetalsolution",
+    "name_pretty": "Bare Metal Solution",
+    "product_documentation": "https://cloud.google.com/bare-metal/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-batch-v1/.repo-metadata.json
+++ b/generated/google-cloud-batch-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "An API to manage the running of Batch resources on Google Cloud Platform.",
+    "api_id": "batch.googleapis.com",
+    "api_shortname": "batch",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-batch-v1/documentation",
+    "distribution_name": "google-cloud-batch-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "batch",
+    "name_pretty": "Batch",
+    "product_documentation": "https://cloud.google.com/batch/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-beyondcorp-appconnections-v1/.repo-metadata.json
+++ b/generated/google-cloud-beyondcorp-appconnections-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Beyondcorp Enterprise provides identity and context aware access controls\nfor enterprise resources and enables zero-trust access. Using the\nBeyondcorp Enterprise APIs, enterprises can set up multi-cloud and on-prem\nconnectivity using the App Connector hybrid connectivity solution.",
+    "api_id": "beyondcorp.googleapis.com",
+    "api_shortname": "beyondcorp",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-beyondcorp-appconnections-v1/documentation",
+    "distribution_name": "google-cloud-beyondcorp-appconnections-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "beyondcorp",
+    "name_pretty": "BeyondCorp",
+    "product_documentation": "https://cloud.google.com/beyondcorp/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-beyondcorp-appconnectors-v1/.repo-metadata.json
+++ b/generated/google-cloud-beyondcorp-appconnectors-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Beyondcorp Enterprise provides identity and context aware access controls\nfor enterprise resources and enables zero-trust access. Using the\nBeyondcorp Enterprise APIs, enterprises can set up multi-cloud and on-prem\nconnectivity using the App Connector hybrid connectivity solution.",
+    "api_id": "beyondcorp.googleapis.com",
+    "api_shortname": "beyondcorp",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-beyondcorp-appconnectors-v1/documentation",
+    "distribution_name": "google-cloud-beyondcorp-appconnectors-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "beyondcorp",
+    "name_pretty": "BeyondCorp",
+    "product_documentation": "https://cloud.google.com/beyondcorp/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-beyondcorp-appgateways-v1/.repo-metadata.json
+++ b/generated/google-cloud-beyondcorp-appgateways-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Beyondcorp Enterprise provides identity and context aware access controls\nfor enterprise resources and enables zero-trust access. Using the\nBeyondcorp Enterprise APIs, enterprises can set up multi-cloud and on-prem\nconnectivity using the App Connector hybrid connectivity solution.",
+    "api_id": "beyondcorp.googleapis.com",
+    "api_shortname": "beyondcorp",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-beyondcorp-appgateways-v1/documentation",
+    "distribution_name": "google-cloud-beyondcorp-appgateways-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "beyondcorp",
+    "name_pretty": "BeyondCorp",
+    "product_documentation": "https://cloud.google.com/beyondcorp/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-beyondcorp-clientconnectorservices-v1/.repo-metadata.json
+++ b/generated/google-cloud-beyondcorp-clientconnectorservices-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Beyondcorp Enterprise provides identity and context aware access controls\nfor enterprise resources and enables zero-trust access. Using the\nBeyondcorp Enterprise APIs, enterprises can set up multi-cloud and on-prem\nconnectivity using the App Connector hybrid connectivity solution.",
+    "api_id": "beyondcorp.googleapis.com",
+    "api_shortname": "beyondcorp",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-beyondcorp-clientconnectorservices-v1/documentation",
+    "distribution_name": "google-cloud-beyondcorp-clientconnectorservices-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "beyondcorp",
+    "name_pretty": "BeyondCorp",
+    "product_documentation": "https://cloud.google.com/beyondcorp/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-beyondcorp-clientgateways-v1/.repo-metadata.json
+++ b/generated/google-cloud-beyondcorp-clientgateways-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Beyondcorp Enterprise provides identity and context aware access controls\nfor enterprise resources and enables zero-trust access. Using the\nBeyondcorp Enterprise APIs, enterprises can set up multi-cloud and on-prem\nconnectivity using the App Connector hybrid connectivity solution.",
+    "api_id": "beyondcorp.googleapis.com",
+    "api_shortname": "beyondcorp",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-beyondcorp-clientgateways-v1/documentation",
+    "distribution_name": "google-cloud-beyondcorp-clientgateways-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "beyondcorp",
+    "name_pretty": "BeyondCorp",
+    "product_documentation": "https://cloud.google.com/beyondcorp/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-biglake-v1/.repo-metadata.json
+++ b/generated/google-cloud-biglake-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "The Lakehouse API (formerly BigLake API) provides access to a serverless,\nfully managed, and highly available metastore that provides a single\nsource of truth for your data lakehouse. It lets multiple\nengines—including Apache Spark, Google Managed Spark, Apache Flink, Trino\nand BigQuery—share tables and metadata for key open formats (Apache\nIceberg, Apache Hive), and query the same copy of data. Plus, through the\nLakehouse runtime catalog federation seamlessly unite your lakehouse\necosystem, letting Iceberg compatible engines on Google Cloud (BigQuery,\nGoogle Managed Spark) discover and analyze enterprise data across\nSnowflake, Databricks, and AWS Glue.",
+    "api_id": "biglake.googleapis.com",
+    "api_shortname": "biglake",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-biglake-v1/documentation",
+    "distribution_name": "google-cloud-biglake-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187149\u0026template=1019829",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "biglake",
+    "name_pretty": "Lakehouse",
+    "product_documentation": "https://cloud.google.com/bigquery/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-bigquery-analyticshub-v1/.repo-metadata.json
+++ b/generated/google-cloud-bigquery-analyticshub-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Exchange data and analytics assets securely and efficiently.",
+    "api_id": "analyticshub.googleapis.com",
+    "api_shortname": "analyticshub",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-bigquery-analyticshub-v1/documentation",
+    "distribution_name": "google-cloud-bigquery-analyticshub-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "analyticshub",
+    "name_pretty": "Analytics Hub",
+    "product_documentation": "https://cloud.google.com/analytics-hub",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-bigquery-connection-v1/.repo-metadata.json
+++ b/generated/google-cloud-bigquery-connection-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Allows users to manage BigQuery connections to external data sources.",
+    "api_id": "bigqueryconnection.googleapis.com",
+    "api_shortname": "bigqueryconnection",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-bigquery-connection-v1/documentation",
+    "distribution_name": "google-cloud-bigquery-connection-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "bigqueryconnection",
+    "name_pretty": "BigQuery Connection",
+    "product_documentation": "https://cloud.google.com/bigquery/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-bigquery-datapolicies-v1/.repo-metadata.json
+++ b/generated/google-cloud-bigquery-datapolicies-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Allows users to manage BigQuery data policies.",
+    "api_id": "bigquerydatapolicy.googleapis.com",
+    "api_shortname": "bigquerydatapolicy",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-bigquery-datapolicies-v1/documentation",
+    "distribution_name": "google-cloud-bigquery-datapolicies-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "bigquerydatapolicy",
+    "name_pretty": "BigQuery Data Policy",
+    "product_documentation": "https://cloud.google.com/bigquery/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-bigquery-datapolicies-v2/.repo-metadata.json
+++ b/generated/google-cloud-bigquery-datapolicies-v2/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Allows users to manage BigQuery data policies.",
+    "api_id": "bigquerydatapolicy.googleapis.com",
+    "api_shortname": "bigquerydatapolicy",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-bigquery-datapolicies-v2/documentation",
+    "distribution_name": "google-cloud-bigquery-datapolicies-v2",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187149\u0026template=1162659",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "bigquerydatapolicy",
+    "name_pretty": "BigQuery Data Policy",
+    "product_documentation": "https://cloud.google.com/bigquery/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-bigquery-datatransfer-v1/.repo-metadata.json
+++ b/generated/google-cloud-bigquery-datatransfer-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Schedule queries or transfer external data from SaaS applications to Google\nBigQuery on a regular basis.",
+    "api_id": "bigquerydatatransfer.googleapis.com",
+    "api_shortname": "bigquerydatatransfer",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-bigquery-datatransfer-v1/documentation",
+    "distribution_name": "google-cloud-bigquery-datatransfer-v1",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559654",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "bigquerydatatransfer",
+    "name_pretty": "BigQuery Data Transfer",
+    "product_documentation": "https://cloud.google.com/bigquery/transfer/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-billing-budgets-v1/.repo-metadata.json
+++ b/generated/google-cloud-billing-budgets-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "The Cloud Billing Budget API stores Cloud Billing budgets, which define a\nbudget plan and the rules to execute as spend is tracked against that\nplan.",
+    "api_id": "billingbudgets.googleapis.com",
+    "api_shortname": "billingbudgets",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-billing-budgets-v1/documentation",
+    "distribution_name": "google-cloud-billing-budgets-v1",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559770",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "billingbudgets",
+    "name_pretty": "Cloud Billing Budget",
+    "product_documentation": "https://cloud.google.com/billing/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-billing-v1/.repo-metadata.json
+++ b/generated/google-cloud-billing-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Allows developers to manage billing for their Google Cloud Platform\nprojects     programmatically.",
+    "api_id": "cloudbilling.googleapis.com",
+    "api_shortname": "cloudbilling",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-billing-v1/documentation",
+    "distribution_name": "google-cloud-billing-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "cloudbilling",
+    "name_pretty": "Cloud Billing",
+    "product_documentation": "https://cloud.google.com/billing",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-binaryauthorization-v1/.repo-metadata.json
+++ b/generated/google-cloud-binaryauthorization-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "The management interface for Binary Authorization, a service that provides\npolicy-based deployment validation and control for images deployed to\nGoogle Kubernetes Engine (GKE), Anthos Service Mesh, Anthos Clusters, and\nCloud Run.",
+    "api_id": "binaryauthorization.googleapis.com",
+    "api_shortname": "binaryauthorization",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-binaryauthorization-v1/documentation",
+    "distribution_name": "google-cloud-binaryauthorization-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "binaryauthorization",
+    "name_pretty": "Binary Authorization",
+    "product_documentation": "https://cloud.google.com/binary-authorization",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-blockchainnodeengine-v1/.repo-metadata.json
+++ b/generated/google-cloud-blockchainnodeengine-v1/.repo-metadata.json
@@ -1,0 +1,12 @@
+{
+    "api_id": "blockchainnodeengine.googleapis.com",
+    "api_shortname": "blockchainnodeengine",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-blockchainnodeengine-v1/documentation",
+    "distribution_name": "google-cloud-blockchainnodeengine-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "blockchainnodeengine",
+    "name_pretty": "Blockchain Node Engine",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-certificatemanager-v1/.repo-metadata.json
+++ b/generated/google-cloud-certificatemanager-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Certificate Manager simplifies the acquisition, deployment, and management of Transport Layer Security (TLS) certificates.",
+    "api_id": "certificatemanager.googleapis.com",
+    "api_shortname": "certificatemanager",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-certificatemanager-v1/documentation",
+    "distribution_name": "google-cloud-certificatemanager-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "certificatemanager",
+    "name_pretty": "Certificate Manager",
+    "product_documentation": "https://docs.cloud.google.com/certificate-manager/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-ces-v1/.repo-metadata.json
+++ b/generated/google-cloud-ces-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_id": "ces.googleapis.com",
+    "api_shortname": "ces",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-ces-v1/documentation",
+    "distribution_name": "google-cloud-ces-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1157150",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "ces",
+    "name_pretty": "Gemini Enterprise for Customer Experience",
+    "product_documentation": "https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-compute-v1/.repo-metadata.json
+++ b/generated/google-cloud-compute-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Compute Engine is an infrastructure as a service (IaaS) product that offers self-managed virtual machine (VM) instances and bare metal instances.",
+    "api_id": "compute.googleapis.com",
+    "api_shortname": "compute",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-compute-v1/documentation",
+    "distribution_name": "google-cloud-compute-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187134\u0026template=0",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "compute",
+    "name_pretty": "Google Compute Engine",
+    "product_documentation": "https://cloud.google.com/compute/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-confidentialcomputing-v1/.repo-metadata.json
+++ b/generated/google-cloud-confidentialcomputing-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Attestation verifier for Confidential Space.",
+    "api_id": "confidentialcomputing.googleapis.com",
+    "api_shortname": "confidentialcomputing",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-confidentialcomputing-v1/documentation",
+    "distribution_name": "google-cloud-confidentialcomputing-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1134314\u0026template=1640550",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "confidentialcomputing",
+    "name_pretty": "Confidential Computing",
+    "product_documentation": "https://cloud.google.com/confidential-computing",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-config-v1/.repo-metadata.json
+++ b/generated/google-cloud-config-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Creates and manages Google Cloud Platform resources and infrastructure.",
+    "api_id": "config.googleapis.com",
+    "api_shortname": "infra-manager",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-config-v1/documentation",
+    "distribution_name": "google-cloud-config-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=536700",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "infra-manager",
+    "name_pretty": "Infrastructure Manager",
+    "product_documentation": "https://cloud.google.com/infrastructure-manager/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-configdelivery-v1/.repo-metadata.json
+++ b/generated/google-cloud-configdelivery-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "ConfigDelivery service manages the deployment of kubernetes configuration\nto a fleet of kubernetes clusters.",
+    "api_id": "configdelivery.googleapis.com",
+    "api_shortname": "configdelivery",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-configdelivery-v1/documentation",
+    "distribution_name": "google-cloud-configdelivery-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1400250",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "configdelivery",
+    "name_pretty": "Config Delivery",
+    "product_documentation": "https://cloud.google.com/kubernetes-engine/enterprise/config-sync/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-connectors-v1/.repo-metadata.json
+++ b/generated/google-cloud-connectors-v1/.repo-metadata.json
@@ -1,0 +1,13 @@
+{
+    "api_description": "Enables users to create and manage connections to Google Cloud services\nand third-party business applications using the Connectors interface.",
+    "api_id": "connectors.googleapis.com",
+    "api_shortname": "connectors",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-connectors-v1/documentation",
+    "distribution_name": "google-cloud-connectors-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "connectors",
+    "name_pretty": "Connectors",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-datacatalog-v1/.repo-metadata.json
+++ b/generated/google-cloud-datacatalog-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "A fully managed and highly scalable data discovery and metadata management\nservice.",
+    "api_id": "datacatalog.googleapis.com",
+    "api_shortname": "datacatalog",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-datacatalog-v1/documentation",
+    "distribution_name": "google-cloud-datacatalog-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=655468\u0026template=1284353",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "datacatalog",
+    "name_pretty": "Google Cloud Data Catalog",
+    "product_documentation": "https://cloud.google.com/data-catalog/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-dataform-v1/.repo-metadata.json
+++ b/generated/google-cloud-dataform-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Service to develop, version control, and operationalize SQL pipelines in\nBigQuery.",
+    "api_id": "dataform.googleapis.com",
+    "api_shortname": "dataform",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-dataform-v1/documentation",
+    "distribution_name": "google-cloud-dataform-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=994183",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "dataform",
+    "name_pretty": "Dataform",
+    "product_documentation": "https://cloud.google.com/dataform/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-datafusion-v1/.repo-metadata.json
+++ b/generated/google-cloud-datafusion-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Cloud Data Fusion is a fully-managed, cloud native, enterprise data\nintegration service for     quickly building and managing data pipelines.\nIt provides a graphical interface to increase     time efficiency and\nreduce complexity, and allows business users, developers, and data\nscientists to easily and reliably build scalable data integration\nsolutions to cleanse,     prepare, blend, transfer and transform data\nwithout having to wrestle with infrastructure.",
+    "api_id": "datafusion.googleapis.com",
+    "api_shortname": "datafusion",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-datafusion-v1/documentation",
+    "distribution_name": "google-cloud-datafusion-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "datafusion",
+    "name_pretty": "Cloud Data Fusion",
+    "product_documentation": "https://cloud.google.com/data-fusion",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-dataplex-v1/.repo-metadata.json
+++ b/generated/google-cloud-dataplex-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "A unified, intelligent governance solution for data and AI assets.",
+    "api_id": "dataplex.googleapis.com",
+    "api_shortname": "dataplex",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-dataplex-v1/documentation",
+    "distribution_name": "google-cloud-dataplex-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1155079\u0026template=1656695",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "dataplex",
+    "name_pretty": "Cloud Dataplex",
+    "product_documentation": "https://cloud.google.com/dataplex/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-deploy-v1/.repo-metadata.json
+++ b/generated/google-cloud-deploy-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Cloud Deploy is a service that automates delivery of your applications to a series of target environments in a defined sequence.",
+    "api_id": "clouddeploy.googleapis.com",
+    "api_shortname": "clouddeploy",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-deploy-v1/documentation",
+    "distribution_name": "google-cloud-deploy-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "clouddeploy",
+    "name_pretty": "Cloud Deploy",
+    "product_documentation": "https://cloud.google.com/deploy/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-dialogflow-cx-v3/.repo-metadata.json
+++ b/generated/google-cloud-dialogflow-cx-v3/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Builds conversational interfaces (for example, chatbots, and voice-powered\napps and devices).",
+    "api_id": "dialogflow.googleapis.com",
+    "api_shortname": "dialogflow",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-dialogflow-cx-v3/documentation",
+    "distribution_name": "google-cloud-dialogflow-cx-v3",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/5300385",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "dialogflow",
+    "name_pretty": "Dialogflow",
+    "product_documentation": "https://cloud.google.com/dialogflow/cx/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-dialogflow-v2/.repo-metadata.json
+++ b/generated/google-cloud-dialogflow-v2/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Builds conversational interfaces (for example, chatbots, and voice-powered\napps and devices).",
+    "api_id": "dialogflow.googleapis.com",
+    "api_shortname": "dialogflow",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-dialogflow-v2/documentation",
+    "distribution_name": "google-cloud-dialogflow-v2",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=501190",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "dialogflow",
+    "name_pretty": "Dialogflow",
+    "product_documentation": "https://docs.cloud.google.com/dialogflow/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-discoveryengine-v1/.repo-metadata.json
+++ b/generated/google-cloud-discoveryengine-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Discovery Engine API.",
+    "api_id": "discoveryengine.googleapis.com",
+    "api_shortname": "discoveryengine",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-discoveryengine-v1/documentation",
+    "distribution_name": "google-cloud-discoveryengine-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=911831\u0026template=1480251",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "discoveryengine",
+    "name_pretty": "Discovery Engine",
+    "product_documentation": "https://cloud.google.com/generative-ai-app-builder/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-domains-v1/.repo-metadata.json
+++ b/generated/google-cloud-domains-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Enables management and configuration of domain names.",
+    "api_id": "domains.googleapis.com",
+    "api_shortname": "domains",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-domains-v1/documentation",
+    "distribution_name": "google-cloud-domains-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "domains",
+    "name_pretty": "Cloud Domains",
+    "product_documentation": "https://cloud.google.com/domains",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-edgecontainer-v1/.repo-metadata.json
+++ b/generated/google-cloud-edgecontainer-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Google Distributed Cloud Edge is a fully managed product that brings Google Cloud infrastructure and services closer to where data is being generated and consumed.",
+    "api_id": "edgecontainer.googleapis.com",
+    "api_shortname": "edgecontainer",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-edgecontainer-v1/documentation",
+    "distribution_name": "google-cloud-edgecontainer-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "edgecontainer",
+    "name_pretty": "Distributed Cloud Edge Container",
+    "product_documentation": "https://cloud.google.com/distributed-cloud/edge",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-edgenetwork-v1/.repo-metadata.json
+++ b/generated/google-cloud-edgenetwork-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Network management API for Distributed Cloud Edge.",
+    "api_id": "edgenetwork.googleapis.com",
+    "api_shortname": "edgenetwork",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-edgenetwork-v1/documentation",
+    "distribution_name": "google-cloud-edgenetwork-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=187192\u0026template=1162689",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "edgenetwork",
+    "name_pretty": "Distributed Cloud Edge Network",
+    "product_documentation": "https://cloud.google.com/distributed-cloud/edge/latest/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-eventarc-v1/.repo-metadata.json
+++ b/generated/google-cloud-eventarc-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Build event-driven applications on Google Cloud Platform.",
+    "api_id": "eventarc.googleapis.com",
+    "api_shortname": "eventarc",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-eventarc-v1/documentation",
+    "distribution_name": "google-cloud-eventarc-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "eventarc",
+    "name_pretty": "Eventarc",
+    "product_documentation": "https://cloud.google.com/eventarc/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-filestore-v1/.repo-metadata.json
+++ b/generated/google-cloud-filestore-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "The Cloud Filestore API is used for creating and managing cloud file\nservers.",
+    "api_id": "file.googleapis.com",
+    "api_shortname": "file",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-filestore-v1/documentation",
+    "distribution_name": "google-cloud-filestore-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "file",
+    "name_pretty": "Cloud Filestore",
+    "product_documentation": "https://cloud.google.com/filestore/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-functions-v2/.repo-metadata.json
+++ b/generated/google-cloud-functions-v2/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Manages lightweight user-provided functions executed in response to events.",
+    "api_id": "cloudfunctions.googleapis.com",
+    "api_shortname": "cloudfunctions",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-functions-v2/documentation",
+    "distribution_name": "google-cloud-functions-v2",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559729",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "cloudfunctions",
+    "name_pretty": "Cloud Functions",
+    "product_documentation": "https://cloud.google.com/functions/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-gkehub-v1/.repo-metadata.json
+++ b/generated/google-cloud-gkehub-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "The GKE Hub service handles the registration of many Kubernetes clusters to Google Cloud, and the management of multi-cluster features over those clusters.",
+    "api_id": "gkehub.googleapis.com",
+    "api_shortname": "gkehub",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-gkehub-v1/documentation",
+    "distribution_name": "google-cloud-gkehub-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "gkehub",
+    "name_pretty": "GKE Hub",
+    "product_documentation": "https://cloud.google.com/anthos/gke/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-gkemulticloud-v1/.repo-metadata.json
+++ b/generated/google-cloud-gkemulticloud-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "GKE Multi-Cloud provides a way to manage Kubernetes clusters that run on\nAWS and Azure infrastructure using the GKE Multi-Cloud API.  Combined with\nConnect, you can manage Kubernetes clusters on Google Cloud, AWS, and\nAzure from the Google Cloud Console.\n\nWhen you create a cluster with GKE Multi-Cloud, Google creates the\nresources needed and brings up a cluster on your behalf.  You can deploy\nworkloads with the GKE Multi-Cloud API or the gcloud and kubectl\ncommand-line tools.",
+    "api_id": "gkemulticloud.googleapis.com",
+    "api_shortname": "gkemulticloud",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-gkemulticloud-v1/documentation",
+    "distribution_name": "google-cloud-gkemulticloud-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=997904\u0026template=1807166",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "gkemulticloud",
+    "name_pretty": "GKE Multi-Cloud",
+    "product_documentation": "https://cloud.google.com/kubernetes-engine/multi-cloud/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-kms-inventory-v1/.repo-metadata.json
+++ b/generated/google-cloud-kms-inventory-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Cloud Key Management Service (Cloud KMS) lets you create and manage cryptographic keys for use in compatible Google Cloud services and in your own applications.",
+    "api_id": "kmsinventory.googleapis.com",
+    "api_shortname": "kmsinventory",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-kms-inventory-v1/documentation",
+    "distribution_name": "google-cloud-kms-inventory-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=190860\u0026template=819701",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "kmsinventory",
+    "name_pretty": "KMS Inventory",
+    "product_documentation": "https://cloud.google.com/kms/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-kms-v1/.repo-metadata.json
+++ b/generated/google-cloud-kms-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Manages keys and performs cryptographic operations in a central cloud\nservice, for direct use by other cloud resources and applications.",
+    "api_id": "cloudkms.googleapis.com",
+    "api_shortname": "cloudkms",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-kms-v1/documentation",
+    "distribution_name": "google-cloud-kms-v1",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/5264932",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "cloudkms",
+    "name_pretty": "Cloud Key Management Service (KMS)",
+    "product_documentation": "https://cloud.google.com/kms",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-language-v2/.repo-metadata.json
+++ b/generated/google-cloud-language-v2/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Provides natural language understanding technologies, such as sentiment\nanalysis, entity recognition, entity sentiment analysis, and other text\nannotations, to developers.",
+    "api_id": "language.googleapis.com",
+    "api_shortname": "language",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-language-v2/documentation",
+    "distribution_name": "google-cloud-language-v2",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559753",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "language",
+    "name_pretty": "Cloud Natural Language",
+    "product_documentation": "https://cloud.google.com/natural-language/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-licensemanager-v1/.repo-metadata.json
+++ b/generated/google-cloud-licensemanager-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "License Manager is a tool to manage and track third-party licenses on\nGoogle Cloud.",
+    "api_id": "licensemanager.googleapis.com",
+    "api_shortname": "licensemanager",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-licensemanager-v1/documentation",
+    "distribution_name": "google-cloud-licensemanager-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1659587",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "licensemanager",
+    "name_pretty": "License Manager",
+    "product_documentation": "https://cloud.google.com/compute/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-location/.repo-metadata.json
+++ b/generated/google-cloud-location/.repo-metadata.json
@@ -1,0 +1,13 @@
+{
+    "api_description": "This API provides static metadata about Google Cloud Platform. Currently,\nit only provides basic information about Google Cloud locations, such as\nzones, regions, and countries.",
+    "api_id": "cloud.googleapis.com",
+    "api_shortname": "cloud",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-location/documentation",
+    "distribution_name": "google-cloud-location",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "cloud",
+    "name_pretty": "Cloud Metadata",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-locationfinder-v1/.repo-metadata.json
+++ b/generated/google-cloud-locationfinder-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Cloud Location Finder is a public API that offers a repository of all Google Cloud and Google Distributed Cloud locations, as well as cloud locations for other cloud providers.",
+    "api_id": "cloudlocationfinder.googleapis.com",
+    "api_shortname": "locationfinder",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-locationfinder-v1/documentation",
+    "distribution_name": "google-cloud-locationfinder-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1569265\u0026template=1988535",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "locationfinder",
+    "name_pretty": "Cloud Location Finder",
+    "product_documentation": "https://cloud.google.com/location-finder/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-memorystore-v1/.repo-metadata.json
+++ b/generated/google-cloud-memorystore-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Memorystore for Valkey is a fully managed Valkey service for Google Cloud which supports both Cluster Mode Enabled and Cluster Mode Disabled instances.",
+    "api_id": "memorystore.googleapis.com",
+    "api_shortname": "memorystore",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-memorystore-v1/documentation",
+    "distribution_name": "google-cloud-memorystore-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1669139",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "memorystore",
+    "name_pretty": "Memorystore",
+    "product_documentation": "https://cloud.google.com/memorystore/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-networkconnectivity-v1/.repo-metadata.json
+++ b/generated/google-cloud-networkconnectivity-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "This API enables connectivity with and between Google Cloud resources.",
+    "api_id": "networkconnectivity.googleapis.com",
+    "api_shortname": "networkconnectivity",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-networkconnectivity-v1/documentation",
+    "distribution_name": "google-cloud-networkconnectivity-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "networkconnectivity",
+    "name_pretty": "Network Connectivity",
+    "product_documentation": "https://cloud.google.com/network-connectivity/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-notebooks-v2/.repo-metadata.json
+++ b/generated/google-cloud-notebooks-v2/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Notebooks API is used to manage notebook resources in Google Cloud.",
+    "api_id": "notebooks.googleapis.com",
+    "api_shortname": "notebooks",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-notebooks-v2/documentation",
+    "distribution_name": "google-cloud-notebooks-v2",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1392625",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "notebooks",
+    "name_pretty": "Notebooks",
+    "product_documentation": "https://cloud.google.com/vertex-ai/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-osconfig-v1/.repo-metadata.json
+++ b/generated/google-cloud-osconfig-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "OS management tools that can be used for patch management, patch\ncompliance, and configuration management on VM instances.",
+    "api_id": "osconfig.googleapis.com",
+    "api_shortname": "osconfig",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-osconfig-v1/documentation",
+    "distribution_name": "google-cloud-osconfig-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "osconfig",
+    "name_pretty": "OS Config",
+    "product_documentation": "https://cloud.google.com/compute/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-parallelstore-v1/.repo-metadata.json
+++ b/generated/google-cloud-parallelstore-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Parallelstore is a high performance, managed parallel file service based on DAOS. It delivers up to 6x greater read throughput performance compared to competitive Lustre scratch offerings.",
+    "api_id": "parallelstore.googleapis.com",
+    "api_shortname": "parallelstore",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-parallelstore-v1/documentation",
+    "distribution_name": "google-cloud-parallelstore-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1181190",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "parallelstore",
+    "name_pretty": "Parallelstore",
+    "product_documentation": "https://cloud.google.com/parallelstore?hl=en",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-resourcemanager-v3/.repo-metadata.json
+++ b/generated/google-cloud-resourcemanager-v3/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Creates, reads, and updates metadata for Google Cloud Platform resource\ncontainers.",
+    "api_id": "cloudresourcemanager.googleapis.com",
+    "api_shortname": "cloudresourcemanager",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-resourcemanager-v3/documentation",
+    "distribution_name": "google-cloud-resourcemanager-v3",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559757",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "cloudresourcemanager",
+    "name_pretty": "Cloud Resource Manager",
+    "product_documentation": "https://cloud.google.com/resource-manager",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-retail-v2/.repo-metadata.json
+++ b/generated/google-cloud-retail-v2/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Vertex AI Search for commerce API is made up of Retail Search, Browse and\nRecommendations. These discovery AI solutions help you implement\npersonalized search, browse and recommendations, based on machine learning\nmodels, across your websites and mobile applications.",
+    "api_id": "retail.googleapis.com",
+    "api_shortname": "retail",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-retail-v2/documentation",
+    "distribution_name": "google-cloud-retail-v2",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "retail",
+    "name_pretty": "Vertex AI Search for commerce",
+    "product_documentation": "https://cloud.google.com/retail/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-run-v2/.repo-metadata.json
+++ b/generated/google-cloud-run-v2/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Deploy and manage user provided container images that scale automatically\nbased on incoming requests. The Cloud Run Admin API v1 follows the Knative\nServing API specification, while v2 is aligned with Google Cloud AIP-based\nAPI standards, as described in https://google.aip.dev/.",
+    "api_id": "run.googleapis.com",
+    "api_shortname": "run",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-run-v2/documentation",
+    "distribution_name": "google-cloud-run-v2",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "run",
+    "name_pretty": "Cloud Run Admin",
+    "product_documentation": "https://cloud.google.com/run/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-scheduler-v1/.repo-metadata.json
+++ b/generated/google-cloud-scheduler-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Creates and manages jobs run on a regular recurring schedule.",
+    "api_id": "cloudscheduler.googleapis.com",
+    "api_shortname": "cloudscheduler",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-scheduler-v1/documentation",
+    "distribution_name": "google-cloud-scheduler-v1",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/5411429",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "cloudscheduler",
+    "name_pretty": "Cloud Scheduler",
+    "product_documentation": "https://cloud.google.com/scheduler/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-secretmanager-v1/.repo-metadata.json
+++ b/generated/google-cloud-secretmanager-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Stores sensitive data such as API keys, passwords, and certificates.\nProvides convenience while improving security.",
+    "api_id": "secretmanager.googleapis.com",
+    "api_shortname": "secretmanager",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-secretmanager-v1/documentation",
+    "distribution_name": "google-cloud-secretmanager-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=784854\u0026template=1380926",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "secretmanager",
+    "name_pretty": "Secret Manager",
+    "product_documentation": "https://cloud.google.com/secret-manager/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-security-privateca-v1/.repo-metadata.json
+++ b/generated/google-cloud-security-privateca-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "The Certificate Authority Service API is a highly-available, scalable\nservice that enables you to simplify and automate the management of\nprivate certificate authorities (CAs) while staying in control of your\nprivate keys.",
+    "api_id": "privateca.googleapis.com",
+    "api_shortname": "privateca",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-security-privateca-v1/documentation",
+    "distribution_name": "google-cloud-security-privateca-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "privateca",
+    "name_pretty": "Certificate Authority",
+    "product_documentation": "https://cloud.google.com/certificate-authority-service",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-security-publicca-v1/.repo-metadata.json
+++ b/generated/google-cloud-security-publicca-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "The Public Certificate Authority API may be used to create and manage ACME\nexternal account binding keys associated with Google Trust Services'\npublicly trusted certificate authority.",
+    "api_id": "publicca.googleapis.com",
+    "api_shortname": "publicca",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-security-publicca-v1/documentation",
+    "distribution_name": "google-cloud-security-publicca-v1",
+    "issue_tracker": "https://cloud.google.com/certificate-manager/docs/getting-support",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "publicca",
+    "name_pretty": "Public Certificate Authority",
+    "product_documentation": "https://cloud.google.com/certificate-manager/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-speech-v2/.repo-metadata.json
+++ b/generated/google-cloud-speech-v2/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Converts audio to text by applying powerful neural network models.",
+    "api_id": "speech.googleapis.com",
+    "api_shortname": "speech",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-speech-v2/documentation",
+    "distribution_name": "google-cloud-speech-v2",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559758",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "speech",
+    "name_pretty": "Cloud Speech-to-Text",
+    "product_documentation": "https://cloud.google.com/speech-to-text/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-sql-v1/.repo-metadata.json
+++ b/generated/google-cloud-sql-v1/.repo-metadata.json
@@ -1,0 +1,13 @@
+{
+    "api_description": "Cloud SQL Admin API",
+    "api_id": "sqladmin.googleapis.com",
+    "api_shortname": "sqladmin",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-sql-v1/documentation",
+    "distribution_name": "google-cloud-sql-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "sqladmin",
+    "name_pretty": "Cloud SQL Admin",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-storageinsights-v1/.repo-metadata.json
+++ b/generated/google-cloud-storageinsights-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Provides insights capability on Google Cloud Storage",
+    "api_id": "storageinsights.googleapis.com",
+    "api_shortname": "storageinsights",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-storageinsights-v1/documentation",
+    "distribution_name": "google-cloud-storageinsights-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1156610",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "storageinsights",
+    "name_pretty": "Storage Insights",
+    "product_documentation": "https://cloud.google.com/storage/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-talent-v4/.repo-metadata.json
+++ b/generated/google-cloud-talent-v4/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Cloud Talent Solution provides the capability to create, read, update, and\ndelete job postings, as well as search jobs based on keywords and filters.",
+    "api_id": "jobs.googleapis.com",
+    "api_shortname": "jobs",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-talent-v4/documentation",
+    "distribution_name": "google-cloud-talent-v4",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559664",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "jobs",
+    "name_pretty": "Cloud Talent Solution",
+    "product_documentation": "https://cloud.google.com/solutions/talent-solution/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-telcoautomation-v1/.repo-metadata.json
+++ b/generated/google-cloud-telcoautomation-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "APIs to automate management of cloud infrastructure for network functions.",
+    "api_id": "telcoautomation.googleapis.com",
+    "api_shortname": "telcoautomation",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-telcoautomation-v1/documentation",
+    "distribution_name": "google-cloud-telcoautomation-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=190865\u0026template=1161103",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "telcoautomation",
+    "name_pretty": "Telco Automation",
+    "product_documentation": "https://cloud.google.com/telecom-network-automation",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-texttospeech-v1/.repo-metadata.json
+++ b/generated/google-cloud-texttospeech-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Synthesizes natural-sounding speech by applying powerful neural network\nmodels.",
+    "api_id": "texttospeech.googleapis.com",
+    "api_shortname": "texttospeech",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-texttospeech-v1/documentation",
+    "distribution_name": "google-cloud-texttospeech-v1",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/5235428",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "texttospeech",
+    "name_pretty": "Cloud Text-to-Speech",
+    "product_documentation": "https://cloud.google.com/text-to-speech",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-tpu-v2/.repo-metadata.json
+++ b/generated/google-cloud-tpu-v2/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "TPU API provides customers with access to Google TPU technology.",
+    "api_id": "tpu.googleapis.com",
+    "api_shortname": "tpu",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-tpu-v2/documentation",
+    "distribution_name": "google-cloud-tpu-v2",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "tpu",
+    "name_pretty": "Cloud TPU",
+    "product_documentation": "https://cloud.google.com/tpu/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-translate-v3/.repo-metadata.json
+++ b/generated/google-cloud-translate-v3/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Integrates text translation into your website or application.",
+    "api_id": "translate.googleapis.com",
+    "api_shortname": "translate",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-translate-v3/documentation",
+    "distribution_name": "google-cloud-translate-v3",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559749",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "translate",
+    "name_pretty": "Cloud Translation",
+    "product_documentation": "https://cloud.google.com/translate/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-vision-v1/.repo-metadata.json
+++ b/generated/google-cloud-vision-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Integrates Google Vision features, including image labeling, face, logo,\nand landmark detection, optical character recognition (OCR), and detection\nof explicit content, into applications.",
+    "api_id": "vision.googleapis.com",
+    "api_shortname": "vision",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-vision-v1/documentation",
+    "distribution_name": "google-cloud-vision-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues?q=status:open%20componentid:187174",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "vision",
+    "name_pretty": "Cloud Vision",
+    "product_documentation": "https://cloud.google.com/vision/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-workflows-executions-v1/.repo-metadata.json
+++ b/generated/google-cloud-workflows-executions-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Execute workflows created with Workflows API.",
+    "api_id": "workflowexecutions.googleapis.com",
+    "api_shortname": "workflowexecutions",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-workflows-executions-v1/documentation",
+    "distribution_name": "google-cloud-workflows-executions-v1",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559729",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "workflowexecutions",
+    "name_pretty": "Workflow Executions",
+    "product_documentation": "https://cloud.google.com/workflows/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-workflows-v1/.repo-metadata.json
+++ b/generated/google-cloud-workflows-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Manage workflow definitions. To execute workflows and manage executions,\nsee the Workflows Executions API.",
+    "api_id": "workflows.googleapis.com",
+    "api_shortname": "workflows",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-workflows-v1/documentation",
+    "distribution_name": "google-cloud-workflows-v1",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559729",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "workflows",
+    "name_pretty": "Workflows",
+    "product_documentation": "https://cloud.google.com/workflows/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-cloud-workloadmanager-v1/.repo-metadata.json
+++ b/generated/google-cloud-workloadmanager-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Workload Manager is a service that provides tooling for enterprise\nworkloads to automate the deployment and validation of your workloads\nagainst best practices and recommendations.",
+    "api_id": "workloadmanager.googleapis.com",
+    "api_shortname": "workloadmanager",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-cloud-workloadmanager-v1/documentation",
+    "distribution_name": "google-cloud-workloadmanager-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1631482\u0026template=0",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "workloadmanager",
+    "name_pretty": "Workload Manager",
+    "product_documentation": "https://docs.cloud.google.com/workload-manager/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-container-v1/.repo-metadata.json
+++ b/generated/google-container-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Builds and manages container-based applications, powered by the open source\nKubernetes technology.",
+    "api_id": "container.googleapis.com",
+    "api_shortname": "container",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-container-v1/documentation",
+    "distribution_name": "google-container-v1",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559746",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "container",
+    "name_pretty": "Kubernetes Engine",
+    "product_documentation": "https://cloud.google.com/kubernetes-engine/",
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-datastore-admin-v1/.repo-metadata.json
+++ b/generated/google-datastore-admin-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Accesses the schemaless NoSQL database to provide fully managed, robust,\nscalable storage for your application.",
+    "api_id": "datastore.googleapis.com",
+    "api_shortname": "datastore",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-datastore-admin-v1/documentation",
+    "distribution_name": "google-datastore-admin-v1",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559768",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "datastore",
+    "name_pretty": "Cloud Datastore",
+    "product_documentation": "https://cloud.google.com/datastore",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-devtools-artifactregistry-v1/.repo-metadata.json
+++ b/generated/google-devtools-artifactregistry-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Store and manage build artifacts in a scalable and integrated service built\non Google infrastructure.",
+    "api_id": "artifactregistry.googleapis.com",
+    "api_shortname": "artifactregistry",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-devtools-artifactregistry-v1/documentation",
+    "distribution_name": "google-devtools-artifactregistry-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "artifactregistry",
+    "name_pretty": "Artifact Registry",
+    "product_documentation": "https://cloud.google.com/artifact-registry",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-devtools-cloudtrace-v2/.repo-metadata.json
+++ b/generated/google-devtools-cloudtrace-v2/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Sends application trace data to Stackdriver Trace for viewing. Trace data\nis collected for all App Engine applications by default. Trace data from\nother applications can be provided using this API. This library is used to\ninteract with the Trace API directly. If you are looking to instrument\nyour application for Stackdriver Trace, we recommend using OpenTelemetry.",
+    "api_id": "cloudtrace.googleapis.com",
+    "api_shortname": "cloudtrace",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-devtools-cloudtrace-v2/documentation",
+    "distribution_name": "google-devtools-cloudtrace-v2",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559776",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "cloudtrace",
+    "name_pretty": "Cloud Trace",
+    "product_documentation": "https://cloud.google.com/trace/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-iam-admin-v1/.repo-metadata.json
+++ b/generated/google-iam-admin-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Manages identity and access control for Google Cloud Platform resources,\nincluding the creation of service accounts, which you can use to\nauthenticate to Google and make API calls.",
+    "api_id": "iam.googleapis.com",
+    "api_shortname": "iam",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-iam-admin-v1/documentation",
+    "distribution_name": "google-iam-admin-v1",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1077618",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "iam",
+    "name_pretty": "Identity and Access Management (IAM)",
+    "product_documentation": "https://cloud.google.com/iam/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-iam-credentials-v1/.repo-metadata.json
+++ b/generated/google-iam-credentials-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Creates short-lived, limited-privilege credentials for IAM service accounts.",
+    "api_id": "iamcredentials.googleapis.com",
+    "api_shortname": "iamcredentials",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-iam-credentials-v1/documentation",
+    "distribution_name": "google-iam-credentials-v1",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559761",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "iamcredentials",
+    "name_pretty": "IAM Service Account Credentials",
+    "product_documentation": "https://cloud.google.com/iam/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-iam-v1/.repo-metadata.json
+++ b/generated/google-iam-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Manages access control for Google Cloud Platform resources.",
+    "api_id": "iam-meta-api.googleapis.com",
+    "api_shortname": "iam-meta-api",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-iam-v1/documentation",
+    "distribution_name": "google-iam-v1",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559761",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "iam-meta-api",
+    "name_pretty": "IAM Meta",
+    "product_documentation": "https://cloud.google.com/iam/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-iam-v2/.repo-metadata.json
+++ b/generated/google-iam-v2/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Manages identity and access control for Google Cloud Platform resources,\nincluding the creation of service accounts, which you can use to\nauthenticate to Google and make API calls.",
+    "api_id": "iam.googleapis.com",
+    "api_shortname": "iam",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-iam-v2/documentation",
+    "distribution_name": "google-iam-v2",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559761",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "iam",
+    "name_pretty": "Identity and Access Management (IAM)",
+    "product_documentation": "https://cloud.google.com/iam/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-iam-v3/.repo-metadata.json
+++ b/generated/google-iam-v3/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Manages identity and access control for Google Cloud resources, including\nthe creation of service accounts, which you can use to authenticate to\nGoogle and make API calls. Enabling this API also enables the IAM Service\nAccount Credentials API (iamcredentials.googleapis.com). However,\ndisabling this API doesn't disable the IAM Service Account Credentials\nAPI.",
+    "api_id": "iam.googleapis.com",
+    "api_shortname": "iam",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-iam-v3/documentation",
+    "distribution_name": "google-iam-v3",
+    "issue_tracker": "https://issuetracker.google.com/issues/new?component=1077618",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "iam",
+    "name_pretty": "Identity and Access Management (IAM)",
+    "product_documentation": "https://cloud.google.com/iam/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-identity-accesscontextmanager-v1/.repo-metadata.json
+++ b/generated/google-identity-accesscontextmanager-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "An API for setting attribute based access control to requests to GCP\nservices.",
+    "api_id": "accesscontextmanager.googleapis.com",
+    "api_shortname": "accesscontextmanager",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-identity-accesscontextmanager-v1/documentation",
+    "distribution_name": "google-identity-accesscontextmanager-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "accesscontextmanager",
+    "name_pretty": "Access Context Manager",
+    "product_documentation": "https://cloud.google.com/access-context-manager/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-logging-v2/.repo-metadata.json
+++ b/generated/google-logging-v2/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Writes log entries and manages your Cloud Logging configuration.",
+    "api_id": "logging.googleapis.com",
+    "api_shortname": "logging",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-logging-v2/documentation",
+    "distribution_name": "google-logging-v2",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559764",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "logging",
+    "name_pretty": "Cloud Logging",
+    "product_documentation": "https://cloud.google.com/logging/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-longrunning/.repo-metadata.json
+++ b/generated/google-longrunning/.repo-metadata.json
@@ -1,0 +1,13 @@
+{
+    "api_description": "Defines types and an abstract service to handle long-running operations.\n\n[Long-running operations] are a common pattern to handle methods that may take\na significant amount of time to execute. Many Google APIs return an `Operation`\nmessage (defined in this package) that are roughly analogous to a future. The\noperation will eventually complete, though it may still return an error on\ncompletion. The client libraries provide helpers to simplify polling of these\noperations.\n\n[Long-running operations]: https://google.aip.dev/151",
+    "api_id": "longrunning.googleapis.com",
+    "api_shortname": "longrunning",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-longrunning/documentation",
+    "distribution_name": "google-longrunning",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "longrunning",
+    "name_pretty": "Long Running Operations",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-monitoring-dashboard-v1/.repo-metadata.json
+++ b/generated/google-monitoring-dashboard-v1/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Manages your Cloud Monitoring data and configurations.",
+    "api_id": "monitoring.googleapis.com",
+    "api_shortname": "monitoring",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-monitoring-dashboard-v1/documentation",
+    "distribution_name": "google-monitoring-dashboard-v1",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559785",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "monitoring",
+    "name_pretty": "Cloud Monitoring",
+    "product_documentation": "https://cloud.google.com/monitoring/dashboards/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-monitoring-v3/.repo-metadata.json
+++ b/generated/google-monitoring-v3/.repo-metadata.json
@@ -1,0 +1,15 @@
+{
+    "api_description": "Manages your Cloud Monitoring data and configurations.",
+    "api_id": "monitoring.googleapis.com",
+    "api_shortname": "monitoring",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-monitoring-v3/documentation",
+    "distribution_name": "google-monitoring-v3",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559785",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "monitoring",
+    "name_pretty": "Cloud Monitoring",
+    "product_documentation": "https://cloud.google.com/monitoring/docs",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-privacy-dlp-v2/.repo-metadata.json
+++ b/generated/google-privacy-dlp-v2/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Discover and protect your sensitive data. A fully managed service designed\nto help you discover, classify, and protect your valuable data assets with\nease.",
+    "api_id": "dlp.googleapis.com",
+    "api_shortname": "dlp",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-privacy-dlp-v2/documentation",
+    "distribution_name": "google-privacy-dlp-v2",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "dlp",
+    "name_pretty": "Sensitive Data Protection (DLP)",
+    "product_documentation": "https://cloud.google.com/dlp/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/google-storagetransfer-v1/.repo-metadata.json
+++ b/generated/google-storagetransfer-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "Transfers data from external data sources to a Google Cloud Storage bucket\nor between Google Cloud Storage buckets.",
+    "api_id": "storagetransfer.googleapis.com",
+    "api_shortname": "storagetransfer",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/google-storagetransfer-v1/documentation",
+    "distribution_name": "google-storagetransfer-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "storagetransfer",
+    "name_pretty": "Storage Transfer",
+    "product_documentation": "https://cloud.google.com/storage-transfer/",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/generated/grafeas-v1/.repo-metadata.json
+++ b/generated/grafeas-v1/.repo-metadata.json
@@ -1,0 +1,14 @@
+{
+    "api_description": "An implementation of the Grafeas API, which stores, and enables querying and\nretrieval of critical metadata about all of your software artifacts.",
+    "api_id": "containeranalysis.googleapis.com",
+    "api_shortname": "containeranalysis",
+    "client_documentation": "https://swiftpackageindex.com/googleapis/grafeas-v1/documentation",
+    "distribution_name": "grafeas-v1",
+    "language": "swift",
+    "library_type": "GAPIC_AUTO",
+    "name": "containeranalysis",
+    "name_pretty": "Container Analysis",
+    "product_documentation": "https://grafeas.io",
+    "release_level": "preview",
+    "repo": "googleapis/google-cloud-swift"
+}

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: swift
-version: v0.31.2-0.20260728174147-6d46535c1c11
+version: v0.31.2-0.20260729222724-b4df72df1c1b
 repo: googleapis/google-cloud-swift
 sources:
   conformance:


### PR DESCRIPTION
This version of librarian generates the `.repo-methodata.json` file, which allows us to track API coverage.

This version also fails to generate a library where the library name (e.g. `GoogleCloudSecretmanagerV1`) differs from the name used in other `PascalCase` SDKs, such as C#, Ruby, or PHP. Setting the library name override, even setting it to the default, disables the error.

The intent is to give us an opportunity to pick a better name when the library is onboarded.