### PR TITLE
fix: skip md5 automatic checksumming if we are resuming with offset > 0

### DIFF
--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -203,6 +203,12 @@ extension StorageClient {
     options: UploadOptions,
     continuation: AsyncStream<UploadStatus>.Continuation
   ) async throws -> StorageObject {
+    var options = options
+    // Explicitly disable calculated MD5 checksums if we are resuming an upload at offset >0
+    // as MD5 requires reading the entire file from the start.
+    if offset > 0 && options.checksums.md5 == .auto {
+      options.checksums.md5 = nil
+    }
     var checksummedSource = ChecksummedSource(source: source, options: options.checksums)
     return try await continueStreamingUpload(
       httpClient: httpClient,
@@ -227,6 +233,12 @@ extension StorageClient {
     options: UploadOptions,
     continuation: AsyncStream<UploadStatus>.Continuation
   ) async throws -> StorageObject {
+    var options = options
+    // Explicitly disable calculated MD5 checksums if we are resuming an upload at offset >0
+    // as MD5 requires reading the entire file from the start.
+    if offset > 0 && options.checksums.md5 == .auto {
+      options.checksums.md5 = nil
+    }
     var checksummedSource = ChecksummedSource(source: source, options: options.checksums)
     if let seed = crc32cSeed {
       checksummedSource.seedCRC32C(seed: seed, bytesHashed: offset)

--- a/packages/storage/Tests/ResumableUploadTests.swift
+++ b/packages/storage/Tests/ResumableUploadTests.swift
@@ -1408,76 +1408,6 @@ import Testing
     #expect(requests.count == 2)
     #expect(requests[1].value(forHTTPHeaderField: "Content-Range") == "bytes */0")
   }
-}
-
-// MARK: - Test Helper Sources
-
-/// A non-seekable computational upload source generating deterministic bytes on-demand.
-private struct DynamicComputationSource: UploadSource {
-  let chunkSize: Int
-  let totalChunks: Int
-  let totalSize: Int64?
-  private var currentChunk: Int = 0
-
-  init(chunkSize: Int, totalChunks: Int, totalSize: Int64?) {
-    self.chunkSize = chunkSize
-    self.totalChunks = totalChunks
-    self.totalSize = totalSize
-  }
-
-  mutating func read(maxBytes: Int) async throws -> Data? {
-    guard currentChunk < totalChunks else { return nil }
-    let count = min(maxBytes, chunkSize)
-    let byteVal = UInt8((currentChunk + 1) % 256)
-    currentChunk += 1
-    return Data(repeating: byteVal, count: count)
-  }
-}
-
-/// A seekable computational upload source that can re-initialize its generator to any offset.
-private struct SeekableComputationSource: SeekableUploadSource {
-  let chunkSize: Int
-  let totalChunks: Int
-  let totalSize: Int64?
-  private var currentOffset: Int64 = 0
-
-  init(chunkSize: Int, totalChunks: Int) {
-    self.chunkSize = chunkSize
-    self.totalChunks = totalChunks
-    self.totalSize = Int64(chunkSize * totalChunks)
-  }
-
-  mutating func read(maxBytes: Int) async throws -> Data? {
-    guard let totalSize = totalSize, currentOffset < totalSize else { return nil }
-    let bytesToRead = min(Int64(maxBytes), totalSize - currentOffset)
-    guard bytesToRead > 0 else { return nil }
-    let chunkIndex = Int(currentOffset / Int64(chunkSize))
-    let byteVal = UInt8((chunkIndex + 1) % 256)
-    currentOffset += bytesToRead
-    return Data(repeating: byteVal, count: Int(bytesToRead))
-  }
-
-  mutating func seek(to offset: Int64) async throws {
-    guard offset >= 0, let total = totalSize, offset <= total else {
-      throw UploadError.localSourceTooSmall(localSize: totalSize ?? 0, gcsOffset: offset)
-    }
-    self.currentOffset = offset
-  }
-}
-
-/// Helper function to create an `AsyncStream<Data>` with asynchronous yielding.
-private func makeAsyncStream(chunks: [Data], delayNanoseconds: UInt64 = 1_000_000) -> AsyncStream<
-  Data
-> {
-  AsyncStream { continuation in
-    Task {
-      for chunk in chunks {
-        try? await Task.sleep(nanoseconds: delayNanoseconds)
-        continuation.yield(chunk)
-      }
-      continuation.finish()
-    }
-  }
 
   /// Tests resuming an upload from an intermediate offset when MD5 checksum was requested (.auto).
   /// Because MD5 is not recoverable from a partial state, MD5 calculation must be skipped,
@@ -1607,5 +1537,75 @@ private func makeAsyncStream(chunks: [Data], delayNanoseconds: UInt64 = 1_000_00
     let hashHeader = finalChunkReq.value(forHTTPHeaderField: "x-goog-hash")
     #expect(hashHeader != nil)
     #expect(hashHeader?.contains("md5=") == true)
+  }
+}
+
+// MARK: - Test Helper Sources
+
+/// A non-seekable computational upload source generating deterministic bytes on-demand.
+private struct DynamicComputationSource: UploadSource {
+  let chunkSize: Int
+  let totalChunks: Int
+  let totalSize: Int64?
+  private var currentChunk: Int = 0
+
+  init(chunkSize: Int, totalChunks: Int, totalSize: Int64?) {
+    self.chunkSize = chunkSize
+    self.totalChunks = totalChunks
+    self.totalSize = totalSize
+  }
+
+  mutating func read(maxBytes: Int) async throws -> Data? {
+    guard currentChunk < totalChunks else { return nil }
+    let count = min(maxBytes, chunkSize)
+    let byteVal = UInt8((currentChunk + 1) % 256)
+    currentChunk += 1
+    return Data(repeating: byteVal, count: count)
+  }
+}
+
+/// A seekable computational upload source that can re-initialize its generator to any offset.
+private struct SeekableComputationSource: SeekableUploadSource {
+  let chunkSize: Int
+  let totalChunks: Int
+  let totalSize: Int64?
+  private var currentOffset: Int64 = 0
+
+  init(chunkSize: Int, totalChunks: Int) {
+    self.chunkSize = chunkSize
+    self.totalChunks = totalChunks
+    self.totalSize = Int64(chunkSize * totalChunks)
+  }
+
+  mutating func read(maxBytes: Int) async throws -> Data? {
+    guard let totalSize = totalSize, currentOffset < totalSize else { return nil }
+    let bytesToRead = min(Int64(maxBytes), totalSize - currentOffset)
+    guard bytesToRead > 0 else { return nil }
+    let chunkIndex = Int(currentOffset / Int64(chunkSize))
+    let byteVal = UInt8((chunkIndex + 1) % 256)
+    currentOffset += bytesToRead
+    return Data(repeating: byteVal, count: Int(bytesToRead))
+  }
+
+  mutating func seek(to offset: Int64) async throws {
+    guard offset >= 0, let total = totalSize, offset <= total else {
+      throw UploadError.localSourceTooSmall(localSize: totalSize ?? 0, gcsOffset: offset)
+    }
+    self.currentOffset = offset
+  }
+}
+
+/// Helper function to create an `AsyncStream<Data>` with asynchronous yielding.
+private func makeAsyncStream(chunks: [Data], delayNanoseconds: UInt64 = 1_000_000) -> AsyncStream<
+  Data
+> {
+  return AsyncStream { continuation in
+    Task {
+      for chunk in chunks {
+        try? await Task.sleep(nanoseconds: delayNanoseconds)
+        continuation.yield(chunk)
+      }
+      continuation.finish()
+    }
   }
 }

--- a/packages/storage/Tests/ResumableUploadTests.swift
+++ b/packages/storage/Tests/ResumableUploadTests.swift
@@ -949,4 +949,134 @@ import Testing
     let finalChunkReq = requests[1]
     #expect(finalChunkReq.value(forHTTPHeaderField: "x-goog-hash") != nil)
   }
+
+  /// Tests resuming an upload from an intermediate offset when MD5 checksum was requested (.auto).
+  /// Because MD5 is not recoverable from a partial state, MD5 calculation must be skipped,
+  /// and no md5 checksum header should be sent in the final chunk upload request.
+  @Test func testResumeUploadPartialWithAutoMD5Skipped() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-object"
+    let data = Data(repeating: 1, count: 1 * 1024 * 1024)
+    let source = BytesSource(data: data)
+
+    let queryUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?upload_id=auto-md5-partial-upload-id")
+
+    let objectJSON = """
+      {
+        "name": "\(objectName)",
+        "bucket": "\(bucket)",
+        "generation": "1",
+        "metageneration": "1",
+        "size": "\(data.count)",
+        "contentType": "application/octet-stream",
+        "storageClass": "STANDARD"
+      }
+      """
+
+    registry.register(
+      response: .success(
+        statusCode: 308, data: Data(),
+        headers: ["Range": "bytes=0-4999"]),
+      for: queryUrl)
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(objectJSON.utf8),
+        headers: nil),
+      for: queryUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+
+    let client = try StorageClient(options)
+    let uploadOptions = UploadOptions().with {
+      $0.checksums = ChecksumOptions(crc32c: nil, md5: .auto)
+    }
+    let task = client.resumeUpload(
+      source, uploadId: queryUrl.absoluteString, options: uploadOptions)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+
+    let requests = registry.recordedRequests()
+    #expect(requests.count == 2)
+    let finalChunkReq = requests[1]
+    let hashHeader = finalChunkReq.value(forHTTPHeaderField: "x-goog-hash")
+    #expect(hashHeader == nil)
+  }
+
+  /// Tests resuming an upload from offset 0 when MD5 checksum was requested (.auto).
+  /// Because the upload starts from byte 0 (not partially complete), MD5 calculation SHOULD occur and be sent.
+  @Test func testResumeUploadFromOffsetZeroWithAutoMD5() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-object"
+    let data = Data(repeating: 1, count: 1 * 1024 * 1024)
+    let source = BytesSource(data: data)
+
+    let queryUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?upload_id=zero-offset-md5-upload-id")
+
+    let objectJSON = """
+      {
+        "name": "\(objectName)",
+        "bucket": "\(bucket)",
+        "generation": "1",
+        "metageneration": "1",
+        "size": "\(data.count)",
+        "contentType": "application/octet-stream",
+        "storageClass": "STANDARD"
+      }
+      """
+
+    registry.register(
+      response: .success(
+        statusCode: 308, data: Data(),
+        headers: [:]),
+      for: queryUrl)
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(objectJSON.utf8),
+        headers: nil),
+      for: queryUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+
+    let client = try StorageClient(options)
+    let uploadOptions = UploadOptions().with {
+      $0.checksums = ChecksumOptions(crc32c: nil, md5: .auto)
+    }
+    let task = client.resumeUpload(
+      source, uploadId: queryUrl.absoluteString, options: uploadOptions)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+
+    let requests = registry.recordedRequests()
+    #expect(requests.count == 2)
+    let finalChunkReq = requests[1]
+    let hashHeader = finalChunkReq.value(forHTTPHeaderField: "x-goog-hash")
+    #expect(hashHeader != nil)
+    #expect(hashHeader?.contains("md5=") == true)
+  }
 }


### PR DESCRIPTION
Fixes #114

The C++ client ignores adding the md5 hash if it's resuming an upload part way through rather than reading the entire payload over again.