### PR TITLE
test(storage): use anonymous credentials

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -40,8 +40,6 @@ flags=(
 )
 for dir in "${packages[@]}"; do
     [[ -f "${dir}/Package.swift" ]] || continue
-    # TODO(https://github.com/googleapis/google-cloud-swift/issues/3) - restore these builds.
-    [[ "${dir}" != "packages/storage" ]] || continue
     count=$((count + 1))
 
     echo "::group::--- Building ${dir} ---"

--- a/packages/storage/Tests/ChecksumTests.swift
+++ b/packages/storage/Tests/ChecksumTests.swift
@@ -16,6 +16,7 @@ import Foundation
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
+import GoogleCloudAuth
 import GoogleCloudGax
 @testable import GoogleCloudStorage
 import Testing
@@ -115,6 +116,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -163,6 +165,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 

--- a/packages/storage/Tests/ResumableUploadTests.swift
+++ b/packages/storage/Tests/ResumableUploadTests.swift
@@ -17,6 +17,7 @@ import Foundation
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
+import GoogleCloudAuth
 import GoogleCloudGax
 @testable import GoogleCloudStorage
 import Testing
@@ -73,6 +74,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -111,6 +113,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -145,6 +148,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -187,6 +191,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -245,6 +250,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -280,6 +286,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -335,6 +342,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -381,6 +389,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -421,6 +430,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -455,6 +465,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -497,6 +508,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -537,6 +549,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -577,6 +590,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -642,6 +656,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 

--- a/packages/storage/Tests/SimpleUploadTests.swift
+++ b/packages/storage/Tests/SimpleUploadTests.swift
@@ -17,6 +17,7 @@ import Foundation
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
+import GoogleCloudAuth
 import GoogleCloudGax
 @testable import GoogleCloudStorage
 import Testing
@@ -55,6 +56,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -83,6 +85,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -117,6 +120,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -154,6 +158,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -196,6 +201,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -223,6 +229,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 
@@ -279,6 +286,7 @@ import Testing
       $0.client = .init().with {
         $0.endpoint = registry.endpoint
         $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
     }
 


### PR DESCRIPTION
By default, the storage client (like all clients) use MDS credentials. These are not available in the test environment, so the tests failed after being unable to initialize the request.

With this change, the tests use anonymous credentials, which always work.

Fixes #3 