### PR TITLE
ci: bootstrap GCB configuration

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A .ignore file for Google Cloud Build
+
+# Ignore anything ignored by `git`:
+#!include:.gitignore

--- a/ci/gcb/README.md
+++ b/ci/gcb/README.md
@@ -1,0 +1,30 @@
+# Google Cloud Build support
+
+This directory contains configuration files and scripts to support GCB (Google
+Cloud Build) builds.
+
+While GHA (GitHub Actions) are an excellent CI system, they can become expensive
+for large projects such as this one. As Googlers, we have a lot more budget for
+running builds on GCB. We can also run integration tests against production
+using GCB.
+
+GCB can perform these integration tests with relatively simple management for
+authentication and authorization: the builds run using a service account
+specific to our project. We can grant this service account the necessary
+permissions to act on the test resources.
+
+In contrast, if we wanted to use GHA for the same role, we would need to either
+(1) download a service account key file and install it as a GHA secret, and
+manually rotate this secret, or (2) configure workload identify federation
+between GitHub and our project. Neither approach is very easy to reason about
+from a security perspective.
+
+## Managing Resources for Integration Test
+
+Integration tests need resources in production. We will need pre-existing
+databases, storage buckets, service accounts, and the configuration for the
+builds themselves.
+
+We have chosen Terraform to manage these resources. That makes it easy to audit
+them, recreate the resources when needed, and we can always change to a
+different IaaC platform if needed.

--- a/ci/gcb/bootstrap/.terraform.lock.hcl
+++ b/ci/gcb/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.42.0"
+  constraints = "~> 7.42.0"
+  hashes = [
+    "h1:JqhNUoY3Jw6g4lfznOd4B8qXh2lNetk5/W+dWVZJUwI=",
+    "zh:30b25728203b9208a167fac3f9880c10242fc5accdd29ba01b21355566fc4e3d",
+    "zh:4468f6ea772e991d890724e44f628a24dae44c9028af654469454d05b00b10ec",
+    "zh:4dfa4f7bcd72ea89f6f3f7411d88bf9a1f060699830e1f1f85bf32102be754b3",
+    "zh:59cf73879f10ad9d29ff8ad96559a476e70695bed26b84b6189728129674618c",
+    "zh:73a7966ae1c6db8a3dc31eb43f05dddd27a47f3ff42e25f62594fc0d5b438412",
+    "zh:7c2ea415fb06147cf9834b2169d75a52bd979ad291bed32c94d9a9307316f7ba",
+    "zh:962efdd3dee2b98860528555b0616ca0c8987dfc6c5e5df6d1c025c9b22c2f26",
+    "zh:c4a5ca9f20cbfbdcb88064d53d16f2ce8038e1ddc3303c7261152856728700b5",
+    "zh:ca56a9477177530737d07feea70bb99309414a7c18aa62f975644138606e1faf",
+    "zh:d0c6db8b1da363f69087569716ed96a3a6dadb4b872f598d442d867bd0706fa9",
+    "zh:ddd2472052e0c5c3fab7cffae8376e8855c35ad8614ba8631f7e448e72a41f21",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/ci/gcb/bootstrap/README.md
+++ b/ci/gcb/bootstrap/README.md
@@ -1,0 +1,65 @@
+# Terraform configuration Bootstrap
+
+We use terraform (https://terraform.io) to create and update the state of our
+testing infrastructure. We describe the desired state of the infrastructure to
+terraform using `.tf` scripts. By default, Terraform stores [state][tf-state]
+locally, in a file called `terraform.tfstate`. This default configuration can
+make Terraform usage difficult for teams. If multiple team members run Terraform
+at the same time on different machine each state may have a different definition
+of the desired and current state.
+
+The recommended practice is to store terraform database in some remote storage,
+shared by the whole team. Google Cloud Storage is one of the available options,
+and one that works well for us.
+
+This directory creates the initial Cloud Storage bucket to store the terraform's
+for each sub-project. The scripts in this directory should be executed rarely,
+ideally only once.
+
+## Usage
+
+Change your working directory, for example:
+
+```shell
+cd $HOME/google-cloud-swift/ci/gcb/bootstrap
+```
+
+Initialize terraform:
+
+```shell
+terraform init
+```
+
+Restore the current state. This may result in no action if you happen to have an
+up-to-date state in your local files.
+
+```shell
+terraform plan -out /tmp/bootstrap.tplan
+```
+
+Execute the plan:
+
+```shell
+terraform apply /tmp/bootstrap.tplan
+```
+
+Make any changes to the configuration and commit them to git:
+
+```shell
+git commit -m"Cool changes" .
+```
+
+Prepare and execute a plan to update the bucket:
+
+```shell
+terraform plan -out /tmp/update.tplan
+terraform apply /tmp/update.tplan
+```
+
+## More Information
+
+This directory follows the [Store Terraform state in a Cloud Storage bucket]
+guide.
+
+[store terraform state in a cloud storage bucket]: https://cloud.google.com/docs/terraform/resource-management/store-state
+[tf-state]: https://www.terraform.io/docs/state/

--- a/ci/gcb/bootstrap/main.tf
+++ b/ci/gcb/bootstrap/main.tf
@@ -1,0 +1,70 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.42.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}
+
+# Re-import the state of the bucket from Google Cloud. Normally one would store
+# terraform's state in a global backend, such as Google Cloud Storage. But this
+# is the terraform configuration to bootstrap such a backend. While re-importing
+# the state of each resource would not scale as the number of resources grows,
+# re-importing a single bootstrap resource seems manageable.
+#import {
+#  to = google_storage_bucket.terraform
+#  id = "${var.project}-terraform"
+#}
+
+# Create a bucket to store the Terraform data.
+resource "google_storage_bucket" "terraform" {
+  name          = "${var.project}-terraform"
+  force_destroy = false
+  # This prevents Terraform from deleting the bucket. Any plan to do so is
+  # rejected. If we really need to delete the bucket we must take additional
+  # steps.
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  # The bucket configuration.
+  location                    = "US"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+  # Keep multiple versions of each object so we can recover if needed.
+  versioning {
+    enabled = true
+  }
+  # Tidy up archived objects after a year. They are small, so there is no need
+  # to rush.
+  lifecycle_rule {
+    condition {
+      days_since_noncurrent_time = 365
+      with_state                 = "ARCHIVED"
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}

--- a/ci/gcb/bootstrap/variables.tf
+++ b/ci/gcb/bootstrap/variables.tf
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {
+  default = "swift-sdk-testing"
+}
+
+variable "region" {
+  default = "us-central1"
+}
+
+variable "zone" {
+  default = "us-central1-f"
+}


### PR DESCRIPTION
We will need to use GCB (Google Cloud Build) for larger CI builds and for any integration tests against production. This PR bootstraps the necessary resource management using Terraform.

The README files explain why I prefer using Terraform to manage the CI resources.

Keeping the Terraform configuration in the repo allows us to evolve the configuration at the same time as the project.

Towards #12 and several other CI tasks
