### PR TITLE
fix(storage): set content-range headers correctly for streaming sources of unknown length

### DIFF
--- a/packages/storage/Sources/GoogleCloudStorage/ChecksummedSource.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/ChecksummedSource.swift
@@ -103,41 +103,44 @@ struct ChecksummedSource<S: UploadSource> {
 
     var checksumStr: String? = nil
     if isLast {
-      var parts = [String]()
-
-      if let crcOption = options.crc32c {
-        switch crcOption {
-        case .auto:
-          let bigEndian = crc32c.finalize().bigEndian
-          var bytes = [UInt8]()
-          withUnsafeBytes(of: bigEndian) {
-            bytes = Array($0)
-          }
-          parts.append("crc32c=" + Data(bytes).base64EncodedString())
-        case .value(let val):
-          let formatted = val.hasPrefix("crc32c=") ? val : "crc32c=" + val
-          parts.append(formatted)
-        }
-      }
-
-      if let md5Option = options.md5 {
-        switch md5Option {
-        case .auto:
-          let digest = md5.finalize()
-          parts.append("md5=" + Data(digest).base64EncodedString())
-        case .value(let val):
-          let formatted = val.hasPrefix("md5=") ? val : "md5=" + val
-          parts.append(formatted)
-        }
-      }
-
-      if !parts.isEmpty {
-        checksumStr = parts.joined(separator: ", ")
-      }
-      isFinished = true
+      checksumStr = finalizeChecksum()
     }
 
     return ChunkInfo(data: currentChunk, isLast: isLast, checksum: checksumStr)
+  }
+
+  mutating func finalizeChecksum() -> String? {
+    guard !isFinished else { return nil }
+    isFinished = true
+    var parts = [String]()
+
+    if let crcOption = options.crc32c {
+      switch crcOption {
+      case .auto:
+        let bigEndian = crc32c.finalize().bigEndian
+        var bytes = [UInt8]()
+        withUnsafeBytes(of: bigEndian) {
+          bytes = Array($0)
+        }
+        parts.append("crc32c=" + Data(bytes).base64EncodedString())
+      case .value(let val):
+        let formatted = val.hasPrefix("crc32c=") ? val : "crc32c=" + val
+        parts.append(formatted)
+      }
+    }
+
+    if let md5Option = options.md5 {
+      switch md5Option {
+      case .auto:
+        let digest = md5.finalize()
+        parts.append("md5=" + Data(digest).base64EncodedString())
+      case .value(let val):
+        let formatted = val.hasPrefix("md5=") ? val : "md5=" + val
+        parts.append(formatted)
+      }
+    }
+
+    return parts.isEmpty ? nil : parts.joined(separator: ", ")
   }
 }
 

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -153,18 +153,24 @@ extension StorageClient {
     continuation: AsyncStream<UploadStatus>.Continuation
   ) async throws -> StorageObject {
     var offset = offset
+    var chunksSent = 0
     while true {
       guard let chunkInfo = try await checksummedSource.readChunk(maxBytes: chunkSize),
         !chunkInfo.data.isEmpty
       else {
         break
       }
+      chunksSent += 1
       let chunk = chunkInfo.data
       let isLast = chunkInfo.isLast
       let checksum = isLast ? chunkInfo.checksum : nil
 
+      let effectiveTotalSize =
+        (isLast && totalSize == nil) ? (offset + Int64(chunk.count)) : totalSize
+
       let uploadRequest = try await httpClient.buildUploadChunkRequest(
-        uploadId: uploadId, data: chunk, offset: offset, totalSize: totalSize, options: options,
+        uploadId: uploadId, data: chunk, offset: offset, totalSize: effectiveTotalSize,
+        options: options,
         checksum: checksum)
       let (uploadData, uploadResponse) = try await httpClient.data(for: uploadRequest)
 
@@ -174,7 +180,7 @@ extension StorageClient {
         continuation.yield(
           UploadStatus(
             bytesUploaded: offset + Int64(chunk.count),
-            totalBytes: totalSize, uploadId: uploadId))
+            totalBytes: effectiveTotalSize, uploadId: uploadId))
         return object
       } else if uploadResponse.statusCode == 308 {
         if let rangeHeader = uploadResponse.value(forHTTPHeaderField: "Range") {
@@ -188,6 +194,19 @@ extension StorageClient {
       } else {
         _ = try httpClient.handleObjectResponse(data: uploadData, response: uploadResponse)
       }
+    }
+
+    if chunksSent == 0 && offset == 0 {
+      let uploadRequest = try await httpClient.buildUploadChunkRequest(
+        uploadId: uploadId, data: Data(), offset: 0, totalSize: totalSize ?? 0, options: options,
+        checksum: nil)
+      let (uploadData, uploadResponse) = try await httpClient.data(for: uploadRequest)
+      let object = try httpClient.handleObjectResponse(
+        data: uploadData, response: uploadResponse)
+      continuation.yield(
+        UploadStatus(
+          bytesUploaded: 0, totalBytes: totalSize ?? 0, uploadId: uploadId))
+      return object
     }
 
     throw UploadError.internalError("Upload completed but object not returned")
@@ -470,9 +489,13 @@ extension HTTPClient {
 
     request.applyCustomerSuppliedEncryptionHeaders(options.customerEncryptionKey)
 
-    let end = offset + Int64(data.count) - 1
     let totalStr = totalSize.map { String($0) } ?? "*"
-    request.setValue("bytes \(offset)-\(end)/\(totalStr)", forHTTPHeaderField: "Content-Range")
+    if data.isEmpty {
+      request.setValue("bytes */\(totalStr)", forHTTPHeaderField: "Content-Range")
+    } else {
+      let end = offset + Int64(data.count) - 1
+      request.setValue("bytes \(offset)-\(end)/\(totalStr)", forHTTPHeaderField: "Content-Range")
+    }
     request.httpBody = data
     return request
   }

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -196,20 +196,19 @@ extension StorageClient {
       }
     }
 
-    if chunksSent == 0 && offset == 0 {
-      let uploadRequest = try await httpClient.buildUploadChunkRequest(
-        uploadId: uploadId, data: Data(), offset: 0, totalSize: totalSize ?? 0, options: options,
-        checksum: nil)
-      let (uploadData, uploadResponse) = try await httpClient.data(for: uploadRequest)
-      let object = try httpClient.handleObjectResponse(
-        data: uploadData, response: uploadResponse)
-      continuation.yield(
-        UploadStatus(
-          bytesUploaded: 0, totalBytes: totalSize ?? 0, uploadId: uploadId))
-      return object
-    }
-
-    throw UploadError.internalError("Upload completed but object not returned")
+    // Finalize upload with an empty chunk if the stream finished without returning an object
+    let finalTotalSize = totalSize ?? offset
+    let checksum = checksummedSource.finalizeChecksum()
+    let uploadRequest = try await httpClient.buildUploadChunkRequest(
+      uploadId: uploadId, data: Data(), offset: offset, totalSize: finalTotalSize, options: options,
+      checksum: checksum)
+    let (uploadData, uploadResponse) = try await httpClient.data(for: uploadRequest)
+    let object = try httpClient.handleObjectResponse(
+      data: uploadData, response: uploadResponse)
+    continuation.yield(
+      UploadStatus(
+        bytesUploaded: offset, totalBytes: finalTotalSize, uploadId: uploadId))
+    return object
   }
 
   fileprivate static func continueResumableUpload<S: UploadSource>(

--- a/packages/storage/Sources/GoogleCloudStorage/UploadSource.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/UploadSource.swift
@@ -106,27 +106,35 @@ public struct BytesSource: SeekableUploadSource {
 }
 
 /// An upload source that wraps an arbitrary AsyncSequence of Data chunks.
-public struct StreamSource<S: AsyncSequence>: UploadSource
-where S.Element == Data, S: Sendable, S.AsyncIterator: Sendable {
-  public var totalSize: Int64? { return nil }
-  private var iterator: S.AsyncIterator?
+public struct StreamSource<S: AsyncSequence>: UploadSource where S.Element == Data, S: Sendable {
+  private final class IteratorBox: @unchecked Sendable {
+    var iterator: S.AsyncIterator?
+
+    init(iterator: S.AsyncIterator) {
+      self.iterator = iterator
+    }
+  }
+
+  public var totalSize: Int64? { return totalSizeValue }
+  private let totalSizeValue: Int64?
+  private let box: IteratorBox
   private var buffer = Data()
 
-  public init(sequence: S) {
-    self.iterator = sequence.makeAsyncIterator()
+  public init(sequence: S, totalSize: Int64? = nil) {
+    self.box = IteratorBox(iterator: sequence.makeAsyncIterator())
+    self.totalSizeValue = totalSize
   }
 
   public mutating func read(maxBytes: Int) async throws -> Data? {
     while buffer.count < maxBytes {
-      guard var iterator = self.iterator else {
+      guard box.iterator != nil else {
         break
       }
-      guard let nextChunk = try await iterator.next() else {
-        self.iterator = nil
+      guard let nextChunk = try await box.iterator?.next() else {
+        box.iterator = nil
         break
       }
       buffer.append(nextChunk)
-      self.iterator = iterator
     }
 
     guard !buffer.isEmpty else {

--- a/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -555,6 +555,78 @@ import Testing
 
       print("Upload with metadata successful: \(object)")
     }
+
+    @Test func testDynamicSourceCompletelyEmptyUpload() async throws {
+      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
+        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
+        return
+      }
+      let bucketName =
+        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
+      let objectName = "test-dynamic-empty-\(UUID().uuidString).bin"
+
+      let source = IntegrationDynamicSource(
+        chunkSize: 4 * 1024 * 1024, totalChunks: 0, totalSize: nil)
+
+      let storage = try StorageClient()
+      let task = storage.upload(source, to: bucketName, as: objectName)
+
+      let object = try await task.value
+      #expect(object.bucket == bucketName)
+      #expect(object.name == objectName)
+      #expect(object.size == 0)
+
+      print("Dynamic source completely empty upload successful: \(object)")
+    }
+
+    @Test func testDynamicSourceLastChunkEmptyUpload() async throws {
+      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
+        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
+        return
+      }
+      let bucketName =
+        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
+      let objectName = "test-dynamic-last-chunk-empty-\(UUID().uuidString).bin"
+
+      let chunkSize = 5 * 1024 * 1024  // 5MB chunks
+      let totalChunks = 2
+      let expectedTotalSize = Int64(chunkSize * totalChunks)  // 10MB
+
+      let source = IntegrationDynamicSource(
+        chunkSize: chunkSize, totalChunks: totalChunks, totalSize: nil)
+
+      let storage = try StorageClient()
+      let options = UploadOptions().with { $0.chunkSize = chunkSize }
+      let task = storage.upload(source, to: bucketName, as: objectName, options: options)
+
+      let object = try await task.value
+      #expect(object.bucket == bucketName)
+      #expect(object.name == objectName)
+      #expect(object.size == expectedTotalSize)
+
+      print("Dynamic source with last chunk empty upload successful: \(object)")
+    }
+  }
+
+  private struct IntegrationDynamicSource: UploadSource {
+    let chunkSize: Int
+    let totalChunks: Int
+    let totalSize: Int64?
+    private var currentChunk: Int = 0
+
+    init(chunkSize: Int, totalChunks: Int, totalSize: Int64? = nil) {
+      self.chunkSize = chunkSize
+      self.totalChunks = totalChunks
+      self.totalSize = totalSize
+    }
+
+    mutating func read(maxBytes: Int) async throws -> Data? {
+      guard currentChunk < totalChunks else { return nil }
+      let count = min(maxBytes, chunkSize)
+      let byteVal = UInt8((currentChunk + 1) % 256)
+      currentChunk += 1
+      return Data(repeating: byteVal, count: count)
+    }
   }
 
   private struct FailingUploadSource: SeekableUploadSource {

--- a/packages/storage/Tests/ResumableUploadTests.swift
+++ b/packages/storage/Tests/ResumableUploadTests.swift
@@ -1288,6 +1288,76 @@ import Testing
     #expect(requests.count == 2)
     #expect(requests[1].value(forHTTPHeaderField: "Content-Range") == "bytes */0")
   }
+
+  /// Tests resumable upload with unknown total size (`totalSize == nil`), where data chunks are sent
+  /// with unknown total size (`*`), and the stream finishes with an empty final chunk specifying the final total size (`Content-Range: bytes */TOTAL`).
+  @Test func resumableUploadUnknownSizeStreamWithEmptyFinalChunkSuccess() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "async-stream-empty-final-chunk"
+    let chunk1 = Data(repeating: 0x11, count: 5 * 1024 * 1024)
+    let chunk2 = Data(repeating: 0x22, count: 5 * 1024 * 1024)
+    let expectedTotalSize = Int64(chunk1.count + chunk2.count)  // 10MB
+
+    let asyncStream = makeAsyncStream(chunks: [chunk1, chunk2, Data()])
+    let source = StreamSource(sequence: asyncStream)
+
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?upload_id=async-stream-empty-final-id")
+
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+    // Chunk 1 (5MB) -> 308
+    registry.register(
+      response: .success(
+        statusCode: 308, data: Data(),
+        headers: ["Range": "bytes=0-\(chunk1.count - 1)"]),
+      for: chunkUrl)
+    // Chunk 2 (5MB) -> 308
+    registry.register(
+      response: .success(
+        statusCode: 308, data: Data(),
+        headers: ["Range": "bytes=0-\(expectedTotalSize - 1)"]),
+      for: chunkUrl)
+    // Final empty chunk (0 bytes) specifying final total size -> 200 OK
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: makeObjectJSON(name: objectName, bucket: bucket, size: Int(expectedTotalSize)),
+        headers: nil),
+      for: chunkUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+
+    let uploadOptions = UploadOptions().with { $0.chunkSize = 5 * 1024 * 1024 }
+    let client = try StorageClient(options)
+    let task = client.upload(source, to: bucket, as: objectName, options: uploadOptions)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
+    #expect(object.size == expectedTotalSize)
+
+    let requests = registry.recordedRequests()
+    #expect(requests.count >= 2)
+    #expect(
+      requests.last?.value(forHTTPHeaderField: "Content-Range") == "bytes */\(expectedTotalSize)")
+  }
 }
 
 // MARK: - Test Helper Sources

--- a/packages/storage/Tests/ResumableUploadTests.swift
+++ b/packages/storage/Tests/ResumableUploadTests.swift
@@ -761,38 +761,76 @@ import Testing
       chunkReq.value(forHTTPHeaderField: "x-goog-encryption-key-sha256") == sample.keyHashBase64)
   }
 
-  /// Tests resuming an upload from an intermediate offset when user provided a pre-computed checksum.
-  /// The user-provided checksum MUST be attached to the final chunk PUT request.
-  @Test func testResumeUploadWithUserProvidedChecksum() async throws {
+  // MARK: - Upload Source Types Unit Tests
+
+  // --- Source Type 1: Fixed Buffers in Memory ---
+
+  /// Tests resumable upload using a fixed buffer in memory (`BytesSource`).
+  @Test func resumableUploadFixedBufferMemorySuccess() async throws {
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
-    let objectName = "test-object"
-    let data = Data(repeating: 1, count: 1 * 1024 * 1024)  // 1MB payload
+    let objectName = "fixed-buffer-object"
+    let data = Data(repeating: 0xAB, count: 10 * 1024 * 1024)  // 10MB
     let source = BytesSource(data: data)
 
-    let queryUrl = registry.url(
-      "/upload/storage/v1/b/\(bucket)/o?upload_id=user-checksum-upload-id")
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=fixed-buffer-id")
 
-    let objectJSON = """
-      {
-        "name": "\(objectName)",
-        "bucket": "\(bucket)",
-        "generation": "1",
-        "metageneration": "1",
-        "size": "\(data.count)",
-        "contentType": "application/octet-stream",
-        "storageClass": "STANDARD"
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+    registry.register(
+      response: .success(
+        statusCode: 200, data: makeObjectJSON(name: objectName, bucket: bucket, size: data.count),
+        headers: nil),
+      for: chunkUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
-      """
+    }
+
+    let client = try StorageClient(options)
+    let task = client.upload(source, to: bucket, as: objectName)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
+    #expect(object.size == Int64(data.count))
+  }
+
+  /// Tests resuming an interrupted upload for a fixed buffer in memory (`BytesSource`).
+  @Test func resumeUploadFixedBufferMemorySuccess() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "fixed-buffer-resumed"
+    let data = Data(repeating: 0xCD, count: 10 * 1024 * 1024)  // 10MB
+    let source = BytesSource(data: data)
+
+    let queryUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=fixed-buffer-resume-id")
+
+    // GCS reports 5MB uploaded (bytes 0-5242879 received)
+    let offset: Int64 = 5 * 1024 * 1024
+    let lastByte = offset - 1
 
     registry.register(
       response: .success(
         statusCode: 308, data: Data(),
-        headers: ["Range": "bytes=0-4999"]),
+        headers: ["Range": "bytes=0-\(lastByte)"]),
       for: queryUrl)
     registry.register(
       response: .success(
-        statusCode: 200, data: Data(objectJSON.utf8),
+        statusCode: 200, data: makeObjectJSON(name: objectName, bucket: bucket, size: data.count),
         headers: nil),
       for: queryUrl)
 
@@ -809,11 +847,7 @@ import Testing
     }
 
     let client = try StorageClient(options)
-    let uploadOptions = UploadOptions().with {
-      $0.checksums = ChecksumOptions(crc32c: "AAAAAA==")
-    }
-    let task = client.resumeUpload(
-      source, uploadId: queryUrl.absoluteString, options: uploadOptions)
+    let task = client.resumeUpload(source, uploadId: queryUrl.absoluteString)
     let object = try await task.value
 
     #expect(object.name == objectName)
@@ -821,42 +855,93 @@ import Testing
 
     let requests = registry.recordedRequests()
     #expect(requests.count == 2)
-    let finalChunkReq = requests[1]
-    #expect(finalChunkReq.value(forHTTPHeaderField: "x-goog-hash") == "crc32c=AAAAAA==")
+    // First is status query
+    #expect(requests[0].value(forHTTPHeaderField: "Content-Range") == "bytes */*")
+    // Second is remaining chunk request starting at 5MB
+    #expect(
+      requests[1].value(forHTTPHeaderField: "Content-Range")
+        == "bytes \(offset)-\(data.count - 1)/\(data.count)")
   }
 
-  /// Tests resuming an upload from an intermediate offset with automatic checksumming.
-  /// The SDK automatically calculates full-file checksum and attaches x-goog-hash header.
-  @Test func testResumeUploadWithAutoChecksumFromOffset() async throws {
+  // --- Source Type 2: Files from Disk ---
+
+  /// Tests resumable upload reading directly from a local file on disk (`FileSource`).
+  @Test func resumableUploadFileFromDiskSuccess() async throws {
+    let tempDirectory = FileManager.default.temporaryDirectory
+    let fileURL = tempDirectory.appendingPathComponent("test_disk_upload_\(UUID().uuidString).dat")
+    let data = Data(repeating: 0xEF, count: 10 * 1024 * 1024)  // 10MB file
+    try data.write(to: fileURL)
+    defer {
+      try? FileManager.default.removeItem(at: fileURL)
+    }
+
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
-    let objectName = "test-object"
-    let data = Data(repeating: 1, count: 1 * 1024 * 1024)
-    let source = BytesSource(data: data)
+    let objectName = "file-from-disk-object"
+    let source = FileSource(fileURL: fileURL)
 
-    let queryUrl = registry.url(
-      "/upload/storage/v1/b/\(bucket)/o?upload_id=auto-checksum-upload-id")
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=disk-file-id")
 
-    let objectJSON = """
-      {
-        "name": "\(objectName)",
-        "bucket": "\(bucket)",
-        "generation": "1",
-        "metageneration": "1",
-        "size": "\(data.count)",
-        "contentType": "application/octet-stream",
-        "storageClass": "STANDARD"
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+    registry.register(
+      response: .success(
+        statusCode: 200, data: makeObjectJSON(name: objectName, bucket: bucket, size: data.count),
+        headers: nil),
+      for: chunkUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
-      """
+    }
+
+    let client = try StorageClient(options)
+    let task = client.upload(source, to: bucket, as: objectName)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
+    #expect(object.size == Int64(data.count))
+  }
+
+  /// Tests resuming an interrupted upload from a local file on disk (`FileSource`), seeking within the file.
+  @Test func resumeUploadFileFromDiskSuccess() async throws {
+    let tempDirectory = FileManager.default.temporaryDirectory
+    let fileURL = tempDirectory.appendingPathComponent("test_disk_resume_\(UUID().uuidString).dat")
+    let data = Data(repeating: 0x42, count: 10 * 1024 * 1024)  // 10MB file
+    try data.write(to: fileURL)
+    defer {
+      try? FileManager.default.removeItem(at: fileURL)
+    }
+
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "file-from-disk-resumed"
+    let source = FileSource(fileURL: fileURL)
+
+    let queryUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=disk-file-resume-id")
+    let resumeOffset: Int64 = 4 * 1024 * 1024  // GCS already received 4MB
 
     registry.register(
       response: .success(
         statusCode: 308, data: Data(),
-        headers: ["Range": "bytes=0-4999"]),
+        headers: ["Range": "bytes=0-\(resumeOffset - 1)"]),
       for: queryUrl)
     registry.register(
       response: .success(
-        statusCode: 200, data: Data(objectJSON.utf8),
+        statusCode: 200, data: makeObjectJSON(name: objectName, bucket: bucket, size: data.count),
         headers: nil),
       for: queryUrl)
 
@@ -873,52 +958,161 @@ import Testing
     }
 
     let client = try StorageClient(options)
-    let uploadOptions = UploadOptions().with {
-      $0.checksums = ChecksumOptions(crc32c: .auto)
-    }
-    let task = client.resumeUpload(
-      source, uploadId: queryUrl.absoluteString, options: uploadOptions)
+    let task = client.resumeUpload(source, uploadId: queryUrl.absoluteString)
     let object = try await task.value
 
     #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
 
     let requests = registry.recordedRequests()
     #expect(requests.count == 2)
-    let finalChunkReq = requests[1]
-    #expect(finalChunkReq.value(forHTTPHeaderField: "x-goog-hash") != nil)
+    #expect(
+      requests[1].value(forHTTPHeaderField: "Content-Range")
+        == "bytes \(resumeOffset)-\(data.count - 1)/\(data.count)")
   }
 
-  /// Tests resuming an upload from offset 0 with automatic on-the-fly checksumming.
-  /// Because the stream starts at byte 0, the auto checksum MUST be attached to the final chunk PUT request.
-  @Test func testResumeUploadFromOffsetZeroWithAutoChecksum() async throws {
+  // --- Source Type 3: Dynamically Created Data via Computation ---
+
+  /// Tests resumable upload of data generated dynamically on-the-fly via computation with a known total size.
+  @Test func resumableUploadDynamicComputationKnownSizeSuccess() async throws {
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
-    let objectName = "test-object"
-    let data = Data(repeating: 1, count: 1 * 1024 * 1024)
-    let source = BytesSource(data: data)
+    let objectName = "dynamic-computation-known"
+    let chunkSize = 4 * 1024 * 1024
+    let totalChunks = 3
+    let totalSize = Int64(chunkSize * totalChunks)  // 12MB
 
-    let queryUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=zero-offset-upload-id")
+    let source = DynamicComputationSource(
+      chunkSize: chunkSize, totalChunks: totalChunks, totalSize: totalSize)
 
-    let objectJSON = """
-      {
-        "name": "\(objectName)",
-        "bucket": "\(bucket)",
-        "generation": "1",
-        "metageneration": "1",
-        "size": "\(data.count)",
-        "contentType": "application/octet-stream",
-        "storageClass": "STANDARD"
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=dynamic-comp-known-id")
+
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: makeObjectJSON(name: objectName, bucket: bucket, size: Int(totalSize)),
+        headers: nil),
+      for: chunkUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
       }
-      """
+    }
+
+    let client = try StorageClient(options)
+    let task = client.upload(source, to: bucket, as: objectName)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
+    #expect(object.size == totalSize)
+  }
+
+  /// Tests resumable upload of dynamically computed data where total size is unknown (`nil`).
+  @Test func resumableUploadDynamicComputationUnknownSizeSuccess() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "dynamic-computation-unknown"
+    let chunkSize = 4 * 1024 * 1024
+    let totalChunks = 2
+    let expectedTotalSize: Int64 = Int64(chunkSize * totalChunks)  // 8MB
+
+    let source = DynamicComputationSource(
+      chunkSize: chunkSize, totalChunks: totalChunks, totalSize: nil)
+
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?upload_id=dynamic-comp-unknown-id")
+
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+    // Chunk 1 (intermediate chunk -> 308)
+    registry.register(
+      response: .success(
+        statusCode: 308, data: Data(),
+        headers: ["Range": "bytes=0-\(chunkSize - 1)"]),
+      for: chunkUrl)
+    // Chunk 2 (final chunk -> 200 OK)
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: makeObjectJSON(name: objectName, bucket: bucket, size: Int(expectedTotalSize)),
+        headers: nil),
+      for: chunkUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+
+    let uploadOptions = UploadOptions().with { $0.chunkSize = chunkSize }
+    let client = try StorageClient(options)
+    let task = client.upload(source, to: bucket, as: objectName, options: uploadOptions)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
+    #expect(object.size == expectedTotalSize)
+
+    let requests = registry.recordedRequests()
+    #expect(requests.count == 3)
+    // Request 0 is start resumable
+    // Request 1 is chunk 1 (intermediate, total length *)
+    #expect(requests[1].value(forHTTPHeaderField: "Content-Range") == "bytes 0-\(chunkSize - 1)/*")
+    // Request 2 is chunk 2 (final chunk, specifies final total length)
+    #expect(
+      requests[2].value(forHTTPHeaderField: "Content-Range")
+        == "bytes \(chunkSize)-\(expectedTotalSize - 1)/\(expectedTotalSize)")
+  }
+
+  /// Tests resuming an interrupted upload for a seekable computational source.
+  @Test func resumeUploadDynamicComputationSeekableSuccess() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "dynamic-computation-seekable-resumed"
+    let chunkSize = 4 * 1024 * 1024
+    let totalChunks = 3
+    let totalSize = Int64(chunkSize * totalChunks)  // 12MB
+
+    let source = SeekableComputationSource(chunkSize: chunkSize, totalChunks: totalChunks)
+
+    let queryUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=dynamic-seek-resume-id")
+    let resumeOffset: Int64 = Int64(chunkSize)  // 4MB already received
 
     registry.register(
       response: .success(
         statusCode: 308, data: Data(),
-        headers: [:]),
+        headers: ["Range": "bytes=0-\(resumeOffset - 1)"]),
       for: queryUrl)
     registry.register(
       response: .success(
-        statusCode: 200, data: Data(objectJSON.utf8),
+        statusCode: 200,
+        data: makeObjectJSON(name: objectName, bucket: bucket, size: Int(totalSize)),
         headers: nil),
       for: queryUrl)
 
@@ -935,18 +1129,233 @@ import Testing
     }
 
     let client = try StorageClient(options)
-    let uploadOptions = UploadOptions().with {
-      $0.checksums = ChecksumOptions(crc32c: .auto)
-    }
-    let task = client.resumeUpload(
-      source, uploadId: queryUrl.absoluteString, options: uploadOptions)
+    let task = client.resumeUpload(source, uploadId: queryUrl.absoluteString)
     let object = try await task.value
 
     #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
+    #expect(object.size == totalSize)
+  }
+
+  // --- Source Type 4: Data Received Asynchronously from External Source (e.g. Download) ---
+
+  /// Tests resumable upload of data received asynchronously via `AsyncStream<Data>` with unknown total size (`nil`).
+  @Test func resumableUploadAsyncStreamUnknownSizeSuccess() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "async-download-stream-unknown"
+    let chunk1 = Data(repeating: 0x11, count: 5 * 1024 * 1024)
+    let chunk2 = Data(repeating: 0x22, count: 5 * 1024 * 1024)
+    let expectedTotalSize = Int64(chunk1.count + chunk2.count)
+
+    let asyncStream = makeAsyncStream(chunks: [chunk1, chunk2])
+    let source = StreamSource(sequence: asyncStream)
+
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?upload_id=async-download-unknown-id")
+
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: makeObjectJSON(name: objectName, bucket: bucket, size: Int(expectedTotalSize)),
+        headers: nil),
+      for: chunkUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+
+    let client = try StorageClient(options)
+    let task = client.upload(source, to: bucket, as: objectName)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
+    #expect(object.size == expectedTotalSize)
+  }
+
+  /// Tests resumable upload of data received asynchronously via `AsyncStream<Data>` with a known total size.
+  @Test func resumableUploadAsyncStreamKnownSizeSuccess() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "async-download-stream-known"
+    let chunk1 = Data(repeating: 0x33, count: 5 * 1024 * 1024)
+    let chunk2 = Data(repeating: 0x44, count: 5 * 1024 * 1024)
+    let totalSize = Int64(chunk1.count + chunk2.count)  // 10MB
+
+    let asyncStream = makeAsyncStream(chunks: [chunk1, chunk2])
+    let source = StreamSource(sequence: asyncStream, totalSize: totalSize)
+
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?upload_id=async-download-known-id")
+
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: makeObjectJSON(name: objectName, bucket: bucket, size: Int(totalSize)),
+        headers: nil),
+      for: chunkUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+
+    let client = try StorageClient(options)
+    let task = client.upload(source, to: bucket, as: objectName)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
+    #expect(object.size == totalSize)
+  }
+
+  /// Tests resumable upload of an empty asynchronous stream (0 bytes).
+  @Test func resumableUploadAsyncStreamEmptyStreamSuccess() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "async-download-empty"
+
+    let asyncStream = makeAsyncStream(chunks: [])
+    let source = StreamSource(sequence: asyncStream)
+
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?upload_id=async-download-empty-id")
+
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+    registry.register(
+      response: .success(
+        statusCode: 200, data: makeObjectJSON(name: objectName, bucket: bucket, size: 0),
+        headers: nil),
+      for: chunkUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+
+    let client = try StorageClient(options)
+    let task = client.upload(source, to: bucket, as: objectName)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
+    #expect(object.size == 0)
 
     let requests = registry.recordedRequests()
     #expect(requests.count == 2)
-    let finalChunkReq = requests[1]
-    #expect(finalChunkReq.value(forHTTPHeaderField: "x-goog-hash") != nil)
+    #expect(requests[1].value(forHTTPHeaderField: "Content-Range") == "bytes */0")
+  }
+}
+
+// MARK: - Test Helper Sources
+
+/// A non-seekable computational upload source generating deterministic bytes on-demand.
+private struct DynamicComputationSource: UploadSource {
+  let chunkSize: Int
+  let totalChunks: Int
+  let totalSize: Int64?
+  private var currentChunk: Int = 0
+
+  init(chunkSize: Int, totalChunks: Int, totalSize: Int64?) {
+    self.chunkSize = chunkSize
+    self.totalChunks = totalChunks
+    self.totalSize = totalSize
+  }
+
+  mutating func read(maxBytes: Int) async throws -> Data? {
+    guard currentChunk < totalChunks else { return nil }
+    let count = min(maxBytes, chunkSize)
+    let byteVal = UInt8((currentChunk + 1) % 256)
+    currentChunk += 1
+    return Data(repeating: byteVal, count: count)
+  }
+}
+
+/// A seekable computational upload source that can re-initialize its generator to any offset.
+private struct SeekableComputationSource: SeekableUploadSource {
+  let chunkSize: Int
+  let totalChunks: Int
+  let totalSize: Int64?
+  private var currentOffset: Int64 = 0
+
+  init(chunkSize: Int, totalChunks: Int) {
+    self.chunkSize = chunkSize
+    self.totalChunks = totalChunks
+    self.totalSize = Int64(chunkSize * totalChunks)
+  }
+
+  mutating func read(maxBytes: Int) async throws -> Data? {
+    guard let totalSize = totalSize, currentOffset < totalSize else { return nil }
+    let bytesToRead = min(Int64(maxBytes), totalSize - currentOffset)
+    guard bytesToRead > 0 else { return nil }
+    let chunkIndex = Int(currentOffset / Int64(chunkSize))
+    let byteVal = UInt8((chunkIndex + 1) % 256)
+    currentOffset += bytesToRead
+    return Data(repeating: byteVal, count: Int(bytesToRead))
+  }
+
+  mutating func seek(to offset: Int64) async throws {
+    guard offset >= 0, let total = totalSize, offset <= total else {
+      throw UploadError.localSourceTooSmall(localSize: totalSize ?? 0, gcsOffset: offset)
+    }
+    self.currentOffset = offset
+  }
+}
+
+/// Helper function to create an `AsyncStream<Data>` with asynchronous yielding.
+private func makeAsyncStream(chunks: [Data], delayNanoseconds: UInt64 = 1_000_000) -> AsyncStream<
+  Data
+> {
+  AsyncStream { continuation in
+    Task {
+      for chunk in chunks {
+        try? await Task.sleep(nanoseconds: delayNanoseconds)
+        continuation.yield(chunk)
+      }
+      continuation.finish()
+    }
   }
 }

--- a/packages/storage/Tests/ResumableUploadTests.swift
+++ b/packages/storage/Tests/ResumableUploadTests.swift
@@ -1358,6 +1358,56 @@ import Testing
     #expect(
       requests.last?.value(forHTTPHeaderField: "Content-Range") == "bytes */\(expectedTotalSize)")
   }
+
+  /// Tests resumable upload of a dynamic computation source where total size is unknown (`nil`), but turns out to be completely empty (0 bytes).
+  @Test func resumableUploadDynamicComputationUnknownSizeCompletelyEmptySuccess() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "dynamic-computation-unknown-empty"
+
+    let source = DynamicComputationSource(
+      chunkSize: 4 * 1024 * 1024, totalChunks: 0, totalSize: nil)
+
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?upload_id=dynamic-comp-unknown-empty-id")
+
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+    registry.register(
+      response: .success(
+        statusCode: 200, data: makeObjectJSON(name: objectName, bucket: bucket, size: 0),
+        headers: nil),
+      for: chunkUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+
+    let client = try StorageClient(options)
+    let task = client.upload(source, to: bucket, as: objectName)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
+    #expect(object.size == 0)
+
+    let requests = registry.recordedRequests()
+    #expect(requests.count == 2)
+    #expect(requests[1].value(forHTTPHeaderField: "Content-Range") == "bytes */0")
+  }
 }
 
 // MARK: - Test Helper Sources

--- a/packages/storage/Tests/ResumableUploadTests.swift
+++ b/packages/storage/Tests/ResumableUploadTests.swift
@@ -37,7 +37,7 @@ import Testing
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
     let objectName = "test-object"
-    let data = Data(repeating: 1, count: 10 * 1024 * 1024)  // 10MB
+    let data = Data(repeating: 1, count: 10 * 1024 * 1024)  // 10MiB
     let source = BytesSource(data: data)
 
     let startUrl = registry.url(
@@ -92,7 +92,7 @@ import Testing
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
     let objectName = "test-object"
-    let data = Data(repeating: 1, count: 10 * 1024 * 1024)  // 10MB
+    let data = Data(repeating: 1, count: 10 * 1024 * 1024)  // 10MiB
     struct DummyError: Error {}
     let source = MockUploadSource(data: data, readError: DummyError())
 
@@ -131,7 +131,7 @@ import Testing
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
     let objectName = "test-object"
-    let data = Data(repeating: 1, count: 10 * 1024 * 1024)  // 10MB
+    let data = Data(repeating: 1, count: 10 * 1024 * 1024)  // 10MiB
     let source = BytesSource(data: data)
 
     let startUrl = registry.url(
@@ -166,7 +166,7 @@ import Testing
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
     let objectName = "test-object"
-    let data = Data(repeating: 1, count: 10 * 1024 * 1024)  // 10MB
+    let data = Data(repeating: 1, count: 10 * 1024 * 1024)  // 10MiB
     let source = BytesSource(data: data)
 
     let startUrl = registry.url(
@@ -215,7 +215,7 @@ import Testing
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
     let objectName = "test-object"
-    let data = Data(repeating: 1, count: 10 * 1024 * 1024)  // 10MB
+    let data = Data(repeating: 1, count: 10 * 1024 * 1024)  // 10MiB
     let source = BytesSource(data: data)
 
     let queryUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=test-id")
@@ -341,7 +341,7 @@ import Testing
   @Test func resumeUploadSourceSeekError() async throws {
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
-    let data = Data(repeating: 1, count: 10 * 1024 * 1024)  // 10MB
+    let data = Data(repeating: 1, count: 10 * 1024 * 1024)  // 10MiB
     struct DummyError: Error {}
     let source = MockUploadSource(data: data, seekError: DummyError())
 
@@ -770,7 +770,7 @@ import Testing
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
     let objectName = "fixed-buffer-object"
-    let data = Data(repeating: 0xAB, count: 10 * 1024 * 1024)  // 10MB
+    let data = Data(repeating: 0xAB, count: 10 * 1024 * 1024)  // 10MiB
     let source = BytesSource(data: data)
 
     let startUrl = registry.url(
@@ -814,7 +814,7 @@ import Testing
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
     let objectName = "fixed-buffer-resumed"
-    let data = Data(repeating: 0xCD, count: 10 * 1024 * 1024)  // 10MB
+    let data = Data(repeating: 0xCD, count: 10 * 1024 * 1024)  // 10MiB
     let source = BytesSource(data: data)
 
     let queryUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=fixed-buffer-resume-id")
@@ -869,7 +869,7 @@ import Testing
   @Test func resumableUploadFileFromDiskSuccess() async throws {
     let tempDirectory = FileManager.default.temporaryDirectory
     let fileURL = tempDirectory.appendingPathComponent("test_disk_upload_\(UUID().uuidString).dat")
-    let data = Data(repeating: 0xEF, count: 10 * 1024 * 1024)  // 10MB file
+    let data = Data(repeating: 0xEF, count: 10 * 1024 * 1024)  // 10MiB file
     try data.write(to: fileURL)
     defer {
       try? FileManager.default.removeItem(at: fileURL)
@@ -920,7 +920,7 @@ import Testing
   @Test func resumeUploadFileFromDiskSuccess() async throws {
     let tempDirectory = FileManager.default.temporaryDirectory
     let fileURL = tempDirectory.appendingPathComponent("test_disk_resume_\(UUID().uuidString).dat")
-    let data = Data(repeating: 0x42, count: 10 * 1024 * 1024)  // 10MB file
+    let data = Data(repeating: 0x42, count: 10 * 1024 * 1024)  // 10MiB file
     try data.write(to: fileURL)
     defer {
       try? FileManager.default.removeItem(at: fileURL)
@@ -1196,7 +1196,7 @@ import Testing
     let objectName = "async-download-stream-known"
     let chunk1 = Data(repeating: 0x33, count: 5 * 1024 * 1024)
     let chunk2 = Data(repeating: 0x44, count: 5 * 1024 * 1024)
-    let totalSize = Int64(chunk1.count + chunk2.count)  // 10MB
+    let totalSize = Int64(chunk1.count + chunk2.count)  // 10MiB
 
     let asyncStream = makeAsyncStream(chunks: [chunk1, chunk2])
     let source = StreamSource(sequence: asyncStream, totalSize: totalSize)


### PR DESCRIPTION
Also adds tests for all our supported upload source types

Fixes #26