### PR TITLE
feat(storage): regenerate conversions for optional, nested fields

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: swift
-version: v0.31.2-0.20260803213559-26e5c8a755c6
+version: v0.31.2-0.20260804010121-662b048ce902
 repo: googleapis/google-cloud-swift
 sources:
   conformance:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: swift
-version: v0.31.2-0.20260730223513-a02c28273b3c
+version: v0.31.2-0.20260803213559-26e5c8a755c6
 repo: googleapis/google-cloud-swift
 sources:
   conformance:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -590,6 +590,12 @@ libraries:
           api_path: google/storage/control/v2
           module_type: convert-swift
           module_path: StorageControlProtos
+        - output: packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/GoogleType
+          api_path: google/type
+          module_type: convert-swift
+          include_list:
+            - interval.proto
+          module_path: StorageControlProtos
   - name: google-cloud-storageinsights-v1
     version: 0.1.0-preview
     copyright_year: "2026"

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/GoogleType/Interval+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/GoogleType/Interval+Convert.swift
@@ -27,8 +27,8 @@ extension Interval {
 
   internal init(proto: ProtoType) throws {
     self.init()
-    self.startTime = proto.hasStartTime ? try GoogleCloudWkt.Timestamp(proto: proto.startTime) : nil
-    self.endTime = proto.hasEndTime ? try GoogleCloudWkt.Timestamp(proto: proto.endTime) : nil
+    self.startTime = proto.hasStartTime ? try .init(proto: proto.startTime) : nil
+    self.endTime = proto.hasEndTime ? try .init(proto: proto.endTime) : nil
   }
 
   internal func toProto() throws -> ProtoType {

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/GoogleType/Interval+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/GoogleType/Interval+Convert.swift
@@ -19,28 +19,22 @@ import GoogleCloudGax
 internal import StorageControlProtos
 internal import SwiftProtobuf
 import GoogleCloudWkt
+import GoogleType
 internal import GoogleCloudWktConvert
 
-extension UpdateOrganizationIntelligenceConfigRequest {
-  internal typealias ProtoType = StorageControlProtos
-    .Google_Storage_Control_V2_UpdateOrganizationIntelligenceConfigRequest
+extension Interval {
+  internal typealias ProtoType = StorageControlProtos.Google_Type_Interval
 
   internal init(proto: ProtoType) throws {
     self.init()
-    self.intelligenceConfig =
-      proto.hasIntelligenceConfig ? try IntelligenceConfig(proto: proto.intelligenceConfig) : nil
-    self.updateMask =
-      proto.hasUpdateMask ? try GoogleCloudWkt.FieldMask(proto: proto.updateMask) : nil
-    self.requestId = proto.requestID
+    self.startTime = proto.hasStartTime ? try GoogleCloudWkt.Timestamp(proto: proto.startTime) : nil
+    self.endTime = proto.hasEndTime ? try GoogleCloudWkt.Timestamp(proto: proto.endTime) : nil
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
-    if let intelligenceConfig = self.intelligenceConfig {
-      proto.intelligenceConfig = try intelligenceConfig.toProto()
-    }
-    if let updateMask = self.updateMask { proto.updateMask = try updateMask.toProto() }
-    proto.requestID = self.requestId
+    if let startTime = self.startTime { proto.startTime = try startTime.toProto() }
+    if let endTime = self.endTime { proto.endTime = try endTime.toProto() }
     return proto
   }
 }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/AnywhereCache+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/AnywhereCache+Convert.swift
@@ -28,13 +28,11 @@ extension AnywhereCache {
     self.init()
     self.name = proto.name
     self.zone = proto.zone
-    self.ttl = proto.hasTtl ? try GoogleCloudWkt.Duration(proto: proto.ttl) : nil
+    self.ttl = proto.hasTtl ? try .init(proto: proto.ttl) : nil
     self.admissionPolicy = proto.admissionPolicy
     self.state = proto.state
-    self.createTime =
-      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
-    self.updateTime =
-      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
+    self.createTime = proto.hasCreateTime ? try .init(proto: proto.createTime) : nil
+    self.updateTime = proto.hasUpdateTime ? try .init(proto: proto.updateTime) : nil
     self.pendingUpdate = proto.pendingUpdate
   }
 

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/AnywhereCache+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/AnywhereCache+Convert.swift
@@ -28,8 +28,13 @@ extension AnywhereCache {
     self.init()
     self.name = proto.name
     self.zone = proto.zone
+    self.ttl = proto.hasTtl ? try GoogleCloudWkt.Duration(proto: proto.ttl) : nil
     self.admissionPolicy = proto.admissionPolicy
     self.state = proto.state
+    self.createTime =
+      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
+    self.updateTime =
+      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
     self.pendingUpdate = proto.pendingUpdate
   }
 
@@ -37,8 +42,11 @@ extension AnywhereCache {
     var proto = ProtoType()
     proto.name = self.name
     proto.zone = self.zone
+    if let ttl = self.ttl { proto.ttl = try ttl.toProto() }
     proto.admissionPolicy = self.admissionPolicy
     proto.state = self.state
+    if let createTime = self.createTime { proto.createTime = try createTime.toProto() }
+    if let updateTime = self.updateTime { proto.updateTime = try updateTime.toProto() }
     proto.pendingUpdate = self.pendingUpdate
     return proto
   }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CommonLongRunningOperationMetadata+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CommonLongRunningOperationMetadata+Convert.swift
@@ -27,6 +27,11 @@ extension CommonLongRunningOperationMetadata {
 
   internal init(proto: ProtoType) throws {
     self.init()
+    self.createTime =
+      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
+    self.endTime = proto.hasEndTime ? try GoogleCloudWkt.Timestamp(proto: proto.endTime) : nil
+    self.updateTime =
+      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
     self.type = proto.type
     self.requestedCancellation = proto.requestedCancellation
     self.progressPercent = proto.progressPercent
@@ -34,6 +39,9 @@ extension CommonLongRunningOperationMetadata {
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
+    if let createTime = self.createTime { proto.createTime = try createTime.toProto() }
+    if let endTime = self.endTime { proto.endTime = try endTime.toProto() }
+    if let updateTime = self.updateTime { proto.updateTime = try updateTime.toProto() }
     proto.type = self.type
     proto.requestedCancellation = self.requestedCancellation
     proto.progressPercent = self.progressPercent

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CommonLongRunningOperationMetadata+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CommonLongRunningOperationMetadata+Convert.swift
@@ -27,11 +27,9 @@ extension CommonLongRunningOperationMetadata {
 
   internal init(proto: ProtoType) throws {
     self.init()
-    self.createTime =
-      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
-    self.endTime = proto.hasEndTime ? try GoogleCloudWkt.Timestamp(proto: proto.endTime) : nil
-    self.updateTime =
-      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
+    self.createTime = proto.hasCreateTime ? try .init(proto: proto.createTime) : nil
+    self.endTime = proto.hasEndTime ? try .init(proto: proto.endTime) : nil
+    self.updateTime = proto.hasUpdateTime ? try .init(proto: proto.updateTime) : nil
     self.type = proto.type
     self.requestedCancellation = proto.requestedCancellation
     self.progressPercent = proto.progressPercent

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateAnywhereCacheMetadata+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateAnywhereCacheMetadata+Convert.swift
@@ -27,15 +27,23 @@ extension CreateAnywhereCacheMetadata {
 
   internal init(proto: ProtoType) throws {
     self.init()
+    self.commonMetadata =
+      proto.hasCommonMetadata
+      ? try CommonLongRunningOperationMetadata(proto: proto.commonMetadata) : nil
     self.anywhereCacheId = proto.hasAnywhereCacheID ? proto.anywhereCacheID : nil
     self.zone = proto.hasZone ? proto.zone : nil
+    self.ttl = proto.hasTtl ? try GoogleCloudWkt.Duration(proto: proto.ttl) : nil
     self.admissionPolicy = proto.hasAdmissionPolicy ? proto.admissionPolicy : nil
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
+    if let commonMetadata = self.commonMetadata {
+      proto.commonMetadata = try commonMetadata.toProto()
+    }
     if let anywhereCacheId = self.anywhereCacheId { proto.anywhereCacheID = anywhereCacheId }
     if let zone = self.zone { proto.zone = zone }
+    if let ttl = self.ttl { proto.ttl = try ttl.toProto() }
     if let admissionPolicy = self.admissionPolicy { proto.admissionPolicy = admissionPolicy }
     return proto
   }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateAnywhereCacheMetadata+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateAnywhereCacheMetadata+Convert.swift
@@ -27,12 +27,10 @@ extension CreateAnywhereCacheMetadata {
 
   internal init(proto: ProtoType) throws {
     self.init()
-    self.commonMetadata =
-      proto.hasCommonMetadata
-      ? try CommonLongRunningOperationMetadata(proto: proto.commonMetadata) : nil
+    self.commonMetadata = proto.hasCommonMetadata ? try .init(proto: proto.commonMetadata) : nil
     self.anywhereCacheId = proto.hasAnywhereCacheID ? proto.anywhereCacheID : nil
     self.zone = proto.hasZone ? proto.zone : nil
-    self.ttl = proto.hasTtl ? try GoogleCloudWkt.Duration(proto: proto.ttl) : nil
+    self.ttl = proto.hasTtl ? try .init(proto: proto.ttl) : nil
     self.admissionPolicy = proto.hasAdmissionPolicy ? proto.admissionPolicy : nil
   }
 

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateAnywhereCacheRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateAnywhereCacheRequest+Convert.swift
@@ -28,8 +28,7 @@ extension CreateAnywhereCacheRequest {
   internal init(proto: ProtoType) throws {
     self.init()
     self.parent = proto.parent
-    self.anywhereCache =
-      proto.hasAnywhereCache ? try AnywhereCache(proto: proto.anywhereCache) : nil
+    self.anywhereCache = proto.hasAnywhereCache ? try .init(proto: proto.anywhereCache) : nil
     self.requestId = proto.requestID
   }
 

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateAnywhereCacheRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateAnywhereCacheRequest+Convert.swift
@@ -28,12 +28,15 @@ extension CreateAnywhereCacheRequest {
   internal init(proto: ProtoType) throws {
     self.init()
     self.parent = proto.parent
+    self.anywhereCache =
+      proto.hasAnywhereCache ? try AnywhereCache(proto: proto.anywhereCache) : nil
     self.requestId = proto.requestID
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
     proto.parent = self.parent
+    if let anywhereCache = self.anywhereCache { proto.anywhereCache = try anywhereCache.toProto() }
     proto.requestID = self.requestId
     return proto
   }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateFolderRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateFolderRequest+Convert.swift
@@ -27,7 +27,7 @@ extension CreateFolderRequest {
   internal init(proto: ProtoType) throws {
     self.init()
     self.parent = proto.parent
-    self.folder = proto.hasFolder ? try Folder(proto: proto.folder) : nil
+    self.folder = proto.hasFolder ? try .init(proto: proto.folder) : nil
     self.folderId = proto.folderID
     self.recursive = proto.recursive
     self.requestId = proto.requestID

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateFolderRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateFolderRequest+Convert.swift
@@ -27,6 +27,7 @@ extension CreateFolderRequest {
   internal init(proto: ProtoType) throws {
     self.init()
     self.parent = proto.parent
+    self.folder = proto.hasFolder ? try Folder(proto: proto.folder) : nil
     self.folderId = proto.folderID
     self.recursive = proto.recursive
     self.requestId = proto.requestID
@@ -35,6 +36,7 @@ extension CreateFolderRequest {
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
     proto.parent = self.parent
+    if let folder = self.folder { proto.folder = try folder.toProto() }
     proto.folderID = self.folderId
     proto.recursive = self.recursive
     proto.requestID = self.requestId

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateManagedFolderRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateManagedFolderRequest+Convert.swift
@@ -28,6 +28,8 @@ extension CreateManagedFolderRequest {
   internal init(proto: ProtoType) throws {
     self.init()
     self.parent = proto.parent
+    self.managedFolder =
+      proto.hasManagedFolder ? try ManagedFolder(proto: proto.managedFolder) : nil
     self.managedFolderId = proto.managedFolderID
     self.requestId = proto.requestID
   }
@@ -35,6 +37,7 @@ extension CreateManagedFolderRequest {
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
     proto.parent = self.parent
+    if let managedFolder = self.managedFolder { proto.managedFolder = try managedFolder.toProto() }
     proto.managedFolderID = self.managedFolderId
     proto.requestID = self.requestId
     return proto

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateManagedFolderRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/CreateManagedFolderRequest+Convert.swift
@@ -28,8 +28,7 @@ extension CreateManagedFolderRequest {
   internal init(proto: ProtoType) throws {
     self.init()
     self.parent = proto.parent
-    self.managedFolder =
-      proto.hasManagedFolder ? try ManagedFolder(proto: proto.managedFolder) : nil
+    self.managedFolder = proto.hasManagedFolder ? try .init(proto: proto.managedFolder) : nil
     self.managedFolderId = proto.managedFolderID
     self.requestId = proto.requestID
   }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/DeleteFolderRecursiveMetadata+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/DeleteFolderRecursiveMetadata+Convert.swift
@@ -27,11 +27,17 @@ extension DeleteFolderRecursiveMetadata {
 
   internal init(proto: ProtoType) throws {
     self.init()
+    self.commonMetadata =
+      proto.hasCommonMetadata
+      ? try CommonLongRunningOperationMetadata(proto: proto.commonMetadata) : nil
     self.folderId = proto.folderID
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
+    if let commonMetadata = self.commonMetadata {
+      proto.commonMetadata = try commonMetadata.toProto()
+    }
     proto.folderID = self.folderId
     return proto
   }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/DeleteFolderRecursiveMetadata+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/DeleteFolderRecursiveMetadata+Convert.swift
@@ -27,9 +27,7 @@ extension DeleteFolderRecursiveMetadata {
 
   internal init(proto: ProtoType) throws {
     self.init()
-    self.commonMetadata =
-      proto.hasCommonMetadata
-      ? try CommonLongRunningOperationMetadata(proto: proto.commonMetadata) : nil
+    self.commonMetadata = proto.hasCommonMetadata ? try .init(proto: proto.commonMetadata) : nil
     self.folderId = proto.folderID
   }
 

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/FindingSummary+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/FindingSummary+Convert.swift
@@ -26,14 +26,12 @@ extension FindingSummary {
 
   internal init(proto: ProtoType) throws {
     self.init()
-    self.type = FindingType(proto: proto.type)
-    self.category = FindingCategory(proto: proto.category)
+    self.type = .init(proto: proto.type)
+    self.category = .init(proto: proto.category)
     self.targetResource = proto.targetResource
-    self.createTime =
-      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
-    self.updateTime =
-      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
-    self.severity = FindingSeverity(proto: proto.severity)
+    self.createTime = proto.hasCreateTime ? try .init(proto: proto.createTime) : nil
+    self.updateTime = proto.hasUpdateTime ? try .init(proto: proto.updateTime) : nil
+    self.severity = .init(proto: proto.severity)
   }
 
   internal func toProto() throws -> ProtoType {
@@ -54,7 +52,7 @@ extension FindingSummary.SummaryDetails {
 
   internal init(proto: ProtoType) throws {
     self.init()
-    self.resourceType = FindingSummary.SummaryDetails.ResourceType(proto: proto.resourceType)
+    self.resourceType = .init(proto: proto.resourceType)
     self.description = proto.description_p
   }
 

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/FindingSummary+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/FindingSummary+Convert.swift
@@ -26,12 +26,78 @@ extension FindingSummary {
 
   internal init(proto: ProtoType) throws {
     self.init()
+    self.type = FindingType(proto: proto.type)
+    self.category = FindingCategory(proto: proto.category)
     self.targetResource = proto.targetResource
+    self.createTime =
+      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
+    self.updateTime =
+      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
+    self.severity = FindingSeverity(proto: proto.severity)
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
+    proto.type = try self.type.toProto()
+    proto.category = try self.category.toProto()
     proto.targetResource = self.targetResource
+    if let createTime = self.createTime { proto.createTime = try createTime.toProto() }
+    if let updateTime = self.updateTime { proto.updateTime = try updateTime.toProto() }
+    proto.severity = try self.severity.toProto()
     return proto
+  }
+}
+
+extension FindingSummary.SummaryDetails {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_FindingSummary
+    .SummaryDetails
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.resourceType = FindingSummary.SummaryDetails.ResourceType(proto: proto.resourceType)
+    self.description = proto.description_p
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.resourceType = try self.resourceType.toProto()
+    proto.description_p = self.description
+    return proto
+  }
+}
+
+extension FindingSummary.SummaryDetails.ResourceType {
+  internal init(
+    proto: StorageControlProtos.Google_Storage_Control_V2_FindingSummary.SummaryDetails.ResourceType
+  ) {
+    switch proto {
+    case .unspecified:
+      self = .unspecified
+    case .project:
+      self = .project
+    case .bucket:
+      self = .bucket
+    case .UNRECOGNIZED(let val): self = .unknownIntValue(val)
+    }
+  }
+
+  internal func toProto() throws
+    -> StorageControlProtos.Google_Storage_Control_V2_FindingSummary.SummaryDetails.ResourceType
+  {
+    switch self {
+    case .unspecified:
+      return .unspecified
+    case .project:
+      return .project
+    case .bucket:
+      return .bucket
+    case .unknownIntValue(let val):
+      return StorageControlProtos.Google_Storage_Control_V2_FindingSummary.SummaryDetails
+        .ResourceType(rawValue: val)
+        ?? .UNRECOGNIZED(val)
+    case .unknownStringValue(let str):
+      throw GoogleCloudGax.ProtobufConversionError.noIntegerValue(
+        enumType: "FindingSummary.SummaryDetails.ResourceType", stringValue: str)
+    }
   }
 }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/Folder+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/Folder+Convert.swift
@@ -28,12 +28,10 @@ extension Folder {
     self.init()
     self.name = proto.name
     self.metageneration = proto.metageneration
-    self.createTime =
-      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
-    self.updateTime =
-      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
+    self.createTime = proto.hasCreateTime ? try .init(proto: proto.createTime) : nil
+    self.updateTime = proto.hasUpdateTime ? try .init(proto: proto.updateTime) : nil
     self.pendingRenameInfo =
-      proto.hasPendingRenameInfo ? try PendingRenameInfo(proto: proto.pendingRenameInfo) : nil
+      proto.hasPendingRenameInfo ? try .init(proto: proto.pendingRenameInfo) : nil
   }
 
   internal func toProto() throws -> ProtoType {

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/Folder+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/Folder+Convert.swift
@@ -28,12 +28,23 @@ extension Folder {
     self.init()
     self.name = proto.name
     self.metageneration = proto.metageneration
+    self.createTime =
+      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
+    self.updateTime =
+      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
+    self.pendingRenameInfo =
+      proto.hasPendingRenameInfo ? try PendingRenameInfo(proto: proto.pendingRenameInfo) : nil
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
     proto.name = self.name
     proto.metageneration = self.metageneration
+    if let createTime = self.createTime { proto.createTime = try createTime.toProto() }
+    if let updateTime = self.updateTime { proto.updateTime = try updateTime.toProto() }
+    if let pendingRenameInfo = self.pendingRenameInfo {
+      proto.pendingRenameInfo = try pendingRenameInfo.toProto()
+    }
     return proto
   }
 }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceConfig+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceConfig+Convert.swift
@@ -59,7 +59,7 @@ extension IntelligenceConfig.Filter {
   }
 
   internal func toProto() throws -> ProtoType {
-    var proto = ProtoType()
+    let proto = ProtoType()
     return proto
   }
 }
@@ -73,7 +73,7 @@ extension IntelligenceConfig.Filter.CloudStorageLocations {
   }
 
   internal func toProto() throws -> ProtoType {
-    var proto = ProtoType()
+    let proto = ProtoType()
     return proto
   }
 }
@@ -87,7 +87,7 @@ extension IntelligenceConfig.Filter.CloudStorageBuckets {
   }
 
   internal func toProto() throws -> ProtoType {
-    var proto = ProtoType()
+    let proto = ProtoType()
     return proto
   }
 }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceConfig+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceConfig+Convert.swift
@@ -27,16 +27,13 @@ extension IntelligenceConfig {
   internal init(proto: ProtoType) throws {
     self.init()
     self.name = proto.name
-    self.editionConfig = IntelligenceConfig.EditionConfig(proto: proto.editionConfig)
-    self.updateTime =
-      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
-    self.filter = proto.hasFilter ? try IntelligenceConfig.Filter(proto: proto.filter) : nil
+    self.editionConfig = .init(proto: proto.editionConfig)
+    self.updateTime = proto.hasUpdateTime ? try .init(proto: proto.updateTime) : nil
+    self.filter = proto.hasFilter ? try .init(proto: proto.filter) : nil
     self.effectiveIntelligenceConfig =
       proto.hasEffectiveIntelligenceConfig
-      ? try IntelligenceConfig.EffectiveIntelligenceConfig(proto: proto.effectiveIntelligenceConfig)
-      : nil
-    self.trialConfig =
-      proto.hasTrialConfig ? try IntelligenceConfig.TrialConfig(proto: proto.trialConfig) : nil
+      ? try .init(proto: proto.effectiveIntelligenceConfig) : nil
+    self.trialConfig = proto.hasTrialConfig ? try .init(proto: proto.trialConfig) : nil
   }
 
   internal func toProto() throws -> ProtoType {
@@ -101,8 +98,7 @@ extension IntelligenceConfig.EffectiveIntelligenceConfig {
 
   internal init(proto: ProtoType) throws {
     self.init()
-    self.effectiveEdition = IntelligenceConfig.EffectiveIntelligenceConfig.EffectiveEdition(
-      proto: proto.effectiveEdition)
+    self.effectiveEdition = .init(proto: proto.effectiveEdition)
     self.intelligenceConfig = proto.intelligenceConfig
   }
 
@@ -158,8 +154,7 @@ extension IntelligenceConfig.TrialConfig {
 
   internal init(proto: ProtoType) throws {
     self.init()
-    self.expireTime =
-      proto.hasExpireTime ? try GoogleCloudWkt.Timestamp(proto: proto.expireTime) : nil
+    self.expireTime = proto.hasExpireTime ? try .init(proto: proto.expireTime) : nil
   }
 
   internal func toProto() throws -> ProtoType {

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceConfig+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceConfig+Convert.swift
@@ -27,11 +27,188 @@ extension IntelligenceConfig {
   internal init(proto: ProtoType) throws {
     self.init()
     self.name = proto.name
+    self.editionConfig = IntelligenceConfig.EditionConfig(proto: proto.editionConfig)
+    self.updateTime =
+      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
+    self.filter = proto.hasFilter ? try IntelligenceConfig.Filter(proto: proto.filter) : nil
+    self.effectiveIntelligenceConfig =
+      proto.hasEffectiveIntelligenceConfig
+      ? try IntelligenceConfig.EffectiveIntelligenceConfig(proto: proto.effectiveIntelligenceConfig)
+      : nil
+    self.trialConfig =
+      proto.hasTrialConfig ? try IntelligenceConfig.TrialConfig(proto: proto.trialConfig) : nil
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
     proto.name = self.name
+    proto.editionConfig = try self.editionConfig.toProto()
+    if let updateTime = self.updateTime { proto.updateTime = try updateTime.toProto() }
+    if let filter = self.filter { proto.filter = try filter.toProto() }
+    if let effectiveIntelligenceConfig = self.effectiveIntelligenceConfig {
+      proto.effectiveIntelligenceConfig = try effectiveIntelligenceConfig.toProto()
+    }
+    if let trialConfig = self.trialConfig { proto.trialConfig = try trialConfig.toProto() }
     return proto
+  }
+}
+
+extension IntelligenceConfig.Filter {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceConfig
+    .Filter
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    return proto
+  }
+}
+
+extension IntelligenceConfig.Filter.CloudStorageLocations {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceConfig
+    .Filter.CloudStorageLocations
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    return proto
+  }
+}
+
+extension IntelligenceConfig.Filter.CloudStorageBuckets {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceConfig
+    .Filter.CloudStorageBuckets
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    return proto
+  }
+}
+
+extension IntelligenceConfig.EffectiveIntelligenceConfig {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceConfig
+    .EffectiveIntelligenceConfig
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.effectiveEdition = IntelligenceConfig.EffectiveIntelligenceConfig.EffectiveEdition(
+      proto: proto.effectiveEdition)
+    self.intelligenceConfig = proto.intelligenceConfig
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.effectiveEdition = try self.effectiveEdition.toProto()
+    proto.intelligenceConfig = self.intelligenceConfig
+    return proto
+  }
+}
+
+extension IntelligenceConfig.EffectiveIntelligenceConfig.EffectiveEdition {
+  internal init(
+    proto: StorageControlProtos.Google_Storage_Control_V2_IntelligenceConfig
+      .EffectiveIntelligenceConfig.EffectiveEdition
+  ) {
+    switch proto {
+    case .unspecified:
+      self = .unspecified
+    case .`none`:
+      self = .`none`
+    case .standard:
+      self = .standard
+    case .UNRECOGNIZED(let val): self = .unknownIntValue(val)
+    }
+  }
+
+  internal func toProto() throws
+    -> StorageControlProtos.Google_Storage_Control_V2_IntelligenceConfig.EffectiveIntelligenceConfig
+    .EffectiveEdition
+  {
+    switch self {
+    case .unspecified:
+      return .unspecified
+    case .`none`:
+      return .`none`
+    case .standard:
+      return .standard
+    case .unknownIntValue(let val):
+      return StorageControlProtos.Google_Storage_Control_V2_IntelligenceConfig
+        .EffectiveIntelligenceConfig.EffectiveEdition(rawValue: val)
+        ?? .UNRECOGNIZED(val)
+    case .unknownStringValue(let str):
+      throw GoogleCloudGax.ProtobufConversionError.noIntegerValue(
+        enumType: "IntelligenceConfig.EffectiveIntelligenceConfig.EffectiveEdition",
+        stringValue: str)
+    }
+  }
+}
+extension IntelligenceConfig.TrialConfig {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceConfig
+    .TrialConfig
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.expireTime =
+      proto.hasExpireTime ? try GoogleCloudWkt.Timestamp(proto: proto.expireTime) : nil
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    if let expireTime = self.expireTime { proto.expireTime = try expireTime.toProto() }
+    return proto
+  }
+}
+
+extension IntelligenceConfig.EditionConfig {
+  internal init(
+    proto: StorageControlProtos.Google_Storage_Control_V2_IntelligenceConfig.EditionConfig
+  ) {
+    switch proto {
+    case .unspecified:
+      self = .unspecified
+    case .inherit:
+      self = .inherit
+    case .disabled:
+      self = .disabled
+    case .standard:
+      self = .standard
+    case .trial:
+      self = .trial
+    case .UNRECOGNIZED(let val): self = .unknownIntValue(val)
+    }
+  }
+
+  internal func toProto() throws
+    -> StorageControlProtos.Google_Storage_Control_V2_IntelligenceConfig.EditionConfig
+  {
+    switch self {
+    case .unspecified:
+      return .unspecified
+    case .inherit:
+      return .inherit
+    case .disabled:
+      return .disabled
+    case .standard:
+      return .standard
+    case .trial:
+      return .trial
+    case .unknownIntValue(let val):
+      return StorageControlProtos.Google_Storage_Control_V2_IntelligenceConfig.EditionConfig(
+        rawValue: val)
+        ?? .UNRECOGNIZED(val)
+    case .unknownStringValue(let str):
+      throw GoogleCloudGax.ProtobufConversionError.noIntegerValue(
+        enumType: "IntelligenceConfig.EditionConfig", stringValue: str)
+    }
   }
 }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceFinding+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceFinding+Convert.swift
@@ -30,14 +30,293 @@ extension IntelligenceFinding {
     self.init()
     self.name = proto.name
     self.description = proto.description_p
+    self.type = FindingType(proto: proto.type)
+    self.category = FindingCategory(proto: proto.category)
+    self.severity = FindingSeverity(proto: proto.severity)
+    self.createTime =
+      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
+    self.updateTime =
+      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
     self.targetResource = proto.targetResource
+    self.observationPeriod =
+      proto.hasObservationPeriod ? try GoogleType.Interval(proto: proto.observationPeriod) : nil
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
     proto.name = self.name
     proto.description_p = self.description
+    proto.type = try self.type.toProto()
+    proto.category = try self.category.toProto()
+    proto.severity = try self.severity.toProto()
+    if let createTime = self.createTime { proto.createTime = try createTime.toProto() }
+    if let updateTime = self.updateTime { proto.updateTime = try updateTime.toProto() }
     proto.targetResource = self.targetResource
+    if let observationPeriod = self.observationPeriod {
+      proto.observationPeriod = try observationPeriod.toProto()
+    }
+    return proto
+  }
+}
+
+extension IntelligenceFinding.ColdlineAndArchivalStorageOperationsSpike {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .ColdlineAndArchivalStorageOperationsSpike
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.percentageIncrease = proto.percentageIncrease
+    self.totalOperationsCount = proto.totalOperationsCount
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.percentageIncrease = self.percentageIncrease
+    proto.totalOperationsCount = self.totalOperationsCount
+    return proto
+  }
+}
+
+extension IntelligenceFinding.ColdlineAndArchivalStorageOperationsSpike.BucketContribution {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .ColdlineAndArchivalStorageOperationsSpike.BucketContribution
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.bucket = proto.bucket
+    self.percentageIncrease = proto.percentageIncrease
+    self.totalOperationsCount = proto.totalOperationsCount
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.bucket = self.bucket
+    proto.percentageIncrease = self.percentageIncrease
+    proto.totalOperationsCount = self.totalOperationsCount
+    return proto
+  }
+}
+
+extension IntelligenceFinding.ColdlineAndArchivalStorageOperationsSpike.BucketContribution
+  .Contribution
+{
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .ColdlineAndArchivalStorageOperationsSpike.BucketContribution.Contribution
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    return proto
+  }
+}
+
+extension IntelligenceFinding.ColdlineAndArchivalStorageOperationsSpike.BucketContribution
+  .Contribution.PrefixContribution
+{
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .ColdlineAndArchivalStorageOperationsSpike.BucketContribution.Contribution.PrefixContribution
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.`prefix` = proto.`prefix`
+    self.percentageIncrease = proto.percentageIncrease
+    self.totalOperationsCount = proto.totalOperationsCount
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.`prefix` = self.`prefix`
+    proto.percentageIncrease = self.percentageIncrease
+    proto.totalOperationsCount = self.totalOperationsCount
+    return proto
+  }
+}
+
+extension IntelligenceFinding.CrossRegionEgressSpike {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .CrossRegionEgressSpike
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.totalEgressBytes = proto.totalEgressBytes
+    self.percentageIncrease = proto.percentageIncrease
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.totalEgressBytes = self.totalEgressBytes
+    proto.percentageIncrease = self.percentageIncrease
+    return proto
+  }
+}
+
+extension IntelligenceFinding.CrossRegionEgressSpike.BucketContribution {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .CrossRegionEgressSpike.BucketContribution
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.bucket = proto.bucket
+    self.totalEgressBytes = proto.totalEgressBytes
+    self.percentageIncrease = proto.percentageIncrease
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.bucket = self.bucket
+    proto.totalEgressBytes = self.totalEgressBytes
+    proto.percentageIncrease = self.percentageIncrease
+    return proto
+  }
+}
+
+extension IntelligenceFinding.CrossRegionEgressSpike.BucketContribution.Contribution {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .CrossRegionEgressSpike.BucketContribution.Contribution
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    return proto
+  }
+}
+
+extension IntelligenceFinding.CrossRegionEgressSpike.BucketContribution.Contribution
+  .PrefixContribution
+{
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .CrossRegionEgressSpike.BucketContribution.Contribution.PrefixContribution
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.`prefix` = proto.`prefix`
+    self.totalEgressBytes = proto.totalEgressBytes
+    self.percentageIncrease = proto.percentageIncrease
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.`prefix` = self.`prefix`
+    proto.totalEgressBytes = self.totalEgressBytes
+    proto.percentageIncrease = self.percentageIncrease
+    return proto
+  }
+}
+
+extension IntelligenceFinding.ThrottledRequestSpike {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .ThrottledRequestSpike
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.throttledRequests = proto.throttledRequests
+    self.percentageIncrease = proto.percentageIncrease
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.throttledRequests = self.throttledRequests
+    proto.percentageIncrease = self.percentageIncrease
+    return proto
+  }
+}
+
+extension IntelligenceFinding.ThrottledRequestSpike.BucketContribution {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .ThrottledRequestSpike.BucketContribution
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.bucket = proto.bucket
+    self.throttledRequests = proto.throttledRequests
+    self.percentageIncrease = proto.percentageIncrease
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.bucket = self.bucket
+    proto.throttledRequests = self.throttledRequests
+    proto.percentageIncrease = self.percentageIncrease
+    return proto
+  }
+}
+
+extension IntelligenceFinding.ThrottledRequestSpike.BucketContribution.Contribution {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .ThrottledRequestSpike.BucketContribution.Contribution
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    return proto
+  }
+}
+
+extension IntelligenceFinding.ThrottledRequestSpike.BucketContribution.Contribution
+  .PrefixContribution
+{
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .ThrottledRequestSpike.BucketContribution.Contribution.PrefixContribution
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.`prefix` = proto.`prefix`
+    self.throttledRequests = proto.throttledRequests
+    self.percentageIncrease = proto.percentageIncrease
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.`prefix` = self.`prefix`
+    proto.throttledRequests = self.throttledRequests
+    proto.percentageIncrease = self.percentageIncrease
+    return proto
+  }
+}
+
+extension IntelligenceFinding.StorageGrowthAboveTrend {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .StorageGrowthAboveTrend
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.totalStorageGrowthBytes = proto.totalStorageGrowthBytes
+    self.percentageIncrease = proto.percentageIncrease
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.totalStorageGrowthBytes = self.totalStorageGrowthBytes
+    proto.percentageIncrease = self.percentageIncrease
+    return proto
+  }
+}
+
+extension IntelligenceFinding.StorageGrowthAboveTrend.BucketContribution {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_IntelligenceFinding
+    .StorageGrowthAboveTrend.BucketContribution
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.bucket = proto.bucket
+    self.totalStorageGrowthBytes = proto.totalStorageGrowthBytes
+    self.percentageIncrease = proto.percentageIncrease
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.bucket = self.bucket
+    proto.totalStorageGrowthBytes = self.totalStorageGrowthBytes
+    proto.percentageIncrease = self.percentageIncrease
     return proto
   }
 }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceFinding+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceFinding+Convert.swift
@@ -106,7 +106,7 @@ extension IntelligenceFinding.ColdlineAndArchivalStorageOperationsSpike.BucketCo
   }
 
   internal func toProto() throws -> ProtoType {
-    var proto = ProtoType()
+    let proto = ProtoType()
     return proto
   }
 }
@@ -180,7 +180,7 @@ extension IntelligenceFinding.CrossRegionEgressSpike.BucketContribution.Contribu
   }
 
   internal func toProto() throws -> ProtoType {
-    var proto = ProtoType()
+    let proto = ProtoType()
     return proto
   }
 }
@@ -254,7 +254,7 @@ extension IntelligenceFinding.ThrottledRequestSpike.BucketContribution.Contribut
   }
 
   internal func toProto() throws -> ProtoType {
-    var proto = ProtoType()
+    let proto = ProtoType()
     return proto
   }
 }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceFinding+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceFinding+Convert.swift
@@ -30,16 +30,14 @@ extension IntelligenceFinding {
     self.init()
     self.name = proto.name
     self.description = proto.description_p
-    self.type = FindingType(proto: proto.type)
-    self.category = FindingCategory(proto: proto.category)
-    self.severity = FindingSeverity(proto: proto.severity)
-    self.createTime =
-      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
-    self.updateTime =
-      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
+    self.type = .init(proto: proto.type)
+    self.category = .init(proto: proto.category)
+    self.severity = .init(proto: proto.severity)
+    self.createTime = proto.hasCreateTime ? try .init(proto: proto.createTime) : nil
+    self.updateTime = proto.hasUpdateTime ? try .init(proto: proto.updateTime) : nil
     self.targetResource = proto.targetResource
     self.observationPeriod =
-      proto.hasObservationPeriod ? try GoogleType.Interval(proto: proto.observationPeriod) : nil
+      proto.hasObservationPeriod ? try .init(proto: proto.observationPeriod) : nil
   }
 
   internal func toProto() throws -> ProtoType {

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceFindingRevision+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceFindingRevision+Convert.swift
@@ -28,11 +28,16 @@ extension IntelligenceFindingRevision {
   internal init(proto: ProtoType) throws {
     self.init()
     self.name = proto.name
+    self.snapshot = proto.hasSnapshot ? try IntelligenceFinding(proto: proto.snapshot) : nil
+    self.createTime =
+      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
     proto.name = self.name
+    if let snapshot = self.snapshot { proto.snapshot = try snapshot.toProto() }
+    if let createTime = self.createTime { proto.createTime = try createTime.toProto() }
     return proto
   }
 }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceFindingRevision+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/IntelligenceFindingRevision+Convert.swift
@@ -28,9 +28,8 @@ extension IntelligenceFindingRevision {
   internal init(proto: ProtoType) throws {
     self.init()
     self.name = proto.name
-    self.snapshot = proto.hasSnapshot ? try IntelligenceFinding(proto: proto.snapshot) : nil
-    self.createTime =
-      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
+    self.snapshot = proto.hasSnapshot ? try .init(proto: proto.snapshot) : nil
+    self.createTime = proto.hasCreateTime ? try .init(proto: proto.createTime) : nil
   }
 
   internal func toProto() throws -> ProtoType {

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/ManagedFolder+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/ManagedFolder+Convert.swift
@@ -28,12 +28,18 @@ extension ManagedFolder {
     self.init()
     self.name = proto.name
     self.metageneration = proto.metageneration
+    self.createTime =
+      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
+    self.updateTime =
+      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
     proto.name = self.name
     proto.metageneration = self.metageneration
+    if let createTime = self.createTime { proto.createTime = try createTime.toProto() }
+    if let updateTime = self.updateTime { proto.updateTime = try updateTime.toProto() }
     return proto
   }
 }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/ManagedFolder+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/ManagedFolder+Convert.swift
@@ -28,10 +28,8 @@ extension ManagedFolder {
     self.init()
     self.name = proto.name
     self.metageneration = proto.metageneration
-    self.createTime =
-      proto.hasCreateTime ? try GoogleCloudWkt.Timestamp(proto: proto.createTime) : nil
-    self.updateTime =
-      proto.hasUpdateTime ? try GoogleCloudWkt.Timestamp(proto: proto.updateTime) : nil
+    self.createTime = proto.hasCreateTime ? try .init(proto: proto.createTime) : nil
+    self.updateTime = proto.hasUpdateTime ? try .init(proto: proto.updateTime) : nil
   }
 
   internal func toProto() throws -> ProtoType {

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/RenameFolderMetadata+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/RenameFolderMetadata+Convert.swift
@@ -26,9 +26,7 @@ extension RenameFolderMetadata {
 
   internal init(proto: ProtoType) throws {
     self.init()
-    self.commonMetadata =
-      proto.hasCommonMetadata
-      ? try CommonLongRunningOperationMetadata(proto: proto.commonMetadata) : nil
+    self.commonMetadata = proto.hasCommonMetadata ? try .init(proto: proto.commonMetadata) : nil
     self.sourceFolderId = proto.sourceFolderID
     self.destinationFolderId = proto.destinationFolderID
   }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/RenameFolderMetadata+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/RenameFolderMetadata+Convert.swift
@@ -26,12 +26,18 @@ extension RenameFolderMetadata {
 
   internal init(proto: ProtoType) throws {
     self.init()
+    self.commonMetadata =
+      proto.hasCommonMetadata
+      ? try CommonLongRunningOperationMetadata(proto: proto.commonMetadata) : nil
     self.sourceFolderId = proto.sourceFolderID
     self.destinationFolderId = proto.destinationFolderID
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
+    if let commonMetadata = self.commonMetadata {
+      proto.commonMetadata = try commonMetadata.toProto()
+    }
     proto.sourceFolderID = self.sourceFolderId
     proto.destinationFolderID = self.destinationFolderId
     return proto

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/StorageLayout+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/StorageLayout+Convert.swift
@@ -29,6 +29,12 @@ extension StorageLayout {
     self.name = proto.name
     self.location = proto.location
     self.locationType = proto.locationType
+    self.customPlacementConfig =
+      proto.hasCustomPlacementConfig
+      ? try StorageLayout.CustomPlacementConfig(proto: proto.customPlacementConfig) : nil
+    self.hierarchicalNamespace =
+      proto.hasHierarchicalNamespace
+      ? try StorageLayout.HierarchicalNamespace(proto: proto.hierarchicalNamespace) : nil
   }
 
   internal func toProto() throws -> ProtoType {
@@ -36,6 +42,42 @@ extension StorageLayout {
     proto.name = self.name
     proto.location = self.location
     proto.locationType = self.locationType
+    if let customPlacementConfig = self.customPlacementConfig {
+      proto.customPlacementConfig = try customPlacementConfig.toProto()
+    }
+    if let hierarchicalNamespace = self.hierarchicalNamespace {
+      proto.hierarchicalNamespace = try hierarchicalNamespace.toProto()
+    }
+    return proto
+  }
+}
+
+extension StorageLayout.CustomPlacementConfig {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_StorageLayout
+    .CustomPlacementConfig
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    return proto
+  }
+}
+
+extension StorageLayout.HierarchicalNamespace {
+  internal typealias ProtoType = StorageControlProtos.Google_Storage_Control_V2_StorageLayout
+    .HierarchicalNamespace
+
+  internal init(proto: ProtoType) throws {
+    self.init()
+    self.enabled = proto.enabled
+  }
+
+  internal func toProto() throws -> ProtoType {
+    var proto = ProtoType()
+    proto.enabled = self.enabled
     return proto
   }
 }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/StorageLayout+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/StorageLayout+Convert.swift
@@ -59,7 +59,7 @@ extension StorageLayout.CustomPlacementConfig {
   }
 
   internal func toProto() throws -> ProtoType {
-    var proto = ProtoType()
+    let proto = ProtoType()
     return proto
   }
 }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/StorageLayout+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/StorageLayout+Convert.swift
@@ -30,11 +30,9 @@ extension StorageLayout {
     self.location = proto.location
     self.locationType = proto.locationType
     self.customPlacementConfig =
-      proto.hasCustomPlacementConfig
-      ? try StorageLayout.CustomPlacementConfig(proto: proto.customPlacementConfig) : nil
+      proto.hasCustomPlacementConfig ? try .init(proto: proto.customPlacementConfig) : nil
     self.hierarchicalNamespace =
-      proto.hasHierarchicalNamespace
-      ? try StorageLayout.HierarchicalNamespace(proto: proto.hierarchicalNamespace) : nil
+      proto.hasHierarchicalNamespace ? try .init(proto: proto.hierarchicalNamespace) : nil
   }
 
   internal func toProto() throws -> ProtoType {

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/SummarizeIntelligenceFindingsRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/SummarizeIntelligenceFindingsRequest+Convert.swift
@@ -28,8 +28,7 @@ extension SummarizeIntelligenceFindingsRequest {
   internal init(proto: ProtoType) throws {
     self.init()
     self.parent = proto.parent
-    self.resourceScope = SummarizeIntelligenceFindingsRequest.ResourceScope(
-      proto: proto.resourceScope)
+    self.resourceScope = .init(proto: proto.resourceScope)
     self.filter = proto.filter
     self.pageSize = proto.pageSize
     self.pageToken = proto.pageToken

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/SummarizeIntelligenceFindingsRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/SummarizeIntelligenceFindingsRequest+Convert.swift
@@ -28,6 +28,8 @@ extension SummarizeIntelligenceFindingsRequest {
   internal init(proto: ProtoType) throws {
     self.init()
     self.parent = proto.parent
+    self.resourceScope = SummarizeIntelligenceFindingsRequest.ResourceScope(
+      proto: proto.resourceScope)
     self.filter = proto.filter
     self.pageSize = proto.pageSize
     self.pageToken = proto.pageToken
@@ -36,9 +38,48 @@ extension SummarizeIntelligenceFindingsRequest {
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
     proto.parent = self.parent
+    proto.resourceScope = try self.resourceScope.toProto()
     proto.filter = self.filter
     proto.pageSize = self.pageSize
     proto.pageToken = self.pageToken
     return proto
+  }
+}
+
+extension SummarizeIntelligenceFindingsRequest.ResourceScope {
+  internal init(
+    proto: StorageControlProtos.Google_Storage_Control_V2_SummarizeIntelligenceFindingsRequest
+      .ResourceScope
+  ) {
+    switch proto {
+    case .unspecified:
+      self = .unspecified
+    case .parent:
+      self = .parent
+    case .project:
+      self = .project
+    case .UNRECOGNIZED(let val): self = .unknownIntValue(val)
+    }
+  }
+
+  internal func toProto() throws
+    -> StorageControlProtos.Google_Storage_Control_V2_SummarizeIntelligenceFindingsRequest
+    .ResourceScope
+  {
+    switch self {
+    case .unspecified:
+      return .unspecified
+    case .parent:
+      return .parent
+    case .project:
+      return .project
+    case .unknownIntValue(let val):
+      return StorageControlProtos.Google_Storage_Control_V2_SummarizeIntelligenceFindingsRequest
+        .ResourceScope(rawValue: val)
+        ?? .UNRECOGNIZED(val)
+    case .unknownStringValue(let str):
+      throw GoogleCloudGax.ProtobufConversionError.noIntegerValue(
+        enumType: "SummarizeIntelligenceFindingsRequest.ResourceScope", stringValue: str)
+    }
   }
 }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateAnywhereCacheMetadata+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateAnywhereCacheMetadata+Convert.swift
@@ -27,12 +27,10 @@ extension UpdateAnywhereCacheMetadata {
 
   internal init(proto: ProtoType) throws {
     self.init()
-    self.commonMetadata =
-      proto.hasCommonMetadata
-      ? try CommonLongRunningOperationMetadata(proto: proto.commonMetadata) : nil
+    self.commonMetadata = proto.hasCommonMetadata ? try .init(proto: proto.commonMetadata) : nil
     self.anywhereCacheId = proto.hasAnywhereCacheID ? proto.anywhereCacheID : nil
     self.zone = proto.hasZone ? proto.zone : nil
-    self.ttl = proto.hasTtl ? try GoogleCloudWkt.Duration(proto: proto.ttl) : nil
+    self.ttl = proto.hasTtl ? try .init(proto: proto.ttl) : nil
     self.admissionPolicy = proto.hasAdmissionPolicy ? proto.admissionPolicy : nil
   }
 

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateAnywhereCacheMetadata+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateAnywhereCacheMetadata+Convert.swift
@@ -27,15 +27,23 @@ extension UpdateAnywhereCacheMetadata {
 
   internal init(proto: ProtoType) throws {
     self.init()
+    self.commonMetadata =
+      proto.hasCommonMetadata
+      ? try CommonLongRunningOperationMetadata(proto: proto.commonMetadata) : nil
     self.anywhereCacheId = proto.hasAnywhereCacheID ? proto.anywhereCacheID : nil
     self.zone = proto.hasZone ? proto.zone : nil
+    self.ttl = proto.hasTtl ? try GoogleCloudWkt.Duration(proto: proto.ttl) : nil
     self.admissionPolicy = proto.hasAdmissionPolicy ? proto.admissionPolicy : nil
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
+    if let commonMetadata = self.commonMetadata {
+      proto.commonMetadata = try commonMetadata.toProto()
+    }
     if let anywhereCacheId = self.anywhereCacheId { proto.anywhereCacheID = anywhereCacheId }
     if let zone = self.zone { proto.zone = zone }
+    if let ttl = self.ttl { proto.ttl = try ttl.toProto() }
     if let admissionPolicy = self.admissionPolicy { proto.admissionPolicy = admissionPolicy }
     return proto
   }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateAnywhereCacheRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateAnywhereCacheRequest+Convert.swift
@@ -27,10 +27,8 @@ extension UpdateAnywhereCacheRequest {
 
   internal init(proto: ProtoType) throws {
     self.init()
-    self.anywhereCache =
-      proto.hasAnywhereCache ? try AnywhereCache(proto: proto.anywhereCache) : nil
-    self.updateMask =
-      proto.hasUpdateMask ? try GoogleCloudWkt.FieldMask(proto: proto.updateMask) : nil
+    self.anywhereCache = proto.hasAnywhereCache ? try .init(proto: proto.anywhereCache) : nil
+    self.updateMask = proto.hasUpdateMask ? try .init(proto: proto.updateMask) : nil
     self.requestId = proto.requestID
   }
 

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateAnywhereCacheRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateAnywhereCacheRequest+Convert.swift
@@ -27,11 +27,17 @@ extension UpdateAnywhereCacheRequest {
 
   internal init(proto: ProtoType) throws {
     self.init()
+    self.anywhereCache =
+      proto.hasAnywhereCache ? try AnywhereCache(proto: proto.anywhereCache) : nil
+    self.updateMask =
+      proto.hasUpdateMask ? try GoogleCloudWkt.FieldMask(proto: proto.updateMask) : nil
     self.requestId = proto.requestID
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
+    if let anywhereCache = self.anywhereCache { proto.anywhereCache = try anywhereCache.toProto() }
+    if let updateMask = self.updateMask { proto.updateMask = try updateMask.toProto() }
     proto.requestID = self.requestId
     return proto
   }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateFolderIntelligenceConfigRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateFolderIntelligenceConfigRequest+Convert.swift
@@ -28,9 +28,8 @@ extension UpdateFolderIntelligenceConfigRequest {
   internal init(proto: ProtoType) throws {
     self.init()
     self.intelligenceConfig =
-      proto.hasIntelligenceConfig ? try IntelligenceConfig(proto: proto.intelligenceConfig) : nil
-    self.updateMask =
-      proto.hasUpdateMask ? try GoogleCloudWkt.FieldMask(proto: proto.updateMask) : nil
+      proto.hasIntelligenceConfig ? try .init(proto: proto.intelligenceConfig) : nil
+    self.updateMask = proto.hasUpdateMask ? try .init(proto: proto.updateMask) : nil
     self.requestId = proto.requestID
   }
 

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateFolderIntelligenceConfigRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateFolderIntelligenceConfigRequest+Convert.swift
@@ -27,11 +27,19 @@ extension UpdateFolderIntelligenceConfigRequest {
 
   internal init(proto: ProtoType) throws {
     self.init()
+    self.intelligenceConfig =
+      proto.hasIntelligenceConfig ? try IntelligenceConfig(proto: proto.intelligenceConfig) : nil
+    self.updateMask =
+      proto.hasUpdateMask ? try GoogleCloudWkt.FieldMask(proto: proto.updateMask) : nil
     self.requestId = proto.requestID
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
+    if let intelligenceConfig = self.intelligenceConfig {
+      proto.intelligenceConfig = try intelligenceConfig.toProto()
+    }
+    if let updateMask = self.updateMask { proto.updateMask = try updateMask.toProto() }
     proto.requestID = self.requestId
     return proto
   }

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateOrganizationIntelligenceConfigRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateOrganizationIntelligenceConfigRequest+Convert.swift
@@ -28,9 +28,8 @@ extension UpdateOrganizationIntelligenceConfigRequest {
   internal init(proto: ProtoType) throws {
     self.init()
     self.intelligenceConfig =
-      proto.hasIntelligenceConfig ? try IntelligenceConfig(proto: proto.intelligenceConfig) : nil
-    self.updateMask =
-      proto.hasUpdateMask ? try GoogleCloudWkt.FieldMask(proto: proto.updateMask) : nil
+      proto.hasIntelligenceConfig ? try .init(proto: proto.intelligenceConfig) : nil
+    self.updateMask = proto.hasUpdateMask ? try .init(proto: proto.updateMask) : nil
     self.requestId = proto.requestID
   }
 

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateProjectIntelligenceConfigRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateProjectIntelligenceConfigRequest+Convert.swift
@@ -28,9 +28,8 @@ extension UpdateProjectIntelligenceConfigRequest {
   internal init(proto: ProtoType) throws {
     self.init()
     self.intelligenceConfig =
-      proto.hasIntelligenceConfig ? try IntelligenceConfig(proto: proto.intelligenceConfig) : nil
-    self.updateMask =
-      proto.hasUpdateMask ? try GoogleCloudWkt.FieldMask(proto: proto.updateMask) : nil
+      proto.hasIntelligenceConfig ? try .init(proto: proto.intelligenceConfig) : nil
+    self.updateMask = proto.hasUpdateMask ? try .init(proto: proto.updateMask) : nil
     self.requestId = proto.requestID
   }
 

--- a/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateProjectIntelligenceConfigRequest+Convert.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/generated/StorageControl/Convert/StorageControl/UpdateProjectIntelligenceConfigRequest+Convert.swift
@@ -27,11 +27,19 @@ extension UpdateProjectIntelligenceConfigRequest {
 
   internal init(proto: ProtoType) throws {
     self.init()
+    self.intelligenceConfig =
+      proto.hasIntelligenceConfig ? try IntelligenceConfig(proto: proto.intelligenceConfig) : nil
+    self.updateMask =
+      proto.hasUpdateMask ? try GoogleCloudWkt.FieldMask(proto: proto.updateMask) : nil
     self.requestId = proto.requestID
   }
 
   internal func toProto() throws -> ProtoType {
     var proto = ProtoType()
+    if let intelligenceConfig = self.intelligenceConfig {
+      proto.intelligenceConfig = try intelligenceConfig.toProto()
+    }
+    if let updateMask = self.updateMask { proto.updateMask = try updateMask.toProto() }
     proto.requestID = self.requestId
     return proto
   }

--- a/packages/storage/Tests/ConversionTests.swift
+++ b/packages/storage/Tests/ConversionTests.swift
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 import GoogleCloudGax
-@testable import GoogleCloudStorage
+import GoogleCloudWkt
+import GoogleType
 import StorageControlProtos
 import Testing
+@testable import GoogleCloudStorage
 
 @Suite struct ConversionTests {
   @Test func findingCategoryKnownValueRoundtrip() throws {
@@ -63,5 +65,89 @@ import Testing
 
     let roundtripped = try PendingRenameInfo(proto: proto)
     #expect(original == roundtripped)
+  }
+
+  @Test func getFolderRequestOptionalPresence() throws {
+    // 1. All optional fields nil
+    var request = GetFolderRequest().with {
+      $0.name = "projects/_/buckets/b/folders/f"
+    }
+    var proto = try request.toProto()
+    #expect(proto.name == "projects/_/buckets/b/folders/f")
+    #expect(!proto.hasIfMetagenerationMatch)
+    #expect(!proto.hasIfMetagenerationNotMatch)
+
+    var roundtripped = try GetFolderRequest(proto: proto)
+    #expect(roundtripped.ifMetagenerationMatch == nil)
+    #expect(roundtripped.ifMetagenerationNotMatch == nil)
+
+    // 2. Optional fields set
+    request = GetFolderRequest().with {
+      $0.name = "projects/_/buckets/b/folders/f"
+      $0.ifMetagenerationMatch = 123
+      $0.ifMetagenerationNotMatch = 456
+    }
+    proto = try request.toProto()
+    #expect(proto.ifMetagenerationMatch == 123)
+    #expect(proto.ifMetagenerationNotMatch == 456)
+
+    roundtripped = try GetFolderRequest(proto: proto)
+    #expect(roundtripped.ifMetagenerationMatch == 123)
+    #expect(roundtripped.ifMetagenerationNotMatch == 456)
+  }
+
+  @Test func folderNestedMessageAndWkt() throws {
+    let timestamp = try GoogleCloudWkt.Timestamp(seconds: 12345, nanos: 6789)
+
+    // 1. Nested message and timestamps set
+    let renameInfo = PendingRenameInfo().with {
+      $0.operation = "op"
+    }
+    let folder = Folder().with {
+      $0.name = "my-folder"
+      $0.createTime = timestamp
+      $0.pendingRenameInfo = renameInfo
+    }
+
+    let proto = try folder.toProto()
+    #expect(proto.name == "my-folder")
+    #expect(proto.hasCreateTime)
+    #expect(proto.hasPendingRenameInfo)
+
+    let roundtripped = try Folder(proto: proto)
+    #expect(roundtripped.name == "my-folder")
+    #expect(roundtripped.createTime == timestamp)
+    #expect(roundtripped.pendingRenameInfo == renameInfo)
+
+    // 2. Nested message and timestamps nil
+    let folderNil = Folder().with {
+      $0.name = "my-folder"
+    }
+    let protoNil = try folderNil.toProto()
+    #expect(!protoNil.hasCreateTime)
+    #expect(!protoNil.hasPendingRenameInfo)
+
+    let roundtrippedNil = try Folder(proto: protoNil)
+    #expect(roundtrippedNil.createTime == nil)
+    #expect(roundtrippedNil.pendingRenameInfo == nil)
+  }
+
+  @Test func googleTypeInterval() throws {
+    let startTime = try GoogleCloudWkt.Timestamp(seconds: 12345, nanos: 6789)
+    let endTime = try GoogleCloudWkt.Timestamp(seconds: 18134, nanos: 6789)
+
+    let interval = GoogleType.Interval().with {
+      $0.startTime = startTime
+      $0.endTime = endTime
+    }
+
+    let proto = try interval.toProto()
+    #expect(proto.hasStartTime)
+    #expect(proto.hasEndTime)
+    #expect(proto.startTime.seconds == startTime.seconds)
+
+    let roundtripped = try GoogleType.Interval(proto: proto)
+    #expect(roundtripped.startTime == startTime)
+    #expect(roundtripped.endTime == endTime)
   }
 }


### PR DESCRIPTION
Regenerate StorageControl conversion extensions to support optional presence checks, nested message fields, Well-Known Types (Timestamp), and GoogleType.Interval.

- Configured google/type module output path in librarian.yaml.
- Regenerated all StorageControl conversion extensions under Sources/GoogleCloudStorage/generated/.
- Added unit tests in ConversionTests.swift covering GetFolderRequest optional presence, Folder nested message & WKT mappings, and GoogleType.Interval roundtrip conversions.