### PR TITLE
refactor: move `CRC32C` to `GoogleCloudGax`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "2a4cefb42b761e69e9ae4cf3094fe5008ef1c4e9afb22d0a74ce38d0f3417147",
+  "originHash" : "936fb7243d6ee0d46ed44890b546b825a8f69530fb0b962bf44d955400a6b3f6",
   "pins" : [
-    {
-      "identity" : "cryptoswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
-      "state" : {
-        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
-        "version" : "1.10.0"
-      }
-    },
     {
       "identity" : "grpc-swift",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -46,10 +46,9 @@ let package = Package(
     .package(path: "./generated/google-cloud-secretmanager-v1"),
     .package(path: "./generated/google-cloud-security-publicca-v1"),
     .package(path: "./generated/google-cloud-workflows-v1"),
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-    // Used in the integration tests.
-    .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.10.0"),
     .package(url: "https://github.com/apple/swift-log", from: "1.12.0"),
+    // Only used for development.
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
   ],
   targets: [
     .testTarget(
@@ -93,10 +92,10 @@ let package = Package(
         .product(name: "GoogleCloudWorkflowsV1", package: "google-cloud-workflows-v1"),
         .product(name: "GoogleCloudLocation", package: "google-cloud-location"),
         .product(name: "GoogleIAMV1", package: "google-iam-v1"),
+        .product(name: "GoogleCloudGax", package: "gax"),
         .product(name: "GoogleCloudWkt", package: "wkt"),
         .product(name: "GoogleCloudStorage", package: "storage"),
         .product(name: "GoogleCloudTestHelpers", package: "test-helpers"),
-        .product(name: "CryptoSwift", package: "CryptoSwift"),
         .product(name: "InMemoryLogging", package: "swift-log"),
       ],
       exclude: ["README.md"],

--- a/Tests/ProtoBasedClient/GlobalEndpoint.swift
+++ b/Tests/ProtoBasedClient/GlobalEndpoint.swift
@@ -16,8 +16,8 @@ import GoogleCloudLocation
 import GoogleCloudSecretManagerV1
 import GoogleCloudTestHelpers
 import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import struct GoogleCloudGax._CRC32C
 import GoogleIAMV1
-import CryptoSwift
 import Logging
 import Foundation
 
@@ -92,7 +92,7 @@ public enum GlobalEndpoint {
   {
     logger.info("\nTesting secret version CRUD")
     let data = Data("the quick brown fox jumps over the lazy dog".utf8)
-    let checksum = CryptoSwift.Checksum.crc32c(data.byteArray)
+    let checksum = _CRC32C.compute(data)
     let version = try await client.addSecretVersion(
       request: .init().with {
         $0.parent = secretName

--- a/Tests/ProtoBasedClient/Logging.swift
+++ b/Tests/ProtoBasedClient/Logging.swift
@@ -16,7 +16,6 @@ import GoogleCloudGax
 import GoogleCloudLocation
 import GoogleCloudSecretManagerV1
 import GoogleCloudTestHelpers
-import CryptoSwift
 import Logging
 import InMemoryLogging
 import Testing

--- a/packages/gax/Sources/GoogleCloudGax/CRC32C.swift
+++ b/packages/gax/Sources/GoogleCloudGax/CRC32C.swift
@@ -15,8 +15,9 @@
 import Foundation
 
 /// A lookup-table based implementation of the CRC32C (Castagnoli) checksum algorithm.
-// TODO(#482): Use hardware accelerated CRC32C on supported platforms.
-public struct CRC32C: Sendable {
+// TODO(https://github.com/googleapis/google-cloud-swift/issues/38) - Use hardware accelerated
+//   CRC32C on supported platforms.
+@_spi(GoogleCloudInternal) public struct _CRC32C: Sendable {
   private static let table: [UInt32] = {
     (0..<256).map { i in
       var crc = UInt32(i)
@@ -45,7 +46,7 @@ public struct CRC32C: Sendable {
   }
 
   public static func compute(_ data: Data) -> UInt32 {
-    var crc = CRC32C()
+    var crc = Self()
     crc.update(data)
     return crc.finalize()
   }

--- a/packages/gax/Tests/CRC32CTests.swift
+++ b/packages/gax/Tests/CRC32CTests.swift
@@ -1,0 +1,83 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+@_spi(GoogleCloudInternal) import GoogleCloudGax
+import Testing
+
+@Suite struct CRC32CTests {
+  @Test(arguments: [
+    ("", UInt32(0)),
+    (hello, helloCRC32C),
+    (spanish, spanishCRC32C),
+    (zebras, zebrasCRC32C),
+    (fox, foxCRC32C),
+    (gettysburg, gettysburgCRC32C),
+  ])
+  func compute(input: String, want: UInt32) {
+    let got = _CRC32C.compute(Data(input.utf8))
+    #expect(want == got)
+  }
+
+  @Test func update() {
+    var checksum = _CRC32C()
+    checksum.update(Data("Hello".utf8))
+    checksum.update(Data(" ".utf8))
+    checksum.update(Data("World".utf8))
+    let got = checksum.finalize()
+    #expect(helloCRC32C == got)
+  }
+}
+
+// We can get these magic value using:
+//   gcloud storage hash --skip-md5 file.txt
+// And then manipulate the output with your favorite base64 decoder.
+let helloCRC32C: UInt32 = 0x691daa2f // 0xaa2f691d
+let hello = "Hello World"
+
+let spanishCRC32C: UInt32 = 0xc72af3d3
+let spanish = "Benjamín pidió una bebida de kiwi y fresa. Noé, sin vergüenza, la más exquisita champaña del menú"
+
+let zebrasCRC32C: UInt32 = 0xf5eb161d
+let zebras = "how vexingly quick daft zebras jump"
+
+let foxCRC32C: UInt32 = 0x3c18f4d6
+let fox = "the quick brown fox jumps over the lazy dog"
+
+let gettysburgCRC32C: UInt32 = 0x802a36d6
+let gettysburg = """
+Four score and seven years ago our fathers brought forth on this continent a new
+nation, conceived in liberty, and dedicated to the proposition that all men are
+created equal.
+
+Now we are engaged in a great civil war, testing whether that nation, or any
+nation so conceived and so dedicated, can long endure. We are met on a great
+battlefield of that war. We have come to dedicate a portion of that field as a
+final resting place for those who here gave their lives that that nation might
+live. It is altogether fitting and proper that we should do this.
+
+But in a larger sense we cannot dedicate, we cannot consecrate, we cannot hallow
+this ground. The brave men, living and dead, who struggled here have consecrated
+it, far above our poor power to add or detract. The world will little note, nor
+long remember, what we say here, but it can never forget what they did here. It
+is for us the living, rather, to be dedicated here to the unfinished work which
+they who fought here have thus far so nobly advanced. It is rather for us to be
+here dedicated to the great task remaining before us,that from these honored
+dead we take increased devotion to that cause for which they gave the last full
+measure of devotion, that we here highly resolve that these dead shall not have
+died in vain, that this nation, under God, shall have a new birth of freedom,
+and that government of the people, by the people, for the people, shall not
+perish from the earth.
+
+"""

--- a/packages/gax/Tests/CRC32CTests.swift
+++ b/packages/gax/Tests/CRC32CTests.swift
@@ -43,11 +43,12 @@ import Testing
 // We can get these magic value using:
 //   gcloud storage hash --skip-md5 file.txt
 // And then manipulate the output with your favorite base64 decoder.
-let helloCRC32C: UInt32 = 0x691daa2f // 0xaa2f691d
+let helloCRC32C: UInt32 = 0x691daa2f  // 0xaa2f691d
 let hello = "Hello World"
 
 let spanishCRC32C: UInt32 = 0xc72af3d3
-let spanish = "Benjamín pidió una bebida de kiwi y fresa. Noé, sin vergüenza, la más exquisita champaña del menú"
+let spanish =
+  "Benjamín pidió una bebida de kiwi y fresa. Noé, sin vergüenza, la más exquisita champaña del menú"
 
 let zebrasCRC32C: UInt32 = 0xf5eb161d
 let zebras = "how vexingly quick daft zebras jump"
@@ -57,27 +58,27 @@ let fox = "the quick brown fox jumps over the lazy dog"
 
 let gettysburgCRC32C: UInt32 = 0x802a36d6
 let gettysburg = """
-Four score and seven years ago our fathers brought forth on this continent a new
-nation, conceived in liberty, and dedicated to the proposition that all men are
-created equal.
+  Four score and seven years ago our fathers brought forth on this continent a new
+  nation, conceived in liberty, and dedicated to the proposition that all men are
+  created equal.
 
-Now we are engaged in a great civil war, testing whether that nation, or any
-nation so conceived and so dedicated, can long endure. We are met on a great
-battlefield of that war. We have come to dedicate a portion of that field as a
-final resting place for those who here gave their lives that that nation might
-live. It is altogether fitting and proper that we should do this.
+  Now we are engaged in a great civil war, testing whether that nation, or any
+  nation so conceived and so dedicated, can long endure. We are met on a great
+  battlefield of that war. We have come to dedicate a portion of that field as a
+  final resting place for those who here gave their lives that that nation might
+  live. It is altogether fitting and proper that we should do this.
 
-But in a larger sense we cannot dedicate, we cannot consecrate, we cannot hallow
-this ground. The brave men, living and dead, who struggled here have consecrated
-it, far above our poor power to add or detract. The world will little note, nor
-long remember, what we say here, but it can never forget what they did here. It
-is for us the living, rather, to be dedicated here to the unfinished work which
-they who fought here have thus far so nobly advanced. It is rather for us to be
-here dedicated to the great task remaining before us,that from these honored
-dead we take increased devotion to that cause for which they gave the last full
-measure of devotion, that we here highly resolve that these dead shall not have
-died in vain, that this nation, under God, shall have a new birth of freedom,
-and that government of the people, by the people, for the people, shall not
-perish from the earth.
+  But in a larger sense we cannot dedicate, we cannot consecrate, we cannot hallow
+  this ground. The brave men, living and dead, who struggled here have consecrated
+  it, far above our poor power to add or detract. The world will little note, nor
+  long remember, what we say here, but it can never forget what they did here. It
+  is for us the living, rather, to be dedicated here to the unfinished work which
+  they who fought here have thus far so nobly advanced. It is rather for us to be
+  here dedicated to the great task remaining before us,that from these honored
+  dead we take increased devotion to that cause for which they gave the last full
+  measure of devotion, that we here highly resolve that these dead shall not have
+  died in vain, that this nation, under God, shall have a new birth of freedom,
+  and that government of the people, by the people, for the people, shall not
+  perish from the earth.
 
-"""
+  """

--- a/packages/storage/Sources/GoogleCloudStorage/ChecksummedSource.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/ChecksummedSource.swift
@@ -14,6 +14,7 @@
 
 import Crypto
 import Foundation
+@_spi(GoogleCloudInternal) import struct GoogleCloudGax._CRC32C
 
 struct ChunkInfo: Sendable {
   let data: Data
@@ -25,7 +26,7 @@ struct ChecksummedSource<S: UploadSource> {
   var source: S
   let options: ChecksumOptions
   private var md5 = Insecure.MD5()
-  private var crc32c = CRC32C()
+  private var crc32c = _CRC32C()
   private var nextChunk: Data? = nil
   private var isInitialized = false
   private var isFinished = false

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -18,6 +18,7 @@ import Foundation
 #endif
 import GoogleCloudGax
 import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import struct GoogleCloudGax._CRC32C
 import Crypto
 
 extension StorageClient {
@@ -488,7 +489,7 @@ extension StorageClient {
     if let crcOption = options.crc32c {
       switch crcOption {
       case .auto:
-        let crc = CRC32C.compute(data)
+        let crc = _CRC32C.compute(data)
         let bigEndian = crc.bigEndian
         var bytes = [UInt8]()
         withUnsafeBytes(of: bigEndian) {


### PR DESCRIPTION
We want to drop the dependency on `CryptoSwift`, we want to keep CRC32C hidden, and we need to use the code in some of our own tests (not examples) and in the implementation of `GoogleCloudStorage`.

This PR moves the code to `GoogleCloudGax`, uses `@_spi()` and the "names starting with `_` are private" convention to make it clear external developers should not use this thing.

Fixes #102 