### PR TITLE
chore: bump all versions circa 2026-07-30

### DIFF
--- a/generated/google-api-apikeys-v2/Sources/GoogleApiApiKeysV1/Clients.swift
+++ b/generated/google-api-apikeys-v2/Sources/GoogleApiApiKeysV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-api-cloudquotas-v1/Sources/GoogleApiCloudQuotasV1/Clients.swift
+++ b/generated/google-api-cloudquotas-v1/Sources/GoogleApiCloudQuotasV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-api-servicecontrol-v1/Sources/GoogleApiServiceControlV1/Clients.swift
+++ b/generated/google-api-servicecontrol-v1/Sources/GoogleApiServiceControlV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-api-servicecontrol-v2/Sources/GoogleApiServiceControlV2/Clients.swift
+++ b/generated/google-api-servicecontrol-v2/Sources/GoogleApiServiceControlV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-api-servicemanagement-v1/Sources/GoogleApiServiceManagementV1/Clients.swift
+++ b/generated/google-api-servicemanagement-v1/Sources/GoogleApiServiceManagementV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-api-serviceusage-v1/Sources/GoogleApiServiceUsageV1/Clients.swift
+++ b/generated/google-api-serviceusage-v1/Sources/GoogleApiServiceUsageV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-appengine-v1/Sources/GoogleAppEngineV1/Clients.swift
+++ b/generated/google-appengine-v1/Sources/GoogleAppEngineV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-bigtable-admin-v2/Sources/GoogleCloudBigtableAdminV2/Clients.swift
+++ b/generated/google-bigtable-admin-v2/Sources/GoogleCloudBigtableAdminV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-accessapproval-v1/Sources/GoogleCloudAccessApprovalV1/Clients.swift
+++ b/generated/google-cloud-accessapproval-v1/Sources/GoogleCloudAccessApprovalV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-advisorynotifications-v1/Sources/GoogleCloudAdvisoryNotificationsV1/Clients.swift
+++ b/generated/google-cloud-advisorynotifications-v1/Sources/GoogleCloudAdvisoryNotificationsV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAIPlatformV1/Clients.swift
+++ b/generated/google-cloud-aiplatform-v1/Sources/GoogleCloudAIPlatformV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-alloydb-v1/Sources/GoogleCloudAlloyDBV1/Clients.swift
+++ b/generated/google-cloud-alloydb-v1/Sources/GoogleCloudAlloyDBV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-apigateway-v1/Sources/GoogleCloudApiGatewayV1/Clients.swift
+++ b/generated/google-cloud-apigateway-v1/Sources/GoogleCloudApiGatewayV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-apihub-v1/Sources/GoogleCloudApiHubV1/Clients.swift
+++ b/generated/google-cloud-apihub-v1/Sources/GoogleCloudApiHubV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-apiregistry-v1/Sources/GoogleCloudApiRegistryV1/Clients.swift
+++ b/generated/google-cloud-apiregistry-v1/Sources/GoogleCloudApiRegistryV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-apphub-v1/Sources/GoogleCloudAppHubV1/Clients.swift
+++ b/generated/google-cloud-apphub-v1/Sources/GoogleCloudAppHubV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-asset-v1/Sources/GoogleCloudAssetV1/Clients.swift
+++ b/generated/google-cloud-asset-v1/Sources/GoogleCloudAssetV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-assuredworkloads-v1/Sources/GoogleCloudAssuredWorkloadsV1/Clients.swift
+++ b/generated/google-cloud-assuredworkloads-v1/Sources/GoogleCloudAssuredWorkloadsV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-auditmanager-v1/Sources/GoogleCloudAuditManagerV1/Clients.swift
+++ b/generated/google-cloud-auditmanager-v1/Sources/GoogleCloudAuditManagerV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-baremetalsolution-v2/Sources/GoogleCloudBareMetalSolutionV2/Clients.swift
+++ b/generated/google-cloud-baremetalsolution-v2/Sources/GoogleCloudBareMetalSolutionV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-batch-v1/Sources/GoogleCloudBatchV1/Clients.swift
+++ b/generated/google-cloud-batch-v1/Sources/GoogleCloudBatchV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-beyondcorp-appconnections-v1/Sources/GoogleCloudBeyondCorpAppConnectionsV1/Clients.swift
+++ b/generated/google-cloud-beyondcorp-appconnections-v1/Sources/GoogleCloudBeyondCorpAppConnectionsV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-beyondcorp-appconnectors-v1/Sources/GoogleCloudBeyondCorpAppConnectorsV1/Clients.swift
+++ b/generated/google-cloud-beyondcorp-appconnectors-v1/Sources/GoogleCloudBeyondCorpAppConnectorsV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-beyondcorp-appgateways-v1/Sources/GoogleCloudBeyondCorpAppGatewaysV1/Clients.swift
+++ b/generated/google-cloud-beyondcorp-appgateways-v1/Sources/GoogleCloudBeyondCorpAppGatewaysV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-beyondcorp-clientconnectorservices-v1/Sources/GoogleCloudBeyondCorpClientConnectorServicesV1/Clients.swift
+++ b/generated/google-cloud-beyondcorp-clientconnectorservices-v1/Sources/GoogleCloudBeyondCorpClientConnectorServicesV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-beyondcorp-clientgateways-v1/Sources/GoogleCloudBeyondCorpClientGatewaysV1/Clients.swift
+++ b/generated/google-cloud-beyondcorp-clientgateways-v1/Sources/GoogleCloudBeyondCorpClientGatewaysV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-biglake-v1/Sources/GoogleCloudBiglakeV1/Clients.swift
+++ b/generated/google-cloud-biglake-v1/Sources/GoogleCloudBiglakeV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-bigquery-analyticshub-v1/Sources/GoogleBigQueryAnalyticsHubV1/Clients.swift
+++ b/generated/google-cloud-bigquery-analyticshub-v1/Sources/GoogleBigQueryAnalyticsHubV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-bigquery-connection-v1/Sources/GoogleBigQueryConnectionV1/Clients.swift
+++ b/generated/google-cloud-bigquery-connection-v1/Sources/GoogleBigQueryConnectionV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-bigquery-datapolicies-v1/Sources/GoogleBigQueryDataPoliciesV1/Clients.swift
+++ b/generated/google-cloud-bigquery-datapolicies-v1/Sources/GoogleBigQueryDataPoliciesV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-bigquery-datapolicies-v2/Sources/GoogleBigQueryDataPoliciesV2/Clients.swift
+++ b/generated/google-cloud-bigquery-datapolicies-v2/Sources/GoogleBigQueryDataPoliciesV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-bigquery-datatransfer-v1/Sources/GoogleBigQueryDataTransferV1/Clients.swift
+++ b/generated/google-cloud-bigquery-datatransfer-v1/Sources/GoogleBigQueryDataTransferV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-billing-budgets-v1/Sources/GoogleCloudBillingBudgetsV1/Clients.swift
+++ b/generated/google-cloud-billing-budgets-v1/Sources/GoogleCloudBillingBudgetsV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-billing-v1/Sources/GoogleCloudBillingV1/Clients.swift
+++ b/generated/google-cloud-billing-v1/Sources/GoogleCloudBillingV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-binaryauthorization-v1/Sources/GoogleCloudBinaryAuthorizationV1/Clients.swift
+++ b/generated/google-cloud-binaryauthorization-v1/Sources/GoogleCloudBinaryAuthorizationV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-blockchainnodeengine-v1/Sources/GoogleCloudBlockChainNodeEngineV1/Clients.swift
+++ b/generated/google-cloud-blockchainnodeengine-v1/Sources/GoogleCloudBlockChainNodeEngineV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-certificatemanager-v1/Sources/GoogleCloudCertificateManagerV1/Clients.swift
+++ b/generated/google-cloud-certificatemanager-v1/Sources/GoogleCloudCertificateManagerV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-ces-v1/Sources/GoogleCloudCESV1/Clients.swift
+++ b/generated/google-cloud-ces-v1/Sources/GoogleCloudCESV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/Clients.swift
+++ b/generated/google-cloud-compute-v1/Sources/GoogleCloudComputeV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-confidentialcomputing-v1/Sources/GoogleCloudConfidentialComputingV1/Clients.swift
+++ b/generated/google-cloud-confidentialcomputing-v1/Sources/GoogleCloudConfidentialComputingV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-config-v1/Sources/GoogleCloudConfigV1/Clients.swift
+++ b/generated/google-cloud-config-v1/Sources/GoogleCloudConfigV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-configdelivery-v1/Sources/GoogleCloudConfigDeliveryV1/Clients.swift
+++ b/generated/google-cloud-configdelivery-v1/Sources/GoogleCloudConfigDeliveryV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-connectors-v1/Sources/GoogleCloudConnectorsV1/Clients.swift
+++ b/generated/google-cloud-connectors-v1/Sources/GoogleCloudConnectorsV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-datacatalog-v1/Sources/GoogleCloudDataCatalogV1/Clients.swift
+++ b/generated/google-cloud-datacatalog-v1/Sources/GoogleCloudDataCatalogV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-dataform-v1/Sources/GoogleCloudDataFormV1/Clients.swift
+++ b/generated/google-cloud-dataform-v1/Sources/GoogleCloudDataFormV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-datafusion-v1/Sources/GoogleCloudDataFusionV1/Clients.swift
+++ b/generated/google-cloud-datafusion-v1/Sources/GoogleCloudDataFusionV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/Clients.swift
+++ b/generated/google-cloud-dataplex-v1/Sources/GoogleCloudDataplexV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-deploy-v1/Sources/GoogleCloudDeployV1/Clients.swift
+++ b/generated/google-cloud-deploy-v1/Sources/GoogleCloudDeployV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCXV3/Clients.swift
+++ b/generated/google-cloud-dialogflow-cx-v3/Sources/GoogleCloudDialogflowCXV3/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Clients.swift
+++ b/generated/google-cloud-dialogflow-v2/Sources/GoogleCloudDialogflowV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryEngineV1/Clients.swift
+++ b/generated/google-cloud-discoveryengine-v1/Sources/GoogleCloudDiscoveryEngineV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-domains-v1/Sources/GoogleCloudDomainsV1/Clients.swift
+++ b/generated/google-cloud-domains-v1/Sources/GoogleCloudDomainsV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-edgecontainer-v1/Sources/GoogleCloudEdgeContainerV1/Clients.swift
+++ b/generated/google-cloud-edgecontainer-v1/Sources/GoogleCloudEdgeContainerV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-edgenetwork-v1/Sources/GoogleCloudEdgeNetworkV1/Clients.swift
+++ b/generated/google-cloud-edgenetwork-v1/Sources/GoogleCloudEdgeNetworkV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-eventarc-v1/Sources/GoogleCloudEventarcV1/Clients.swift
+++ b/generated/google-cloud-eventarc-v1/Sources/GoogleCloudEventarcV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-filestore-v1/Sources/GoogleCloudFilestoreV1/Clients.swift
+++ b/generated/google-cloud-filestore-v1/Sources/GoogleCloudFilestoreV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-functions-v2/Sources/GoogleCloudFunctionsV2/Clients.swift
+++ b/generated/google-cloud-functions-v2/Sources/GoogleCloudFunctionsV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-gkehub-v1/Sources/GoogleCloudGKEHubV1/Clients.swift
+++ b/generated/google-cloud-gkehub-v1/Sources/GoogleCloudGKEHubV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-gkemulticloud-v1/Sources/GoogleCloudGKEMultiCloudV1/Clients.swift
+++ b/generated/google-cloud-gkemulticloud-v1/Sources/GoogleCloudGKEMultiCloudV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-kms-inventory-v1/Sources/GoogleCloudKMSInventoryV1/Clients.swift
+++ b/generated/google-cloud-kms-inventory-v1/Sources/GoogleCloudKMSInventoryV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-kms-v1/Sources/GoogleCloudKMSV1/Clients.swift
+++ b/generated/google-cloud-kms-v1/Sources/GoogleCloudKMSV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-language-v2/Sources/GoogleCloudLanguageV2/Clients.swift
+++ b/generated/google-cloud-language-v2/Sources/GoogleCloudLanguageV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-licensemanager-v1/Sources/GoogleCloudLicenseManagerV1/Clients.swift
+++ b/generated/google-cloud-licensemanager-v1/Sources/GoogleCloudLicenseManagerV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-location/Sources/GoogleCloudLocation/Clients.swift
+++ b/generated/google-cloud-location/Sources/GoogleCloudLocation/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-locationfinder-v1/Sources/GoogleCloudLocationFinderV1/Clients.swift
+++ b/generated/google-cloud-locationfinder-v1/Sources/GoogleCloudLocationFinderV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-memorystore-v1/Sources/GoogleCloudMemoryStoreV1/Clients.swift
+++ b/generated/google-cloud-memorystore-v1/Sources/GoogleCloudMemoryStoreV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-networkconnectivity-v1/Sources/GoogleCloudNetworkConnectivityV1/Clients.swift
+++ b/generated/google-cloud-networkconnectivity-v1/Sources/GoogleCloudNetworkConnectivityV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-notebooks-v2/Sources/GoogleCloudNotebooksV2/Clients.swift
+++ b/generated/google-cloud-notebooks-v2/Sources/GoogleCloudNotebooksV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-osconfig-v1/Sources/GoogleCloudOSConfigV1/Clients.swift
+++ b/generated/google-cloud-osconfig-v1/Sources/GoogleCloudOSConfigV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-parallelstore-v1/Sources/GoogleCloudParallelStoreV1/Clients.swift
+++ b/generated/google-cloud-parallelstore-v1/Sources/GoogleCloudParallelStoreV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourceManagerV3/Clients.swift
+++ b/generated/google-cloud-resourcemanager-v3/Sources/GoogleCloudResourceManagerV3/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/Clients.swift
+++ b/generated/google-cloud-retail-v2/Sources/GoogleCloudRetailV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Clients.swift
+++ b/generated/google-cloud-run-v2/Sources/GoogleCloudRunV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-scheduler-v1/Sources/GoogleCloudSchedulerV1/Clients.swift
+++ b/generated/google-cloud-scheduler-v1/Sources/GoogleCloudSchedulerV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-secretmanager-v1/Sources/GoogleCloudSecretManagerV1/Clients.swift
+++ b/generated/google-cloud-secretmanager-v1/Sources/GoogleCloudSecretManagerV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-security-privateca-v1/Sources/GoogleCloudSecurityPrivateCAV1/Clients.swift
+++ b/generated/google-cloud-security-privateca-v1/Sources/GoogleCloudSecurityPrivateCAV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-security-publicca-v1/Sources/GoogleCloudSecurityPublicCAV1/Clients.swift
+++ b/generated/google-cloud-security-publicca-v1/Sources/GoogleCloudSecurityPublicCAV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-speech-v2/Sources/GoogleCloudSpeechV2/Clients.swift
+++ b/generated/google-cloud-speech-v2/Sources/GoogleCloudSpeechV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/Clients.swift
+++ b/generated/google-cloud-sql-v1/Sources/GoogleCloudSqlV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-storageinsights-v1/Sources/GoogleCloudStorageInsightsV1/Clients.swift
+++ b/generated/google-cloud-storageinsights-v1/Sources/GoogleCloudStorageInsightsV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-talent-v4/Sources/GoogleCloudTalentV4/Clients.swift
+++ b/generated/google-cloud-talent-v4/Sources/GoogleCloudTalentV4/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-telcoautomation-v1/Sources/GoogleCloudTelcoAutomationV1/Clients.swift
+++ b/generated/google-cloud-telcoautomation-v1/Sources/GoogleCloudTelcoAutomationV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-texttospeech-v1/Sources/GoogleCloudTextToSpeechV1/Clients.swift
+++ b/generated/google-cloud-texttospeech-v1/Sources/GoogleCloudTextToSpeechV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-tpu-v2/Sources/GoogleCloudTpuV2/Clients.swift
+++ b/generated/google-cloud-tpu-v2/Sources/GoogleCloudTpuV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-translate-v3/Sources/GoogleCloudTranslateV3/Clients.swift
+++ b/generated/google-cloud-translate-v3/Sources/GoogleCloudTranslateV3/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-vision-v1/Sources/GoogleCloudVisionV1/Clients.swift
+++ b/generated/google-cloud-vision-v1/Sources/GoogleCloudVisionV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-workflows-executions-v1/Sources/GoogleCloudWorkflowsExecutionsV1/Clients.swift
+++ b/generated/google-cloud-workflows-executions-v1/Sources/GoogleCloudWorkflowsExecutionsV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-workflows-v1/Sources/GoogleCloudWorkflowsV1/Clients.swift
+++ b/generated/google-cloud-workflows-v1/Sources/GoogleCloudWorkflowsV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-cloud-workloadmanager-v1/Sources/GoogleCloudWorkloadManagerV1/Clients.swift
+++ b/generated/google-cloud-workloadmanager-v1/Sources/GoogleCloudWorkloadManagerV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-container-v1/.repo-metadata.json
+++ b/generated/google-container-v1/.repo-metadata.json
@@ -10,6 +10,6 @@
     "name": "container",
     "name_pretty": "Kubernetes Engine",
     "product_documentation": "https://cloud.google.com/kubernetes-engine/",
-    "release_level": "stable",
+    "release_level": "preview",
     "repo": "googleapis/google-cloud-swift"
 }

--- a/generated/google-container-v1/Sources/GoogleCloudContainerV1/Clients.swift
+++ b/generated/google-container-v1/Sources/GoogleCloudContainerV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0")
 }

--- a/generated/google-datastore-admin-v1/Sources/GoogleCloudDatastoreAdminV1/Clients.swift
+++ b/generated/google-datastore-admin-v1/Sources/GoogleCloudDatastoreAdminV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-devtools-artifactregistry-v1/Sources/GoogleCloudArtifactRegistryV1/Clients.swift
+++ b/generated/google-devtools-artifactregistry-v1/Sources/GoogleCloudArtifactRegistryV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-devtools-cloudtrace-v2/Sources/GoogleCloudTraceV2/Clients.swift
+++ b/generated/google-devtools-cloudtrace-v2/Sources/GoogleCloudTraceV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-iam-admin-v1/Sources/GoogleIAMAdminV1/Clients.swift
+++ b/generated/google-iam-admin-v1/Sources/GoogleIAMAdminV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-iam-credentials-v1/Sources/GoogleIAMCredentialsV1/Clients.swift
+++ b/generated/google-iam-credentials-v1/Sources/GoogleIAMCredentialsV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-iam-v1/Sources/GoogleIAMV1/Clients.swift
+++ b/generated/google-iam-v1/Sources/GoogleIAMV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-iam-v2/Sources/GoogleIAMV2/Clients.swift
+++ b/generated/google-iam-v2/Sources/GoogleIAMV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-iam-v3/Sources/GoogleIAMV3/Clients.swift
+++ b/generated/google-iam-v3/Sources/GoogleIAMV3/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-identity-accesscontextmanager-v1/Sources/GoogleIdentityAccessContextManagerV1/Clients.swift
+++ b/generated/google-identity-accesscontextmanager-v1/Sources/GoogleIdentityAccessContextManagerV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-logging-v2/Sources/GoogleCloudLoggingV2/Clients.swift
+++ b/generated/google-logging-v2/Sources/GoogleCloudLoggingV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-longrunning/Sources/GoogleLongRunning/Clients.swift
+++ b/generated/google-longrunning/Sources/GoogleLongRunning/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-monitoring-dashboard-v1/Sources/GoogleCloudMonitoringDashboardV1/Clients.swift
+++ b/generated/google-monitoring-dashboard-v1/Sources/GoogleCloudMonitoringDashboardV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-monitoring-v3/Sources/GoogleCloudMonitoringV3/Clients.swift
+++ b/generated/google-monitoring-v3/Sources/GoogleCloudMonitoringV3/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-privacy-dlp-v2/Sources/GoogleCloudDLPV2/Clients.swift
+++ b/generated/google-privacy-dlp-v2/Sources/GoogleCloudDLPV2/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/google-storagetransfer-v1/Sources/GoogleStorageTransferV1/Clients.swift
+++ b/generated/google-storagetransfer-v1/Sources/GoogleStorageTransferV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/generated/grafeas-v1/Sources/GoogleGrafeasV1/Clients.swift
+++ b/generated/grafeas-v1/Sources/GoogleGrafeasV1/Clients.swift
@@ -23,5 +23,5 @@ import GoogleCloudGax
 // Defines concrete implementations of the client protocols.
 public enum Clients {
   static let clientHeader: Swift.String =
-    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.0.0-preview")
+    GoogleCloudGax._gapicApiClientHeader(packageVersion: "0.1.0-preview")
 }

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -102,65 +102,65 @@ default:
     default_version: 0.0.0-preview
 libraries:
   - name: google-api
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-api-apikeys-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleApiApiKeysV1
   - name: google-api-cloudquotas-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleApiCloudQuotasV1
   - name: google-api-servicecontrol-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleApiServiceControlV1
   - name: google-api-servicecontrol-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleApiServiceControlV2
   - name: google-api-servicemanagement-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleApiServiceManagementV1
   - name: google-api-serviceusage-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleApiServiceUsageV1
   - name: google-appengine-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleAppEngineV1
   - name: google-bigtable-admin-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudBigtableAdminV2
   - name: google-cloud-abuseevent-logging-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudAbuseEventLoggingV1
   - name: google-cloud-accessapproval-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudAccessApprovalV1
   - name: google-cloud-advisorynotifications-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudAdvisoryNotificationsV1
   - name: google-cloud-aiplatform-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudAIPlatformV1
@@ -168,45 +168,45 @@ libraries:
       default_traits:
         - PredictionService
   - name: google-cloud-alloydb-connectors-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudAlloyDBConnectorsV1
   - name: google-cloud-alloydb-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudAlloyDBV1
   - name: google-cloud-apigateway-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudApiGatewayV1
   - name: google-cloud-apihub-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudApiHubV1
   - name: google-cloud-apiregistry-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudApiRegistryV1
   - name: google-cloud-apphub-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudAppHubV1
   - name: google-cloud-asset-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-assuredworkloads-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudAssuredWorkloadsV1
   - name: google-cloud-auditmanager-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudAuditManagerV1
@@ -220,89 +220,89 @@ libraries:
           api_path: ""
           module_type: package-version
   - name: google-cloud-baremetalsolution-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudBareMetalSolutionV2
   - name: google-cloud-batch-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-beyondcorp-appconnections-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudBeyondCorpAppConnectionsV1
   - name: google-cloud-beyondcorp-appconnectors-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudBeyondCorpAppConnectorsV1
   - name: google-cloud-beyondcorp-appgateways-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudBeyondCorpAppGatewaysV1
   - name: google-cloud-beyondcorp-clientconnectorservices-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudBeyondCorpClientConnectorServicesV1
   - name: google-cloud-beyondcorp-clientgateways-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudBeyondCorpClientGatewaysV1
   - name: google-cloud-biglake-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-bigquery-analyticshub-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleBigQueryAnalyticsHubV1
   - name: google-cloud-bigquery-connection-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleBigQueryConnectionV1
   - name: google-cloud-bigquery-datapolicies-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleBigQueryDataPoliciesV1
   - name: google-cloud-bigquery-datapolicies-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleBigQueryDataPoliciesV2
   - name: google-cloud-bigquery-datatransfer-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleBigQueryDataTransferV1
   - name: google-cloud-billing-budgets-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-billing-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-binaryauthorization-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudBinaryAuthorizationV1
   - name: google-cloud-blockchainnodeengine-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudBlockChainNodeEngineV1
   - name: google-cloud-certificatemanager-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudCertificateManagerV1
   - name: google-cloud-ces-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudCESV1
@@ -310,7 +310,7 @@ libraries:
     version: 0.0.0-preview
     copyright_year: "2026"
   - name: google-cloud-compute-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     apis:
       - path: discoveries/compute.v1.json
     copyright_year: "2026"
@@ -337,48 +337,48 @@ libraries:
           - prefix: compute/v1/
             method_id: .google.cloud.compute.v1.globalOrganizationOperations.get
   - name: google-cloud-confidentialcomputing-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudConfidentialComputingV1
   - name: google-cloud-config-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudConfigV1
   - name: google-cloud-configdelivery-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudConfigDeliveryV1
   - name: google-cloud-connectors-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-datacatalog-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudDataCatalogV1
   - name: google-cloud-dataform-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudDataFormV1
   - name: google-cloud-datafusion-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudDataFusionV1
   - name: google-cloud-dataplex-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudDataplexV1
   - name: google-cloud-deploy-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-dialogflow-cx-v3
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudDialogflowCXV3
@@ -386,14 +386,14 @@ libraries:
       default_traits:
         - Agents
   - name: google-cloud-dialogflow-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       per_service_traits: true
       default_traits:
         - Agents
   - name: google-cloud-discoveryengine-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudDiscoveryEngineV1
@@ -402,26 +402,26 @@ libraries:
         - SearchService
         - RecommendationService
   - name: google-cloud-domains-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-edgecontainer-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudEdgeContainerV1
   - name: google-cloud-edgenetwork-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudEdgeNetworkV1
   - name: google-cloud-eventarc-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-filestore-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-functions-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-gax
     version: 0.0.0-preview
@@ -433,126 +433,126 @@ libraries:
           api_path: ""
           module_type: package-version
   - name: google-cloud-gkebackup-logging-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudGKEBackupLoggingV1
   - name: google-cloud-gkehub-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudGKEHubV1
   - name: google-cloud-gkehub-v1-configmanagement
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     output: generated/google-cloud-gkehub-configmanagement-v1
     swift:
       library_name_override: GoogleCloudGKEHubConfigManagementV1
   - name: google-cloud-gkehub-v1-multiclusteringress
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     output: generated/google-cloud-gkehub-multiclusteringress-v1
     swift:
       library_name_override: GoogleCloudGKEHubMultiClusterIngressV1
   - name: google-cloud-gkehub-v1-rbacrolebindingactuation
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     output: generated/google-cloud-gkehub-rbacrolebindingactuation-v1
     swift:
       library_name_override: GoogleCloudGKEHubRBACRoleBindingActuationV1
   - name: google-cloud-gkemulticloud-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudGKEMultiCloudV1
   - name: google-cloud-kms-inventory-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudKMSInventoryV1
   - name: google-cloud-kms-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudKMSV1
   - name: google-cloud-language-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-licensemanager-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudLicenseManagerV1
   - name: google-cloud-location
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-locationfinder-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudLocationFinderV1
   - name: google-cloud-memorystore-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudMemoryStoreV1
   - name: google-cloud-networkconnectivity-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudNetworkConnectivityV1
   - name: google-cloud-notebooks-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-orgpolicy-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudOrgPolicyV1
   - name: google-cloud-osconfig-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudOSConfigV1
   - name: google-cloud-parallelstore-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudParallelStoreV1
   - name: google-cloud-resourcemanager-v3
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudResourceManagerV3
   - name: google-cloud-retail-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-run-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-scheduler-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-secretmanager-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudSecretManagerV1
   - name: google-cloud-security-privateca-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudSecurityPrivateCAV1
   - name: google-cloud-security-publicca-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudSecurityPublicCAV1
   - name: google-cloud-speech-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-sql-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       per_service_traits: true
@@ -579,36 +579,36 @@ libraries:
           module_type: convert-swift
           module_path: StorageControlProtos
   - name: google-cloud-storageinsights-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudStorageInsightsV1
   - name: google-cloud-talent-v4
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-telcoautomation-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudTelcoAutomationV1
   - name: google-cloud-texttospeech-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudTextToSpeechV1
   - name: google-cloud-tpu-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-translate-v3
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudTranslateV3
   - name: google-cloud-vision-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-wkt
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     output: packages/wkt/Sources/GoogleCloudWkt/generated
     roots:
@@ -626,116 +626,117 @@ libraries:
           api_path: google/protobuf
           module_type: package-version
   - name: google-cloud-workflows-executions-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-workflows-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-cloud-workloadmanager-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudWorkloadManagerV1
   - name: google-container-v1
+    version: 0.1.0
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudContainerV1
   - name: google-datastore-admin-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudDatastoreAdminV1
   - name: google-devtools-artifactregistry-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudArtifactRegistryV1
   - name: google-devtools-cloudtrace-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudTraceV2
   - name: google-iam-admin-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleIAMAdminV1
   - name: google-iam-credentials-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleIAMCredentialsV1
   - name: google-iam-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleIAMV1
   - name: google-iam-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleIAMV2
   - name: google-iam-v3
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleIAMV3
   - name: google-identity-accesscontextmanager-type
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleIdentityAccessContextManagerType
   - name: google-identity-accesscontextmanager-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleIdentityAccessContextManagerV1
   - name: google-logging-type
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudLoggingType
   - name: google-logging-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudLoggingV2
   - name: google-longrunning
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleLongRunning
   - name: google-monitoring-dashboard-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudMonitoringDashboardV1
   - name: google-monitoring-v3
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudMonitoringV3
   - name: google-privacy-dlp-v2
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleCloudDLPV2
   - name: google-rpc
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: google-rpc-context
     version: 0.0.0-preview
     copyright_year: "2026"
   - name: google-storagetransfer-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleStorageTransferV1
   - name: google-type
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
   - name: grafeas-v1
-    version: 0.0.0-preview
+    version: 0.1.0-preview
     copyright_year: "2026"
     swift:
       library_name_override: GoogleGrafeasV1

--- a/packages/wkt/Sources/GoogleCloudWkt/generated/version/PackageVersion.swift
+++ b/packages/wkt/Sources/GoogleCloudWkt/generated/version/PackageVersion.swift
@@ -15,5 +15,5 @@
 // limitations under the License.
 
 enum PackageVersion {
-  static let version: Swift.String = "0.0.0-preview"
+  static let version: Swift.String = "0.1.0-preview"
 }


### PR DESCRIPTION
I am testing the `librarian bump --all` command for Swift. This seems to work, it bumped the versions of most libraries because they had changes. Libraries like `google-rpc` or `google-cloud-auth`, which did not have changes, do not receive a version bump.