### PR TITLE
feat: allow specifying checksums with raw int values

### DIFF
--- a/packages/storage/Sources/GoogleCloudStorage/UploadOptions.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/UploadOptions.swift
@@ -37,7 +37,9 @@ public struct ChecksumOptions: Sendable, Hashable {
   public var md5: ChecksumValue?
 
   /// Specifies how a checksum should be provided for upload validation.
-  public enum ChecksumValue: Sendable, Hashable, ExpressibleByStringLiteral {
+  public enum ChecksumValue: Sendable, Hashable, ExpressibleByStringLiteral,
+    ExpressibleByIntegerLiteral
+  {
     /// Automatically calculate the checksum on-the-fly during upload streaming.
     case auto
 
@@ -47,6 +49,18 @@ public struct ChecksumOptions: Sendable, Hashable {
     /// Creates a `ChecksumValue` from a string literal containing a pre-computed checksum.
     public init(stringLiteral value: String) {
       self = .value(value)
+    }
+
+    /// Creates a `ChecksumValue` from a 32-bit unsigned integer CRC32C checksum value.
+    public init(_ intValue: UInt32) {
+      let bigEndian = intValue.bigEndian
+      let base64 = withUnsafeBytes(of: bigEndian) { Data($0).base64EncodedString() }
+      self = .value(base64)
+    }
+
+    /// Creates a `ChecksumValue` from an integer literal containing a CRC32C checksum value.
+    public init(integerLiteral value: UInt64) {
+      self.init(UInt32(truncatingIfNeeded: value))
     }
   }
 

--- a/packages/storage/Tests/ChecksumTests.swift
+++ b/packages/storage/Tests/ChecksumTests.swift
@@ -211,6 +211,20 @@ import Testing
     #expect(chunk!.checksum == "crc32c=PRE_CRC, md5=PRE_MD5")
   }
 
+  @Test func testChecksummedSourceUserProvidedUInt32() async throws {
+    let source = BytesSource(data: Data("Hello, World!".utf8))
+    // 0x4D551068 (big-endian [0x4D, 0x55, 0x10, 0x68]) encodes to "TVUQaA=="
+    let checksumsLiteral = ChecksumOptions(crc32c: 0x4D551068)
+    #expect(checksumsLiteral.crc32c == .value("TVUQaA=="))
+
+    var checksummedSource = ChecksummedSource(source: source, options: checksumsLiteral)
+    let chunk = try await checksummedSource.readChunk(maxBytes: 100)
+
+    #expect(chunk != nil)
+    #expect(chunk!.isLast == true)
+    #expect(chunk!.checksum == "crc32c=TVUQaA==")
+  }
+
   @Test func testChecksummedSourceMixedAutoAndUserProvided() async throws {
     let data = Data("Hello, World!".utf8)
     let source = BytesSource(data: data)


### PR DESCRIPTION
Fixes #117

By implementing the `ExpressibleByIntegerLiteral` on `ChecksumValue`, a user can set a raw integer value like:

```swift
let checksumsLiteral = ChecksumOptions(crc32c: 0x4D551068)
```