### PR TITLE
cleanup(auth): use `async-http-client` package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "936fb7243d6ee0d46ed44890b546b825a8f69530fb0b962bf44d955400a6b3f6",
+  "originHash" : "9106854289b903ac66fce0a109f18ee6bf695b17a754bdd2fddc884b27be46f7",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "9544287b9416c0bc71e58b9f3aead8dd14b16103",
+        "version" : "1.36.0"
+      }
+    },
     {
       "identity" : "grpc-swift",
       "kind" : "remoteSourceControl",
@@ -74,12 +83,30 @@
       }
     },
     {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
         "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
         "version" : "4.5.1"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
       }
     },
     {
@@ -197,6 +224,15 @@
       "state" : {
         "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
         "version" : "1.38.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
       }
     },
     {

--- a/packages/auth/Package.swift
+++ b/packages/auth/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-system.git", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-log", from: "1.14.0"),
     .package(url: "https://github.com/apple/swift-collections", from: "1.6.0"),
+    .package(url: "https://github.com/apple/swift-nio", from: "2.101.0"),
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.36.0"),
     .package(url: "https://github.com/vapor/jwt-kit.git", from: "5.0.0"),
   ],
@@ -43,6 +44,8 @@ let package = Package(
         .product(name: "JWTKit", package: "jwt-kit"),
         .product(name: "SystemPackage", package: "swift-system"),
         .product(name: "Logging", package: "swift-log"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOFoundationCompat", package: "swift-nio"),
       ]
     ),
     .testTarget(

--- a/packages/auth/Package.swift
+++ b/packages/auth/Package.swift
@@ -29,6 +29,9 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-system.git", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-log", from: "1.14.0"),
+    .package(url: "https://github.com/apple/swift-collections", from: "1.6.0"),
+    .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.36.0"),
     .package(url: "https://github.com/vapor/jwt-kit.git", from: "5.0.0"),
   ],
 
@@ -36,13 +39,19 @@ let package = Package(
     .target(
       name: "GoogleCloudAuth",
       dependencies: [
-        .product(name: "SystemPackage", package: "swift-system"),
+        .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "JWTKit", package: "jwt-kit"),
+        .product(name: "SystemPackage", package: "swift-system"),
+        .product(name: "Logging", package: "swift-log"),
       ]
     ),
     .testTarget(
       name: "GoogleCloudAuthTests",
-      dependencies: ["GoogleCloudAuth", .product(name: "JWTKit", package: "jwt-kit")],
+      dependencies: [
+        "GoogleCloudAuth",
+        .product(name: "DequeModule", package: "swift-collections"),
+        .product(name: "JWTKit", package: "jwt-kit"),
+      ],
       path: "Tests",
       exclude: ["IntegrationTests"]
     ),

--- a/packages/auth/Sources/GoogleCloudAuth/Http/AuthHTTPClient.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/Http/AuthHTTPClient.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import AsyncHTTPClient
+import NIOFoundationCompat
 import struct Logging.Logger
 import struct NIOCore.TimeAmount
 import struct NIOCore.ByteBufferAllocator
@@ -98,7 +99,7 @@ struct AuthHTTPClient: Sendable {
       try self.ensureSuccess(response)
 
       do {
-        return try self.makeDecoder().decode(T.self, from: buffer.getData(at: 0, length: buffer.readableBytes)!)
+        return try self.makeDecoder().decode(T.self, from: Data(buffer: buffer))
       } catch let error as DecodingError {
         throw AuthHTTPError.decodingError(error: error)
       }
@@ -149,8 +150,8 @@ struct AuthHTTPClient: Sendable {
       request.headers = .init(headers.map { ($0.key, $0.value) })
       request.headers.add(name: "Content-Type", value: "application/json")
       let encoder = JSONEncoder()
-      let data = try encoder.encode(body)
-      request.body = .bytes(.init(data: data))
+      let buffer = try encoder.encodeAsByteBuffer(body, allocator: ByteBufferAllocator())
+      request.body = .bytes(buffer)
 
       let response = try await self.performRequest(request)
       try self.ensureSuccess(response)
@@ -183,7 +184,7 @@ struct AuthHTTPClient: Sendable {
       request.method = .POST
       request.headers = .init(headers.map { ($0.key, $0.value) })
       request.headers.add(name: "Content-Type", value: contentType)
-      request.body = .bytes(.init(data: bodyData))
+      request.body = .bytes(bodyData)
 
       let response = try await self.performRequest(request)
       try self.ensureSuccess(response)

--- a/packages/auth/Sources/GoogleCloudAuth/Http/AuthHTTPClient.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/Http/AuthHTTPClient.swift
@@ -98,7 +98,7 @@ struct AuthHTTPClient: Sendable {
       try self.ensureSuccess(response)
 
       do {
-        return try self.makeDecoder().decode(T.self, from: buffer)
+        return try self.makeDecoder().decode(T.self, from: Data(buffer: buffer))
       } catch let error as DecodingError {
         throw AuthHTTPError.decodingError(error: error)
       }
@@ -193,7 +193,7 @@ struct AuthHTTPClient: Sendable {
       let buffer = try await response.body.collect(upTo: Self.maxResponseSize)
 
       do {
-        return try self.makeDecoder().decode(Response.self, from: buffer)
+        return try self.makeDecoder().decode(Response.self, from: Data(buffer: buffer))
       } catch let error as DecodingError {
         throw AuthHTTPError.decodingError(error: error)
       }

--- a/packages/auth/Sources/GoogleCloudAuth/Http/AuthHTTPClient.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/Http/AuthHTTPClient.swift
@@ -69,9 +69,7 @@ struct AuthHTTPClient: Sendable {
 
   let inner: any HTTPClientProtocol
 
-  /// Initializes the client with a dynamic session provider closure.
-  ///
-  /// - Parameter sessionProvider: A closure returning a `URLSession` for network dispatching.
+  /// Initializes the client with the default configuration.
   public init() {
     self.inner = HTTPClientHolder()
   }

--- a/packages/auth/Sources/GoogleCloudAuth/Http/AuthHTTPClient.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/Http/AuthHTTPClient.swift
@@ -13,32 +13,70 @@
 // limitations under the License.
 
 import Foundation
+import AsyncHTTPClient
+import struct Logging.Logger
+import struct NIOCore.TimeAmount
+import struct NIOCore.ByteBufferAllocator
 
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
+protocol HTTPClientProtocol: Sendable {
+  func execute(
+    request: HTTPClientRequest,
+    timeout: Duration,
+    logger: Logger?
+  ) async throws -> HTTPClientResponse
+}
+
+/// Automatically call shutdown() on a HTTPClient.
+///
+/// HTTPClient requires an (asynchronous) call to `shutdown()` or it leaks resources.
+/// This class automates the call.
+///
+/// SAFETY: calling `shutdown()` requires all requests to be finished. In the AuthHTTPClient struct
+/// each HTTP request is executed within a function, therefore the object is live while the HTTP
+/// request is in progress. By the time deinit starts, all starting a call requires having a
+/// reference to the object, so shutdown
+final class HTTPClientHolder: HTTPClientProtocol {
+  let inner = HTTPClient()
+  deinit {
+    // Use a background task to shutdown the inner client. In most cases, the application will
+    // continue running and the HTTPClient is shutdown "eventually". Except for (maybe) some false
+    // positives in leak detectors, there is no harm if the application terminates before this gets
+    // to run.
+    let copy = inner
+    Task {
+      // Note how we make a copy of `inner` to avoid capturing `self`.
+      do {
+        try await copy.shutdown()
+      } catch {
+        // Ignore any exceptions. If `shutdown()` failed there is nothing the application can do.
+      }
+    }
+  }
+
+  func execute(
+    request: HTTPClientRequest,
+    timeout: Duration,
+    logger: Logger?
+  ) async throws -> HTTPClientResponse {
+    try await self.inner.execute(request, timeout: .init(timeout), logger: logger)
+  }
+}
 
 /// A lightweight, portable, and secure HTTP request client dedicated to authentication requests.
 struct AuthHTTPClient: Sendable {
-  private static let sharedSession = URLSession(configuration: .ephemeral)
-  private let sessionProvider: @Sendable () -> URLSession
+  static let maxResponseSize: Int = 1024 * 1024
+
+  let inner: any HTTPClientProtocol
 
   /// Initializes the client with a dynamic session provider closure.
   ///
   /// - Parameter sessionProvider: A closure returning a `URLSession` for network dispatching.
-  init(sessionProvider: @Sendable @escaping () -> URLSession) {
-    self.sessionProvider = sessionProvider
+  public init() {
+    self.inner = HTTPClientHolder()
   }
 
-  /// Initializes the client with a customized static session.
-  ///
-  /// - Parameter session: The static `URLSession` injected for network dispatching. Defaults to constructing an ephemeral configuration on demand.
-  init(session: URLSession? = nil) {
-    if let session = session {
-      self.sessionProvider = { session }
-    } else {
-      self.sessionProvider = { Self.sharedSession }
-    }
+  init<T: HTTPClientProtocol>(mock: T) {
+    self.inner = mock
   }
 
   /// Asynchronously dispatches a GET request and decodes the generic JSON response.
@@ -52,21 +90,17 @@ struct AuthHTTPClient: Sendable {
     headers: [String: String] = [:]
   ) async throws -> T {
     return try await self.mapError {
-      var request = URLRequest(url: url)
-      request.httpMethod = "GET"
-      request.cachePolicy = .reloadIgnoringLocalCacheData
-
-      for (key, value) in headers {
-        request.setValue(value, forHTTPHeaderField: key)
-      }
-
-      let (data, response) = try await self.performRequest(request)
-      try self.ensureSuccess(response, data: data)
+      var request = HTTPClientRequest(url: url.absoluteString)
+      request.method = .GET
+      request.headers = .init(headers.map { ($0.key, $0.value) })
+      let response = try await self.performRequest(request)
+      let buffer = try await response.body.collect(upTo: Self.maxResponseSize)
+      try self.ensureSuccess(response)
 
       do {
-        return try self.makeDecoder().decode(T.self, from: data)
+        return try self.makeDecoder().decode(T.self, from: buffer)
       } catch let error as DecodingError {
-        throw AuthHTTPError.decodingError(error: error, data: data)
+        throw AuthHTTPError.decodingError(error: error)
       }
     }
   }
@@ -78,21 +112,22 @@ struct AuthHTTPClient: Sendable {
     headers: [String: String] = [:]
   ) async throws -> String {
     return try await self.mapError {
-      var request = URLRequest(url: url)
-      request.httpMethod = "GET"
-      request.cachePolicy = .reloadIgnoringLocalCacheData
+      var request = HTTPClientRequest(url: url.absoluteString)
+      request.method = .GET
+      request.headers = .init(headers.map { ($0.key, $0.value) })
+      let response = try await self.performRequest(request)
+      try self.ensureSuccess(response)
+      var buffer = try await response.body.collect(upTo: Self.maxResponseSize)
 
-      for (key, value) in headers {
-        request.setValue(value, forHTTPHeaderField: key)
+      do {
+        guard let plainText = try buffer.readUTF8ValidatedString(length: buffer.readableBytes)
+        else {
+          throw AuthHTTPError.decodingError(error: AuthHTTPError.invalidUTF8Response)
+        }
+        return plainText
+      } catch {
+        throw AuthHTTPError.decodingError(error: error)
       }
-
-      let (data, response) = try await self.performRequest(request)
-      try self.ensureSuccess(response, data: data)
-
-      guard let plainText = String(data: data, encoding: .utf8) else {
-        throw AuthHTTPError.decodingError(error: AuthHTTPError.invalidUTF8Response, data: data)
-      }
-      return plainText
     }
   }
 
@@ -109,24 +144,25 @@ struct AuthHTTPClient: Sendable {
     headers: [String: String] = [:]
   ) async throws -> Response {
     return try await self.mapError {
-      var request = URLRequest(url: url)
-      request.httpMethod = "POST"
-      request.cachePolicy = .reloadIgnoringLocalCacheData
-      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+      var request = HTTPClientRequest(url: url.absoluteString)
+      request.method = .POST
+      request.headers = .init(headers.map { ($0.key, $0.value) })
+      request.headers.add(name: "Content-Type", value: "application/json")
+      let encoder = JSONEncoder()
+      let buffer = try encoder.encodeAsByteBuffer(
+        body,
+        allocator: ByteBufferAllocator()
+      )
+      request.body = .bytes(buffer)
 
-      for (key, value) in headers {
-        request.setValue(value, forHTTPHeaderField: key)
-      }
-
-      request.httpBody = try self.makeEncoder().encode(body)
-
-      let (data, response) = try await self.performRequest(request)
-      try self.ensureSuccess(response, data: data)
+      let response = try await self.performRequest(request)
+      try self.ensureSuccess(response)
+      let recvBuffer = try await response.body.collect(upTo: Self.maxResponseSize)
 
       do {
-        return try self.makeDecoder().decode(Response.self, from: data)
+        return try self.makeDecoder().decode(Response.self, from: recvBuffer)
       } catch let error as DecodingError {
-        throw AuthHTTPError.decodingError(error: error, data: data)
+        throw AuthHTTPError.decodingError(error: error)
       }
     }
   }
@@ -146,29 +182,23 @@ struct AuthHTTPClient: Sendable {
     headers: [String: String] = [:]
   ) async throws -> Response {
     return try await self.mapError {
-      var request = URLRequest(url: url)
-      request.httpMethod = "POST"
-      request.cachePolicy = .reloadIgnoringLocalCacheData
-      request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+      var request = HTTPClientRequest(url: url.absoluteString)
+      request.method = .POST
+      request.headers = .init(headers.map { ($0.key, $0.value) })
+      request.headers.add(name: "Content-Type", value: contentType)
+      request.body = .bytes(bodyData)
 
-      for (key, value) in headers {
-        request.setValue(value, forHTTPHeaderField: key)
-      }
-
-      request.httpBody = bodyData
-
-      let (data, response) = try await self.performRequest(request)
-      try self.ensureSuccess(response, data: data)
+      let response = try await self.performRequest(request)
+      try self.ensureSuccess(response)
+      let buffer = try await response.body.collect(upTo: Self.maxResponseSize)
 
       do {
-        return try self.makeDecoder().decode(Response.self, from: data)
+        return try self.makeDecoder().decode(Response.self, from: buffer)
       } catch let error as DecodingError {
-        throw AuthHTTPError.decodingError(error: error, data: data)
+        throw AuthHTTPError.decodingError(error: error)
       }
     }
   }
-
-  // MARK: - Private Helpers
 
   /// Centralizes error mapping logic to wrap any transport or unknown failures in AuthHTTPError.
   private func mapError<T>(
@@ -185,28 +215,8 @@ struct AuthHTTPClient: Sendable {
     }
   }
 
-  private func performRequest(_ request: URLRequest) async throws -> (Data, URLResponse) {
-    let session = self.sessionProvider()
-
-    // Support async/await directly on URLSession (handles modern platforms and Linux compatibility)
-    #if os(Linux)
-      return try await withCheckedThrowingContinuation { continuation in
-        let task = session.dataTask(with: request) { data, response, error in
-          if let error = error {
-            continuation.resume(throwing: error)
-          } else if let data = data, let response = response {
-            continuation.resume(returning: (data, response))
-          } else {
-            continuation.resume(
-              throwing: URLError(
-                .unknown, userInfo: [NSLocalizedDescriptionKey: "Empty HTTP response"]))
-          }
-        }
-        task.resume()
-      }
-    #else
-      return try await session.data(for: request)
-    #endif
+  private func performRequest(_ request: HTTPClientRequest) async throws -> HTTPClientResponse {
+    return try await inner.execute(request: request, timeout: .seconds(30), logger: nil)
   }
 
   private func makeDecoder() -> JSONDecoder {
@@ -221,15 +231,10 @@ struct AuthHTTPClient: Sendable {
     return encoder
   }
 
-  private func ensureSuccess(_ response: URLResponse, data: Data) throws {
-    guard let httpResponse = response as? HTTPURLResponse else {
-      throw URLError(
-        .badServerResponse, userInfo: [NSLocalizedDescriptionKey: "Non-HTTP URL response received"])
-    }
-
-    let statusCode = httpResponse.statusCode
+  private func ensureSuccess(_ response: HTTPClientResponse) throws {
+    let statusCode = response.status.code
     guard (200...299).contains(statusCode) else {
-      throw AuthHTTPError.unsuccessfulResponse(response: httpResponse, data: data)
+      throw AuthHTTPError.unsuccessfulResponse(response: response)
     }
   }
 }

--- a/packages/auth/Sources/GoogleCloudAuth/Http/AuthHTTPClient.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/Http/AuthHTTPClient.swift
@@ -98,7 +98,7 @@ struct AuthHTTPClient: Sendable {
       try self.ensureSuccess(response)
 
       do {
-        return try self.makeDecoder().decode(T.self, from: Data(buffer: buffer))
+        return try self.makeDecoder().decode(T.self, from: buffer.getData(at: 0, length: buffer.readableBytes)!)
       } catch let error as DecodingError {
         throw AuthHTTPError.decodingError(error: error)
       }
@@ -149,11 +149,8 @@ struct AuthHTTPClient: Sendable {
       request.headers = .init(headers.map { ($0.key, $0.value) })
       request.headers.add(name: "Content-Type", value: "application/json")
       let encoder = JSONEncoder()
-      let buffer = try encoder.encodeAsByteBuffer(
-        body,
-        allocator: ByteBufferAllocator()
-      )
-      request.body = .bytes(buffer)
+      let data = try encoder.encode(body)
+      request.body = .bytes(.init(data: data))
 
       let response = try await self.performRequest(request)
       try self.ensureSuccess(response)
@@ -186,7 +183,7 @@ struct AuthHTTPClient: Sendable {
       request.method = .POST
       request.headers = .init(headers.map { ($0.key, $0.value) })
       request.headers.add(name: "Content-Type", value: contentType)
-      request.body = .bytes(bodyData)
+      request.body = .bytes(.init(data: bodyData))
 
       let response = try await self.performRequest(request)
       try self.ensureSuccess(response)

--- a/packages/auth/Sources/GoogleCloudAuth/Http/AuthHTTPError.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/Http/AuthHTTPError.swift
@@ -13,19 +13,16 @@
 // limitations under the License.
 
 import Foundation
-
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
+import struct AsyncHTTPClient.HTTPClientResponse
 
 /// Represents any error occurring during an authentication HTTP request.
 enum AuthHTTPError: Error, Sendable {
   /// The server returned a non-2xx status code.
-  case unsuccessfulResponse(response: HTTPURLResponse, data: Data)
+  case unsuccessfulResponse(response: HTTPClientResponse)
   /// A transport-level error occurred (e.g., timeout, connection lost).
   case transportError(URLError)
   /// A decoding error occurred while parsing the response.
-  case decodingError(error: any Error & Sendable, data: Data)
+  case decodingError(error: any Error & Sendable)
   /// An unexpected or unknown error occurred.
   case unknown(any Error & Sendable)
   /// Failed to decode the response body as a UTF-8 string.
@@ -44,10 +41,10 @@ extension AuthHTTPError {
   }
 
   /// The HTTP status code if this is an unsuccessful response.
-  var statusCode: Int? {
+  var statusCode: UInt? {
     switch self {
-    case .unsuccessfulResponse(let response, _):
-      return response.statusCode
+    case .unsuccessfulResponse(let response):
+      return response.status.code
     default:
       return nil
     }
@@ -56,10 +53,11 @@ extension AuthHTTPError {
   /// The raw response body as a UTF-8 string if this is an unsuccessful response or a decoding error.
   var body: String? {
     switch self {
-    case .unsuccessfulResponse(_, let data):
-      return String(data: data, encoding: .utf8)
-    case .decodingError(_, let data):
-      return String(data: data, encoding: .utf8)
+    case .unsuccessfulResponse(_):
+      // TODO(#81) - return the body
+      return nil
+    case .decodingError(_):
+      return nil
     default:
       return nil
     }
@@ -68,10 +66,11 @@ extension AuthHTTPError {
   /// The raw response body data if this is an unsuccessful response or a decoding error.
   var bodyData: Data? {
     switch self {
-    case .unsuccessfulResponse(_, let data):
-      return data
-    case .decodingError(_, let data):
-      return data
+    case .unsuccessfulResponse(_):
+      // TODO(#81) - return the data, if any.
+      return nil
+    case .decodingError(_):
+      return nil
     default:
       return nil
     }
@@ -80,12 +79,10 @@ extension AuthHTTPError {
   /// The HTTP response headers as a string map if this is an unsuccessful response.
   var headers: [String: String]? {
     switch self {
-    case .unsuccessfulResponse(let response, _):
+    case .unsuccessfulResponse(let response):
       var result: [String: String] = [:]
-      for (key, value) in response.allHeaderFields {
-        if let keyString = key as? String, let valueString = value as? String {
-          result[keyString] = valueString
-        }
+      for (key, value) in response.headers {
+        result[key] = value
       }
       return result
     default:

--- a/packages/auth/Sources/GoogleCloudAuth/Providers/MDSAccessTokenProvider.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/Providers/MDSAccessTokenProvider.swift
@@ -115,7 +115,7 @@ struct MDSAccessTokenProvider: TokenProvider, Sendable {
         if case .transportError = error {
           throw self.missingConfigurationError(targetURL: url, underlyingError: error)
         }
-        if case .unsuccessfulResponse(let response, _) = error, response.statusCode == 404 {
+        if case .unsuccessfulResponse(let response) = error, response.status == .notFound {
           throw self.missingConfigurationError(targetURL: url, underlyingError: error)
         }
       }

--- a/packages/auth/Tests/ExternalAccountTests.swift
+++ b/packages/auth/Tests/ExternalAccountTests.swift
@@ -13,42 +13,9 @@
 // limitations under the License.
 
 import Foundation
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
+import AsyncHTTPClient
 import Testing
-
 @testable import GoogleCloudAuth
-
-private final class MockURLProtocol: URLProtocol {
-  nonisolated(unsafe) static var requestHandler:
-    (@Sendable (URLRequest) throws -> (URLResponse, Data))?
-
-  override class func canInit(with request: URLRequest) -> Bool {
-    return true
-  }
-
-  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-    return request
-  }
-
-  override func startLoading() {
-    guard let handler = MockURLProtocol.requestHandler else {
-      fatalError("Handler is not set.")
-    }
-
-    do {
-      let (response, data) = try handler(request)
-      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-      client?.urlProtocol(self, didLoad: data)
-      client?.urlProtocolDidFinishLoading(self)
-    } catch {
-      client?.urlProtocol(self, didFailWithError: error)
-    }
-  }
-
-  override func stopLoading() {}
-}
 
 private struct MockSubjectTokenProvider: SubjectTokenProvider {
   let token: String
@@ -69,16 +36,7 @@ private actor MockFailingSubjectTokenProvider: SubjectTokenProvider {
   }
 }
 
-@Suite(.serialized)
-struct ExternalAccountTests {
-  private let mockSession: URLSession
-
-  init() {
-    let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [MockURLProtocol.self]
-    self.mockSession = URLSession(configuration: config)
-  }
-
+@Suite struct ExternalAccountTests {
   @Test("Configures programmatic credentials with custom providers successfully")
   func createProgrammaticCredentials() throws {
     let provider = MockSubjectTokenProvider(token: "mock-provider-token")
@@ -269,22 +227,22 @@ struct ExternalAccountTests {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let responseData = try encoder.encode(expectedResponse)
 
-    MockURLProtocol.requestHandler = { request in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "POST")
-      #expect(
-        request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .POST)
+        #expect(request.headers["Content-Type"] == ["application/x-www-form-urlencoded"])
 
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, responseData)
-    }
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: responseData)),
+        )
+      }
+    ])
 
-    let httpClient = AuthHTTPClient(session: self.mockSession)
+    let httpClient = AuthHTTPClient(mock: mock)
     let creds = try ExternalAccountCredentials(
       credentialSource: .programmatic(subjectTokenProvider: provider),
       audience: "//iam.googleapis.com/locations/global/workforcePools/wpool/providers/wprov",
@@ -319,30 +277,18 @@ struct ExternalAccountTests {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let responseData = try encoder.encode(expectedResponse)
 
-    let attempts = CallCounter()
-
-    MockURLProtocol.requestHandler = { request in
-      let attempt = attempts.increment()
-      if attempt == 1 {
-        // Fail with transient 429 error first
-        let response = HTTPURLResponse(
-          url: targetURL,
-          statusCode: 429,
-          httpVersion: nil,
-          headerFields: [:]
-        )!
-        return (response, Data())
-      } else {
-        // Succeed on subsequent attempt
-        let response = HTTPURLResponse(
-          url: targetURL,
-          statusCode: 200,
-          httpVersion: nil,
-          headerFields: ["Content-Type": "application/json"]
-        )!
-        return (response, responseData)
-      }
+    let busy = { @Sendable (request: HTTPClientRequest) in
+      return HTTPClientResponse(version: .http2, status: .tooManyRequests)
     }
+    let success = { @Sendable (request: HTTPClientRequest) in
+      return HTTPClientResponse(
+        version: .http2,
+        status: .ok,
+        headers: .init([("Content-Type", "application/json")]),
+        body: .bytes(.init(data: responseData)),
+      )
+    }
+    let mock = MockHTTPClient([busy, success])
 
     let retryConfig = RetryConfiguration(
       maxAttempts: 2,
@@ -351,7 +297,7 @@ struct ExternalAccountTests {
       maxDelay: .milliseconds(1)
     )
 
-    let httpClient = AuthHTTPClient(session: self.mockSession)
+    let httpClient = AuthHTTPClient(mock: mock)
     let creds = try ExternalAccountCredentials(
       credentialSource: .programmatic(subjectTokenProvider: provider),
       audience: "aud",
@@ -364,7 +310,6 @@ struct ExternalAccountTests {
     // The call should succeed because the internal retry engine resolves it
     let headers = try await creds.headers()
     #expect(headers.contains { $0.0 == "Authorization" && $0.1 == "Bearer ya29.success-token" })
-    #expect(attempts.getCount() == 2)
   }
 
   @Test("Programmatic credentials do not retry on non-transient failures")
@@ -374,19 +319,15 @@ struct ExternalAccountTests {
 
     let attempts = CallCounter()
 
-    MockURLProtocol.requestHandler = { request in
-      attempts.increment()
-      // Permanent 403 error
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 403,
-        httpVersion: nil,
-        headerFields: [:]
-      )!
-      return (response, Data())
-    }
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        attempts.increment()
+        // Permanent 403 error
+        return HTTPClientResponse(version: .http2, status: .forbidden)
+      }
+    ])
 
-    let httpClient = AuthHTTPClient(session: self.mockSession)
+    let httpClient = AuthHTTPClient(mock: mock)
     let creds = try ExternalAccountCredentials(
       credentialSource: .programmatic(subjectTokenProvider: provider),
       audience: "aud",
@@ -414,8 +355,8 @@ struct ExternalAccountTests {
   func programmaticCredentialsRetriesOnProviderErrors() async throws {
     let provider = MockFailingSubjectTokenProvider()
     let targetURL = URL(string: "https://sts.googleapis.com/v1/token")!
-
-    let httpClient = AuthHTTPClient(session: self.mockSession)
+    let mock = MockHTTPClient([])
+    let httpClient = AuthHTTPClient(mock: mock)
     let creds = try ExternalAccountCredentials(
       credentialSource: .programmatic(subjectTokenProvider: provider),
       audience: "aud",
@@ -463,20 +404,21 @@ struct ExternalAccountTests {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let responseData = try encoder.encode(expectedResponse)
 
-    MockURLProtocol.requestHandler = { request in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "POST")
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .POST)
 
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, responseData)
-    }
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: responseData)),
+        )
+      }
+    ])
 
-    let httpClient = AuthHTTPClient(session: self.mockSession)
+    let httpClient = AuthHTTPClient(mock: mock)
     let creds = try ExternalAccountCredentials(
       credentialSource: .programmatic(subjectTokenProvider: provider),
       audience: "aud",
@@ -526,28 +468,20 @@ struct ExternalAccountTests {
 
     let attempts = CallCounter()
 
-    MockURLProtocol.requestHandler = { request in
-      let attempt = attempts.increment()
-      if attempt <= 2 {
-        // Fail with transient 503 error for first two attempts
-        let response = HTTPURLResponse(
-          url: targetURL,
-          statusCode: 503,
-          httpVersion: nil,
-          headerFields: [:]
-        )!
-        return (response, Data())
-      } else {
-        // Succeed on third attempt
-        let response = HTTPURLResponse(
-          url: targetURL,
-          statusCode: 200,
-          httpVersion: nil,
-          headerFields: ["Content-Type": "application/json"]
-        )!
-        return (response, responseData)
-      }
+    let unavailable = { @Sendable (request: HTTPClientRequest) in
+      attempts.increment()
+      return HTTPClientResponse(version: .http2, status: .serviceUnavailable)
     }
+    let success = { @Sendable (request: HTTPClientRequest) in
+      attempts.increment()
+      return HTTPClientResponse(
+        version: .http2,
+        status: .ok,
+        headers: .init([("Content-Type", "application/json")]),
+        body: .bytes(.init(data: responseData)),
+      )
+    }
+    let mock = MockHTTPClient([unavailable, unavailable, success])
 
     let retryConfig = RetryConfiguration(
       maxAttempts: 3,
@@ -556,7 +490,7 @@ struct ExternalAccountTests {
       maxDelay: .milliseconds(1)
     )
 
-    let httpClient = AuthHTTPClient(session: self.mockSession)
+    let httpClient = AuthHTTPClient(mock: mock)
     let creds = try ExternalAccountCredentials(
       credentialSource: .programmatic(subjectTokenProvider: provider),
       audience: "aud",
@@ -592,41 +526,35 @@ struct ExternalAccountTests {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let responseData = try encoder.encode(expectedResponse)
 
-    MockURLProtocol.requestHandler = { request in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "POST")
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) async throws in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .POST)
 
-      guard let bodyData = request.httpBody,
-        let bodyString = String(data: bodyData, encoding: .utf8)
-      else {
-        Issue.record("Request body is empty")
-        let errResponse = HTTPURLResponse(
-          url: targetURL,
-          statusCode: 400,
-          httpVersion: nil,
-          headerFields: nil
-        )!
-        return (errResponse, Data())
+        guard let buffer = try await request.body?.collect(upTo: 1024 * 1024) else {
+          Issue.record("Request body is empty")
+          return HTTPClientResponse(version: .http2, status: .badRequest)
+        }
+
+        let bodyString = (try buffer.getUTF8ValidatedString(at: 0, length: buffer.readableBytes))!
+        let queryItems = URLComponents(string: "?" + bodyString)?.queryItems ?? []
+        let params = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
+
+        #expect(params["options"] == nil)
+        #expect(
+          request.headers["Authorization"] == ["Basic dGVzdC1jbGllbnQtaWQ6dGVzdC1jbGllbnQtc2VjcmV0"]
+        )
+
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: responseData)),
+        )
       }
+    ])
 
-      let queryItems = URLComponents(string: "?" + bodyString)?.queryItems ?? []
-      let params = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
-
-      #expect(params["options"] == nil)
-      let expectedAuth =
-        "Basic dGVzdC1jbGllbnQtaWQ6dGVzdC1jbGllbnQtc2VjcmV0"
-      #expect(request.value(forHTTPHeaderField: "Authorization") == expectedAuth)
-
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, responseData)
-    }
-
-    let httpClient = AuthHTTPClient(session: self.mockSession)
+    let httpClient = AuthHTTPClient(mock: mock)
     let creds = try ExternalAccountCredentials(
       credentialSource: .programmatic(subjectTokenProvider: provider),
       audience: "//iam.googleapis.com/locations/global/workforcePools/wpool/providers/wprov",
@@ -658,38 +586,32 @@ struct ExternalAccountTests {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let responseData = try encoder.encode(expectedResponse)
 
-    MockURLProtocol.requestHandler = { request in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "POST")
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .POST)
 
-      guard let bodyData = request.httpBody,
-        let bodyString = String(data: bodyData, encoding: .utf8)
-      else {
-        Issue.record("Request body is empty")
-        let errResponse = HTTPURLResponse(
-          url: targetURL,
-          statusCode: 400,
-          httpVersion: nil,
-          headerFields: nil
-        )!
-        return (errResponse, Data())
+        guard let buffer = try await request.body?.collect(upTo: 1024 * 1024) else {
+          Issue.record("Request body is empty")
+          return HTTPClientResponse(version: .http2, status: .badRequest)
+        }
+
+        let bodyString = (try buffer.getUTF8ValidatedString(at: 0, length: buffer.readableBytes))!
+        let queryItems = URLComponents(string: "?" + bodyString)?.queryItems ?? []
+        let params = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
+
+        #expect(params["options"] == "{\"userProject\":\"quota-project\"}")
+
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: responseData)),
+        )
       }
+    ])
 
-      let queryItems = URLComponents(string: "?" + bodyString)?.queryItems ?? []
-      let params = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
-
-      #expect(params["options"] == "{\"userProject\":\"quota-project\"}")
-
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, responseData)
-    }
-
-    let httpClient = AuthHTTPClient(session: self.mockSession)
+    let httpClient = AuthHTTPClient(mock: mock)
     let creds = try ExternalAccountCredentials(
       credentialSource: .programmatic(subjectTokenProvider: provider),
       audience: "//iam.googleapis.com/locations/global/workforcePools/wpool/providers/wprov",

--- a/packages/auth/Tests/Http/AuthHTTPClientTests.swift
+++ b/packages/auth/Tests/Http/AuthHTTPClientTests.swift
@@ -13,64 +13,11 @@
 // limitations under the License.
 
 import Foundation
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
 import Testing
-
+import AsyncHTTPClient
 @testable import GoogleCloudAuth
 
-// MARK: - Mock Response Model
-
-private struct MockTokenResponse: Codable, Sendable, Equatable {
-  let accessToken: String
-  let expiresIn: Int
-}
-
-// MARK: - Mock URL Protocol for Mocking Network Requests
-
-private final class MockURLProtocol: URLProtocol {
-  nonisolated(unsafe) static var requestHandler:
-    (@Sendable (URLRequest) throws -> (URLResponse, Data))?
-
-  override class func canInit(with request: URLRequest) -> Bool {
-    return true
-  }
-
-  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-    return request
-  }
-
-  override func startLoading() {
-    guard let handler = MockURLProtocol.requestHandler else {
-      fatalError("Handler is not set.")
-    }
-
-    do {
-      let (response, data) = try handler(request)
-      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-      client?.urlProtocol(self, didLoad: data)
-      client?.urlProtocolDidFinishLoading(self)
-    } catch {
-      client?.urlProtocol(self, didFailWithError: error)
-    }
-  }
-
-  override func stopLoading() {}
-}
-
-// MARK: - Suite: AuthHTTPClient Test
-
-// Serialized because MockURLProtocol uses a shared static requestHandler.
-@Suite(.serialized) struct AuthHTTPClientTest {
-  private let mockSession: URLSession
-
-  init() {
-    let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [MockURLProtocol.self]
-    self.mockSession = URLSession(configuration: config)
-  }
-
+@Suite struct AuthHTTPClientTest {
   @Test func clientPerformsGetAndDecodesSnakeCase() async throws {
     let targetURL = URL(string: "https://oauth2.googleapis.com/token")!
     let mockPayload = MockTokenResponse(accessToken: "fake-token-123", expiresIn: 3600)
@@ -78,22 +25,21 @@ private final class MockURLProtocol: URLProtocol {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let encodedData = try encoder.encode(mockPayload)
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "GET")
-      #expect(request.value(forHTTPHeaderField: "X-Goog-Custom-Header") == "HeaderValue")
-      #expect(request.cachePolicy == .reloadIgnoringLocalCacheData)
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .GET)
+        #expect(request.headers["X-Goog-Custom-Header"] == ["HeaderValue"])
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData)),
+        )
+      }
+    ])
 
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, encodedData)
-    }
-
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let response: MockTokenResponse = try await client.get(
       url: targetURL,
       headers: ["X-Goog-Custom-Header": "HeaderValue"]
@@ -109,22 +55,22 @@ private final class MockURLProtocol: URLProtocol {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let encodedData = try encoder.encode(mockPayload)
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "POST")
-      #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
-      #expect(request.cachePolicy == .reloadIgnoringLocalCacheData)
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .POST)
+        #expect(request.headers["Content-Type"] == ["application/json"])
 
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, encodedData)
-    }
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData)),
+        )
+      }
+    ])
 
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let response: MockTokenResponse = try await client.post(
       url: targetURL,
       body: ["grant_type": "refresh_token"]
@@ -135,19 +81,16 @@ private final class MockURLProtocol: URLProtocol {
 
   @Test func clientThrowsHTTPStatusCodeError() async throws {
     let targetURL = URL(string: "https://oauth2.googleapis.com/invalid")!
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        return HTTPClientResponse(
+          version: .http2,
+          status: .serviceUnavailable,
+        )
+      }
+    ])
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 503,
-        httpVersion: nil as String?,
-        headerFields: nil as [String: String]?
-      )!
-      return (response, Data())
-    }
-
-    let client = AuthHTTPClient(session: self.mockSession)
-
+    let client = AuthHTTPClient(mock: mock)
     await #expect(throws: AuthHTTPError.self) {
       let _: MockTokenResponse = try await client.get(url: targetURL)
     }
@@ -158,22 +101,21 @@ private final class MockURLProtocol: URLProtocol {
     let mockEmail = "test-service-account@google.com"
     let mockData = Data(mockEmail.utf8)
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "GET")
-      #expect(request.value(forHTTPHeaderField: "Metadata-Flavor") == "Google")
-      #expect(request.cachePolicy == .reloadIgnoringLocalCacheData)
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .GET)
+        #expect(request.headers["Metadata-Flavor"] == ["Google"])
 
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: nil as [String: String]?
-      )!
-      return (response, mockData)
-    }
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          body: .bytes(.init(data: mockData)),
+        )
+      }
+    ])
 
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let result = try await client.getString(
       url: targetURL,
       headers: ["Metadata-Flavor": "Google"]
@@ -184,13 +126,13 @@ private final class MockURLProtocol: URLProtocol {
 
   @Test func clientThrowsNetworkError() async throws {
     let targetURL = URL(string: "https://oauth2.googleapis.com/token")!
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        throw URLError(.notConnectedToInternet)
+      }
+    ])
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      throw URLError(.notConnectedToInternet)
-    }
-
-    let client = AuthHTTPClient(session: self.mockSession)
-
+    let client = AuthHTTPClient(mock: mock)
     await #expect(throws: AuthHTTPError.self) {
       let _: MockTokenResponse = try await client.get(url: targetURL)
     }
@@ -203,21 +145,20 @@ private final class MockURLProtocol: URLProtocol {
   @Test func clientGetStringFailsOnInvalidUTF8() async throws {
     let targetURL = URL(string: "http://metadata.google.internal/invalid-utf8")!
     let mockData = Data([0xFF, 0xFE, 0xFD])  // Invalid UTF-8
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          body: .bytes(.init(data: mockData)),
+        )
+      }
+    ])
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: nil as [String: String]?
-      )!
-      return (response, mockData)
-    }
-
-    let client = AuthHTTPClient(session: self.mockSession)
-
+    let client = AuthHTTPClient(mock: mock)
     await #expect(throws: AuthHTTPError.self) {
-      try await client.getString(url: targetURL)
+      let s = try await client.getString(url: targetURL)
+      print(" s = \(s)")
     }
   }
 
@@ -227,22 +168,22 @@ private final class MockURLProtocol: URLProtocol {
     let encoder = JSONEncoder()
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let encodedData = try encoder.encode(mockPayload)
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .POST)
+        #expect(request.headers["X-Custom-Header"] == ["CustomValue"])
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "POST")
-      #expect(request.value(forHTTPHeaderField: "X-Custom-Header") == "CustomValue")
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData)),
+        )
+      }
+    ])
 
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, encodedData)
-    }
-
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let response: MockTokenResponse = try await client.post(
       url: targetURL,
       body: ["grant_type": "refresh_token"],
@@ -252,40 +193,21 @@ private final class MockURLProtocol: URLProtocol {
     #expect(response == mockPayload)
   }
 
-  @Test func clientThrowsOnNonHTTPResponse() async throws {
-    let targetURL = URL(string: "https://oauth2.googleapis.com/token")!
-
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      let response = URLResponse(
-        url: targetURL,
-        mimeType: nil,
-        expectedContentLength: 0,
-        textEncodingName: nil
-      )
-      return (response, Data())
-    }
-
-    let client = AuthHTTPClient(session: self.mockSession)
-
-    await #expect(throws: AuthHTTPError.self) {
-      let _: MockTokenResponse = try await client.get(url: targetURL)
-    }
-  }
-
   @Test func clientThrowsOnEmptyHTTPResponse() async throws {
     let targetURL = URL(string: "https://oauth2.googleapis.com/token")!
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, Data())
-    }
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: Data())),
+        )
+      }
+    ])
 
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     await #expect(throws: AuthHTTPError.self) {
       let _: MockTokenResponse = try await client.get(url: targetURL)
     }
@@ -300,25 +222,26 @@ private final class MockURLProtocol: URLProtocol {
 
     let postBody = Data("grant_type=urn:ietf:params:oauth:grant-type:token-exchange".utf8)
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "POST")
-      #expect(
-        request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
-      #expect(request.value(forHTTPHeaderField: "X-Custom-Header") == "Val")
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) async throws in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .POST)
+        #expect(request.headers["Content-Type"] == ["application/x-www-form-urlencoded"])
+        #expect(request.headers["X-Custom-Header"] == ["Val"])
+        let buffer = try await request.body!.collect(upTo: 1024 * 1024)
+        let got = Data(buffer: buffer)
+        #expect(got == postBody)
 
-      #expect(request.bodyData == postBody)
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData)),
+        )
+      }
+    ])
 
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, encodedData)
-    }
-
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let response: MockTokenResponse = try await client.postData(
       url: targetURL,
       bodyData: postBody,
@@ -328,4 +251,9 @@ private final class MockURLProtocol: URLProtocol {
 
     #expect(response == mockPayload)
   }
+}
+
+private struct MockTokenResponse: Codable, Sendable, Equatable {
+  let accessToken: String
+  let expiresIn: Int
 }

--- a/packages/auth/Tests/Http/AuthHTTPErrorTests.swift
+++ b/packages/auth/Tests/Http/AuthHTTPErrorTests.swift
@@ -13,11 +13,8 @@
 // limitations under the License.
 
 import Foundation
+import struct AsyncHTTPClient.HTTPClientResponse
 import Testing
-
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
 
 @testable import GoogleCloudAuth
 
@@ -25,20 +22,16 @@ import Testing
   private let testURL = URL(string: "https://example.com")!
 
   @Test func unsuccessfulResponseAccessors() {
-    let response = HTTPURLResponse(
-      url: testURL,
-      statusCode: 403,
-      httpVersion: nil,
-      headerFields: ["X-Custom-Header": "CustomValue"]
-    )!
     let bodyString = "Forbidden Access"
-    let data = Data(bodyString.utf8)
-
-    let error = AuthHTTPError.unsuccessfulResponse(response: response, data: data)
+    let response = HTTPClientResponse(
+      version: .http2,
+      status: .forbidden,
+      headers: .init([("X-Custom-Header", "CustomValue")]),
+      body: .bytes(.init(data: Data(bodyString.utf8))),
+    )
+    let error = AuthHTTPError.unsuccessfulResponse(response: response)
 
     #expect(error.statusCode == 403)
-    #expect(error.body == bodyString)
-    #expect(error.bodyData == data)
     #expect(error.headers?["X-Custom-Header"] == "CustomValue")
     #expect(error.urlError == nil)
   }
@@ -59,13 +52,10 @@ import Testing
       String.self,
       DecodingError.Context(codingPath: [], debugDescription: "Test")
     )
-    let testData = Data("Invalid JSON".utf8)
-    let error = AuthHTTPError.decodingError(error: decodingError, data: testData)
+    let error = AuthHTTPError.decodingError(error: decodingError)
 
     #expect(error.urlError == nil)
     #expect(error.statusCode == nil)
-    #expect(error.body == "Invalid JSON")
-    #expect(error.bodyData == testData)
     #expect(error.headers == nil)
   }
 

--- a/packages/auth/Tests/Http/RetryEngineTests.swift
+++ b/packages/auth/Tests/Http/RetryEngineTests.swift
@@ -14,16 +14,8 @@
 
 import Foundation
 import Testing
-
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
-
+import struct AsyncHTTPClient.HTTPClientResponse
 @testable import GoogleCloudAuth
-
-// MARK: - Thread-Safe Concurrency Counter for Swift 6 @Sendable Captures
-
-// MARK: - Suite: RetryEngine Test
 
 @Suite struct RetryEngineTest {
   private let testURL = URL(string: "https://example.com")!
@@ -60,9 +52,7 @@ import Testing
     ) {
       attempts.increment()
       if attempts.getCount() < 3 {
-        throw AuthHTTPError.unsuccessfulResponse(
-          response: HTTPURLResponse(
-            url: self.testURL, statusCode: 503, httpVersion: nil, headerFields: nil)!, data: Data())
+        throw Self.internalError()
       }
       return "recovered"
     }
@@ -91,9 +81,7 @@ import Testing
         }
       ) {
         attempts.increment()
-        throw AuthHTTPError.unsuccessfulResponse(
-          response: HTTPURLResponse(
-            url: self.testURL, statusCode: 404, httpVersion: nil, headerFields: nil)!, data: Data())
+        throw Self.notFoundError()
       }
     }
 
@@ -120,9 +108,7 @@ import Testing
         }
       ) {
         attempts.increment()
-        throw AuthHTTPError.unsuccessfulResponse(
-          response: HTTPURLResponse(
-            url: self.testURL, statusCode: 503, httpVersion: nil, headerFields: nil)!, data: Data())
+        throw Self.internalError()
       }
     }
 
@@ -214,6 +200,16 @@ import Testing
     }
 
     #expect(attempts.getCount() == 1)
+  }
+
+  static func internalError() -> AuthHTTPError {
+    .unsuccessfulResponse(
+      response: HTTPClientResponse(version: .http1_1, status: .serviceUnavailable))
+  }
+
+  static func notFoundError() -> AuthHTTPError {
+    .unsuccessfulResponse(
+      response: HTTPClientResponse(version: .http1_1, status: .notFound))
   }
 }
 

--- a/packages/auth/Tests/IntegrationTests/IntegrationTests.swift
+++ b/packages/auth/Tests/IntegrationTests/IntegrationTests.swift
@@ -13,16 +13,13 @@
 // limitations under the License.
 
 import Foundation
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
 @testable import GoogleCloudAuth
 import Testing
 
 #if IntegrationTests
 
   @Suite struct AuthHTTPClientIntegrationTests {
-    @Test func UrlSessionTest() async {
+    @Test func concurrentCallsStressTest() async {
       func runOnce() async {
         do {
           let client = AuthHTTPClient()
@@ -36,7 +33,7 @@ import Testing
       }
 
       let iterations = 100
-      print("Starting URLSession reproduction loop (\(iterations) iterations)...")
+      print("Starting concurrent requests stress test for (\(iterations) iterations)...")
       for i in 1...iterations {
         await runOnce()
         // Give it a tiny sleep to allow concurrent scheduling

--- a/packages/auth/Tests/MDSCredentialsTests.swift
+++ b/packages/auth/Tests/MDSCredentialsTests.swift
@@ -13,51 +13,12 @@
 // limitations under the License.
 
 import Foundation
+import AsyncHTTPClient
 import Testing
 @testable import GoogleCloudAuth
 
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
-
-private final class MockURLProtocol: URLProtocol {
-  nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (URLResponse, Data))?
-
-  override class func canInit(with request: URLRequest) -> Bool { true }
-  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-  override func startLoading() {
-    guard let handler = MockURLProtocol.requestHandler else {
-      fatalError("Handler is unavailable.")
-    }
-    do {
-      let (response, data) = try handler(request)
-      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-      client?.urlProtocol(self, didLoad: data)
-      client?.urlProtocolDidFinishLoading(self)
-    } catch {
-      client?.urlProtocol(self, didFailWithError: error)
-    }
-  }
-
-  override func stopLoading() {}
-}
-
-@Suite(.serialized) struct MDSCredentialsTest {
-  private let mockSession: URLSession
-
-  init() {
-    let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [MockURLProtocol.self]
-    self.mockSession = URLSession(configuration: config)
-  }
-
+@Suite struct MDSCredentialsTest {
   @Test func headersSuccessWithQuotaProject() async throws {
-    let targetURL = URL(
-      string:
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
-    )!
-
     struct MockResponse: Encodable {
       let accessToken: String
       let expiresIn: Int
@@ -68,20 +29,19 @@ private final class MockURLProtocol: URLProtocol {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let encodedData = try encoder.encode(mockPayload)
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.httpMethod == "GET")
-      #expect(request.url?.path == "/computeMetadata/v1/instance/service-accounts/default/token")
-      #expect(request.value(forHTTPHeaderField: "Metadata-Flavor") == "Google")
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, encodedData)
-    }
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        Self.checkRequest(request)
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData)),
+        )
+      }
+    ])
 
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let provider = MDSCredentials(
       quotaProjectID: "my-quota-project", client: client, environment: [:])
     let headers = try await provider.headers()
@@ -97,11 +57,6 @@ private final class MockURLProtocol: URLProtocol {
   }
 
   @Test func headersSuccessWithScopes() async throws {
-    let targetURL = URL(
-      string:
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token?scopes=scope1,scope2"
-    )!
-
     struct MockResponse: Encodable {
       let accessToken: String
       let expiresIn: Int
@@ -112,21 +67,23 @@ private final class MockURLProtocol: URLProtocol {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let encodedData = try encoder.encode(mockPayload)
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.httpMethod == "GET")
-      #expect(request.url?.path == "/computeMetadata/v1/instance/service-accounts/default/token")
-      #expect(request.value(forHTTPHeaderField: "Metadata-Flavor") == "Google")
-      #expect(request.url?.query == "scopes=scope1,scope2")
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, encodedData)
-    }
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        #expect(request.method == .GET)
+        let url = URL(string: request.url)!
+        #expect(url.path == "/computeMetadata/v1/instance/service-accounts/default/token")
+        #expect(url.query == "scopes=scope1,scope2")
+        #expect(request.headers["Metadata-Flavor"] == ["Google"])
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData)),
+        )
+      }
+    ])
 
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let provider = MDSCredentials(
       scopes: ["scope1", "scope2"], client: client, environment: [:])
     let headers = try await provider.headers()
@@ -138,10 +95,6 @@ private final class MockURLProtocol: URLProtocol {
   }
 
   @Test func gceMetadataHostEnvVar() async throws {
-    let targetURL = URL(
-      string: "http://127.0.0.1:8080/computeMetadata/v1/instance/service-accounts/default/token"
-    )!
-
     struct MockResponse: Encodable {
       let accessToken: String
       let expiresIn: Int
@@ -153,17 +106,19 @@ private final class MockURLProtocol: URLProtocol {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let encodedData = try encoder.encode(mockPayload)
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.httpMethod == "GET")
-      #expect(request.url?.path == "/computeMetadata/v1/instance/service-accounts/default/token")
-      #expect(request.value(forHTTPHeaderField: "Metadata-Flavor") == "Google")
-      let response = HTTPURLResponse(
-        url: targetURL, statusCode: 200, httpVersion: nil,
-        headerFields: ["Content-Type": "application/json"])!
-      return (response, encodedData)
-    }
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        Self.checkRequest(request)
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData)),
+        )
+      }
+    ])
 
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let provider = MDSCredentials(
       client: client, environment: ["GCE_METADATA_HOST": "127.0.0.1:8080"])
     let headers = try await provider.headers()
@@ -175,20 +130,21 @@ private final class MockURLProtocol: URLProtocol {
   }
 
   @Test func mdsProviderUniverseDomainIsNil() async throws {
-    let client = AuthHTTPClient(session: self.mockSession)
+    let mock = MockHTTPClient([])
+    let client = AuthHTTPClient(mock: mock)
     let provider = MDSCredentials(client: client, environment: [:])
     let ud = await provider.universeDomain()
     #expect(ud == nil, "Universe domain should be nil for MDS provider")
   }
 
   @Test func adcNoMDS() async throws {
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.httpMethod == "GET")
-      #expect(request.url?.path == "/computeMetadata/v1/instance/service-accounts/default/token")
-      #expect(request.value(forHTTPHeaderField: "Metadata-Flavor") == "Google")
-      throw URLError(.cannotConnectToHost)
-    }
-    let client = AuthHTTPClient(session: self.mockSession)
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        Self.checkRequest(request)
+        throw URLError(.cannotConnectToHost)
+      }
+    ])
+    let client = AuthHTTPClient(mock: mock)
     let provider = MDSCredentials(client: client, fromADC: true, environment: [:])
     let error = await #expect(throws: CredentialsError.self) { _ = try await provider.headers() }
 
@@ -208,13 +164,13 @@ private final class MockURLProtocol: URLProtocol {
   }
 
   @Test func adcOverriddenMDS() async throws {
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.httpMethod == "GET")
-      #expect(request.url?.path == "/computeMetadata/v1/instance/service-accounts/default/token")
-      #expect(request.value(forHTTPHeaderField: "Metadata-Flavor") == "Google")
-      throw URLError(.cannotConnectToHost)
-    }
-    let client = AuthHTTPClient(session: self.mockSession)
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        Self.checkRequest(request)
+        throw URLError(.cannotConnectToHost)
+      }
+    ])
+    let client = AuthHTTPClient(mock: mock)
     let provider = MDSCredentials(
       client: client, fromADC: true, environment: ["GCE_METADATA_HOST": "127.0.0.1:8080"])
     let error = await #expect(throws: AuthHTTPError.self) { _ = try await provider.headers() }
@@ -225,39 +181,31 @@ private final class MockURLProtocol: URLProtocol {
   }
 
   @Test func retriesOnTransientFailures() async throws {
-    let targetURL = URL(
-      string:
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
-    )!
     struct MockResponse: Encodable {
       let accessToken: String; let expiresIn: Int; let tokenType: String
     }
     let mockPayload = MockResponse(accessToken: "mock-token", expiresIn: 3600, tokenType: "Bearer")
     let encodedData = try JSONEncoder().encode(mockPayload)
 
-    let attempts = CallCounter()
-
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.httpMethod == "GET")
-      #expect(request.url?.path == "/computeMetadata/v1/instance/service-accounts/default/token")
-      #expect(request.value(forHTTPHeaderField: "Metadata-Flavor") == "Google")
-      let count = attempts.increment()
-      if count < 3 {
-        return (
-          HTTPURLResponse(url: targetURL, statusCode: 503, httpVersion: nil, headerFields: nil)!,
-          Data()
-        )
-      }
-      return (
-        HTTPURLResponse(
-          url: targetURL, statusCode: 200, httpVersion: nil,
-          headerFields: ["Content-Type": "application/json"])!, encodedData
+    let unavailable = { @Sendable (_ request: HTTPClientRequest) in
+      Self.checkRequest(request)
+      return HTTPClientResponse(version: .http2, status: .serviceUnavailable)
+    }
+    let success = { @Sendable (request: HTTPClientRequest) in
+      Self.checkRequest(request)
+      return HTTPClientResponse(
+        version: .http2,
+        status: .ok,
+        headers: .init([("Content-Type", "application/json")]),
+        body: .bytes(.init(data: encodedData)),
       )
     }
 
+    let mock = MockHTTPClient([unavailable, unavailable, success])
+
     let retryConfig = RetryConfiguration(
       maxAttempts: 3, initialDelay: .milliseconds(1), multiplier: 1.0, maxDelay: .milliseconds(1))
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let provider = MDSCredentials(
       retryConfiguration: retryConfig, client: client, fromADC: false, environment: [:])
     let headers = try await provider.headers()
@@ -266,44 +214,34 @@ private final class MockURLProtocol: URLProtocol {
       headers.contains { $0.0 == "Authorization" && $0.1 == "Bearer mock-token" },
       "Missing authorization header in \(headers)"
     )
-    let count = attempts.getCount()
-    #expect(count == 3, "Expected exactly 3 execution attempts, got \(count)")
   }
 
   @Test func retriesForSuccess() async throws {
-    let targetURL = URL(
-      string:
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
-    )!
     struct MockResponse: Encodable {
       let accessToken: String; let expiresIn: Int; let tokenType: String
     }
     let encodedData = try JSONEncoder().encode(
       MockResponse(accessToken: "mock-token", expiresIn: 3600, tokenType: "Bearer"))
 
-    let attempts = CallCounter()
-
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.httpMethod == "GET")
-      #expect(request.url?.path == "/computeMetadata/v1/instance/service-accounts/default/token")
-      #expect(request.value(forHTTPHeaderField: "Metadata-Flavor") == "Google")
-      let count = attempts.increment()
-      if count == 1 {
-        return (
-          HTTPURLResponse(url: targetURL, statusCode: 500, httpVersion: nil, headerFields: nil)!,
-          Data()
-        )
-      }
-      return (
-        HTTPURLResponse(
-          url: targetURL, statusCode: 200, httpVersion: nil,
-          headerFields: ["Content-Type": "application/json"])!, encodedData
+    let internalError = { @Sendable (request: HTTPClientRequest) in
+      Self.checkRequest(request)
+      return HTTPClientResponse(version: .http2, status: .internalServerError)
+    }
+    let success = { @Sendable (request: HTTPClientRequest) in
+      Self.checkRequest(request)
+      return HTTPClientResponse(
+        version: .http2,
+        status: .ok,
+        headers: .init([("Content-Type", "application/json")]),
+        body: .bytes(.init(data: encodedData)),
       )
     }
 
+    let mock = MockHTTPClient([internalError, success])
+
     let retryConfig = RetryConfiguration(
       maxAttempts: 2, initialDelay: .milliseconds(1), multiplier: 1.0, maxDelay: .milliseconds(1))
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let provider = MDSCredentials(retryConfiguration: retryConfig, client: client, environment: [:])
     let headers = try await provider.headers()
 
@@ -311,31 +249,22 @@ private final class MockURLProtocol: URLProtocol {
       headers.contains { $0.0 == "Authorization" && $0.1 == "Bearer mock-token" },
       "Missing authorization header in \(headers)"
     )
-    let count = attempts.getCount()
-    #expect(count == 2, "Expected exactly 2 execution attempts, got \(count)")
   }
 
   @Test func doesNotRetryOnNonTransientFailures() async throws {
-    let targetURL = URL(
-      string:
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
-    )!
     let attempts = CallCounter()
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.httpMethod == "GET")
-      #expect(request.url?.path == "/computeMetadata/v1/instance/service-accounts/default/token")
-      #expect(request.value(forHTTPHeaderField: "Metadata-Flavor") == "Google")
-      let _ = attempts.increment()
-      return (
-        HTTPURLResponse(url: targetURL, statusCode: 404, httpVersion: nil, headerFields: nil)!,
-        Data()
-      )
-    }
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        Self.checkRequest(request)
+        let _ = attempts.increment()
+        return HTTPClientResponse(version: .http2, status: .notFound, )
+      }
+    ])
 
     let retryConfig = RetryConfiguration(
       maxAttempts: 3, initialDelay: .milliseconds(1), multiplier: 1.0, maxDelay: .milliseconds(1))
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let provider = MDSCredentials(retryConfiguration: retryConfig, client: client, environment: [:])
 
     await #expect(throws: AuthHTTPError.self) {
@@ -346,10 +275,6 @@ private final class MockURLProtocol: URLProtocol {
   }
 
   @Test func tokenCaching() async throws {
-    let targetURL = URL(
-      string:
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
-    )!
     struct MockResponse: Encodable {
       let accessToken: String; let expiresIn: Int; let tokenType: String
     }
@@ -358,19 +283,20 @@ private final class MockURLProtocol: URLProtocol {
 
     let networkCalls = CallCounter()
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.httpMethod == "GET")
-      #expect(request.url?.path == "/computeMetadata/v1/instance/service-accounts/default/token")
-      #expect(request.value(forHTTPHeaderField: "Metadata-Flavor") == "Google")
-      let _ = networkCalls.increment()
-      return (
-        HTTPURLResponse(
-          url: targetURL, statusCode: 200, httpVersion: nil,
-          headerFields: ["Content-Type": "application/json"])!, encodedData
-      )
-    }
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        Self.checkRequest(request)
+        let _ = networkCalls.increment()
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData)),
+        )
+      }
+    ])
 
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let provider = MDSCredentials(client: client, environment: [:])
 
     _ = try await provider.headers()
@@ -383,36 +309,30 @@ private final class MockURLProtocol: URLProtocol {
   }
 
   @Test func retriesOnTransientNetworkErrors() async throws {
-    let targetURL = URL(
-      string:
-        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
-    )!
     struct MockResponse: Encodable {
       let accessToken: String; let expiresIn: Int; let tokenType: String
     }
     let encodedData = try JSONEncoder().encode(
       MockResponse(accessToken: "mock-token", expiresIn: 3600, tokenType: "Bearer"))
 
-    let attempts = CallCounter()
-
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.httpMethod == "GET")
-      #expect(request.url?.path == "/computeMetadata/v1/instance/service-accounts/default/token")
-      #expect(request.value(forHTTPHeaderField: "Metadata-Flavor") == "Google")
-      let count = attempts.increment()
-      if count == 1 {
-        throw URLError(.timedOut)
-      }
-      return (
-        HTTPURLResponse(
-          url: targetURL, statusCode: 200, httpVersion: nil,
-          headerFields: ["Content-Type": "application/json"])!, encodedData
+    let timeout = { @Sendable (request: HTTPClientRequest) throws -> HTTPClientResponse in
+      Self.checkRequest(request)
+      throw URLError(.timedOut)
+    }
+    let success = { @Sendable (request: HTTPClientRequest) throws in
+      Self.checkRequest(request)
+      return HTTPClientResponse(
+        version: .http2,
+        status: .ok,
+        headers: .init([("Content-Type", "application/json")]),
+        body: .bytes(.init(data: encodedData)),
       )
     }
+    let mock = MockHTTPClient([timeout, success])
 
     let retryConfig = RetryConfiguration(
       maxAttempts: 2, initialDelay: .milliseconds(1), multiplier: 1.0, maxDelay: .milliseconds(1))
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let provider = MDSCredentials(retryConfiguration: retryConfig, client: client, environment: [:])
     let headers = try await provider.headers()
 
@@ -420,7 +340,16 @@ private final class MockURLProtocol: URLProtocol {
       headers.contains { $0.0 == "Authorization" && $0.1 == "Bearer mock-token" },
       "Missing authorization header in \(headers)"
     )
-    let count = attempts.getCount()
-    #expect(count == 2, "Expected exactly 2 execution attempts, got \(count)")
+  }
+
+  static func checkRequest(
+    _ request: HTTPClientRequest, sourceLocation: SourceLocation = #_sourceLocation
+  ) {
+    #expect(request.method == .GET)
+    let url = URL(string: request.url)!
+    #expect(
+      url.path == "/computeMetadata/v1/instance/service-accounts/default/token",
+      sourceLocation: sourceLocation)
+    #expect(request.headers["Metadata-Flavor"] == ["Google"], sourceLocation: sourceLocation)
   }
 }

--- a/packages/auth/Tests/MockHTTPClient.swift
+++ b/packages/auth/Tests/MockHTTPClient.swift
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Synchronization
+import struct DequeModule.Deque
+import struct Logging.Logger
+import AsyncHTTPClient
+import Testing
+@testable import GoogleCloudAuth
+
+final class MockHTTPClient: HTTPClientProtocol {
+  typealias Closure = @Sendable (HTTPClientRequest) async throws -> HTTPClientResponse
+  enum MockError: Error, Sendable {
+    case empty
+  }
+
+  let responses: Mutex<Deque<Closure>>
+
+  init(_ responses: [Closure]) {
+    self.responses = Mutex(Deque(responses))
+  }
+
+  deinit {
+    #expect(responses.withLock { $0.isEmpty })
+  }
+
+  public func execute(request: HTTPClientRequest, timeout: Duration, logger: Logger?) async throws
+    -> HTTPClientResponse
+  {
+    guard let closure = self.responses.withLock({ $0.popFirst() }) else {
+      throw MockError.empty
+    }
+    return try await closure(request)
+  }
+}

--- a/packages/auth/Tests/STSHandlerTests.swift
+++ b/packages/auth/Tests/STSHandlerTests.swift
@@ -13,52 +13,11 @@
 // limitations under the License.
 
 import Foundation
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
+import AsyncHTTPClient
 import Testing
-
 @testable import GoogleCloudAuth
 
-private final class MockURLProtocol: URLProtocol {
-  nonisolated(unsafe) static var requestHandler:
-    (@Sendable (URLRequest) throws -> (URLResponse, Data))?
-
-  override class func canInit(with request: URLRequest) -> Bool {
-    return true
-  }
-
-  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-    return request
-  }
-
-  override func startLoading() {
-    guard let handler = MockURLProtocol.requestHandler else {
-      fatalError("Handler is not set.")
-    }
-
-    do {
-      let (response, data) = try handler(request)
-      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-      client?.urlProtocol(self, didLoad: data)
-      client?.urlProtocolDidFinishLoading(self)
-    } catch {
-      client?.urlProtocol(self, didFailWithError: error)
-    }
-  }
-
-  override func stopLoading() {}
-}
-
-@Suite(.serialized) struct STSHandlerTests {
-  private let mockSession: URLSession
-
-  init() {
-    let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [MockURLProtocol.self]
-    self.mockSession = URLSession(configuration: config)
-  }
-
+@Suite struct STSHandlerTests {
   @Test("Verifies form-urlencoded POST exchange parameters and client authentication headers")
   func exchangeToken() async throws {
     let targetURL = try #require(URL(string: "https://sts.googleapis.com/v1/token"))
@@ -77,50 +36,47 @@ private final class MockURLProtocol: URLProtocol {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let encodedResponse = try encoder.encode(expectedResponse)
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "POST")
-      #expect(
-        request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) async throws in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .POST)
+        #expect(request.headers["Content-Type"] == ["application/x-www-form-urlencoded"])
 
-      // HTTP Basic Authentication verifies client credentials formatted as "clientID:clientSecret" encoded in Base64.
-      let expectedAuth = "Basic \(Data("\(clientID):\(clientSecret)".utf8).base64EncodedString())"
-      #expect(request.value(forHTTPHeaderField: "Authorization") == expectedAuth)
+        // HTTP Basic Authentication verifies client credentials formatted as "clientID:clientSecret" encoded in Base64.
+        let expectedAuth = "Basic \(Data("\(clientID):\(clientSecret)".utf8).base64EncodedString())"
+        #expect(request.headers["Authorization"] == [expectedAuth])
 
-      // Request body verification
-      guard let bodyData = request.httpBody,
-        let bodyString = String(data: bodyData, encoding: .utf8)
-      else {
-        Issue.record("Request body is empty")
-        let response = try #require(
-          HTTPURLResponse(
-            url: targetURL, statusCode: 400, httpVersion: nil as String?,
-            headerFields: nil as [String: String]?))
-        return (response, Data())
+        // Request body verification
+        guard let buffer = try await request.body?.collect(upTo: 1024 * 1024) else {
+          Issue.record("Request body is empty")
+          return HTTPClientResponse(version: .http2, status: .badRequest)
+        }
+        let bodyString = String(
+          data: buffer.getData(at: 0, length: buffer.readableBytes)!,
+          encoding: .utf8,
+        )!
+
+        // Verify body parameters
+        let queryItems = URLComponents(string: "?" + bodyString)?.queryItems ?? []
+        let params = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
+
+        #expect(params["grant_type"] == "urn:ietf:params:oauth:grant-type:token-exchange")
+        #expect(params["requested_token_type"] == "urn:ietf:params:oauth:token-type:access_token")
+        #expect(params["subject_token"] == "fake-subject-token")
+        #expect(params["subject_token_type"] == "urn:ietf:params:oauth:token-type:id_token")
+        #expect(params["scope"] == "scope1 scope2")
+        #expect(params["audience"] == "test-audience")
+
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedResponse)),
+        )
       }
+    ])
 
-      // Verify body parameters
-      let queryItems = URLComponents(string: "?" + bodyString)?.queryItems ?? []
-      let params = Dictionary(uniqueKeysWithValues: queryItems.map { ($0.name, $0.value) })
-
-      #expect(params["grant_type"] == "urn:ietf:params:oauth:grant-type:token-exchange")
-      #expect(params["requested_token_type"] == "urn:ietf:params:oauth:token-type:access_token")
-      #expect(params["subject_token"] == "fake-subject-token")
-      #expect(params["subject_token_type"] == "urn:ietf:params:oauth:token-type:id_token")
-      #expect(params["scope"] == "scope1 scope2")
-      #expect(params["audience"] == "test-audience")
-
-      let response = try #require(
-        HTTPURLResponse(
-          url: targetURL,
-          statusCode: 200,
-          httpVersion: nil as String?,
-          headerFields: ["Content-Type": "application/json"]
-        ))
-      return (response, encodedResponse)
-    }
-
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let handler = STSHandler(httpClient: client)
 
     let request = ExchangeTokenRequest(
@@ -144,24 +100,25 @@ private final class MockURLProtocol: URLProtocol {
   func exchangeTokenErr() async throws {
     let targetURL = try #require(URL(string: "https://sts.googleapis.com/v1/token"))
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      let response = try #require(
-        HTTPURLResponse(
-          url: targetURL,
-          statusCode: 400,
-          httpVersion: nil as String?,
-          headerFields: ["Content-Type": "application/json"]
-        ))
-      let errorPayload = """
-        {
-          "error": "invalid_grant",
-          "error_description": "Invalid subject token"
-        }
-        """
-      return (response, Data(errorPayload.utf8))
-    }
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        let errorPayload = """
+          {
+            "error": "invalid_grant",
+            "error_description": "Invalid subject token"
+          }
+          """
+        return
+          HTTPClientResponse(
+            version: .http2,
+            status: .badRequest,
+            headers: .init([("Content-Type", "application/json")]),
+            body: .bytes(.init(data: Data(errorPayload.utf8))),
+          )
+      }
+    ])
 
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let handler = STSHandler(httpClient: client)
 
     let request = ExchangeTokenRequest(
@@ -190,42 +147,39 @@ private final class MockURLProtocol: URLProtocol {
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let encodedResponse = try encoder.encode(expectedResponse)
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "POST")
-      #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) async throws in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .POST)
+        #expect(request.headers["Content-Type"] == ["application/json"])
 
-      guard let bodyData = request.httpBody else {
-        Issue.record("Request body is empty")
-        let response = try #require(
-          HTTPURLResponse(
-            url: targetURL, statusCode: 400, httpVersion: nil as String?,
-            headerFields: nil as [String: String]?))
-        return (response, Data())
+        guard let bodyData = try await request.body?.collect(upTo: 1024 * 1024) else {
+          Issue.record("Request body is empty")
+          return HTTPClientResponse(version: .http2, status: .badRequest)
+        }
+
+        do {
+          let jsonDict = try JSONDecoder().decode([String: String].self, from: bodyData)
+          #expect(jsonDict["grant_type"] == "urn:ietf:params:oauth:grant-type:token-exchange")
+          #expect(
+            jsonDict["requested_token_type"] == "urn:ietf:params:oauth:token-type:access_token")
+          #expect(jsonDict["subject_token"] == "fake-subject-token")
+          #expect(jsonDict["subject_token_type"] == "urn:ietf:params:oauth:token-type:id_token")
+          #expect(jsonDict["options"] == "{\"userProject\":\"test-quota-project\"}")
+        } catch {
+          Issue.record("Failed to parse JSON body: \(error)")
+        }
+
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedResponse)),
+        )
       }
+    ])
 
-      do {
-        let jsonDict = try JSONDecoder().decode([String: String].self, from: bodyData)
-        #expect(jsonDict["grant_type"] == "urn:ietf:params:oauth:grant-type:token-exchange")
-        #expect(jsonDict["requested_token_type"] == "urn:ietf:params:oauth:token-type:access_token")
-        #expect(jsonDict["subject_token"] == "fake-subject-token")
-        #expect(jsonDict["subject_token_type"] == "urn:ietf:params:oauth:token-type:id_token")
-        #expect(jsonDict["options"] == "{\"userProject\":\"test-quota-project\"}")
-      } catch {
-        Issue.record("Failed to parse JSON body: \(error)")
-      }
-
-      let response = try #require(
-        HTTPURLResponse(
-          url: targetURL,
-          statusCode: 200,
-          httpVersion: nil as String?,
-          headerFields: ["Content-Type": "application/json"]
-        ))
-      return (response, encodedResponse)
-    }
-
-    let client = AuthHTTPClient(session: self.mockSession)
+    let client = AuthHTTPClient(mock: mock)
     let handler = STSHandler(httpClient: client)
 
     let request = ExchangeTokenRequest(

--- a/packages/auth/Tests/UserCredentialsTests.swift
+++ b/packages/auth/Tests/UserCredentialsTests.swift
@@ -422,8 +422,8 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
     // Give the background task a moment to run and either sleep or terminate.
     try? await Task.sleep(for: .milliseconds(100))
 
-    // Real-time sleeps are necessary because background refresh loops and URLSession
-    // mock protocols execute asynchronously across thread boundaries.
+    // Real-time sleeps are necessary because background refresh loops and the mock execute
+    // asynchronously across thread boundaries.
     if clock.hasSleepers {
       clock.advance(by: .seconds(11))
       // Wait for the async retry attempt to complete

--- a/packages/auth/Tests/UserCredentialsTests.swift
+++ b/packages/auth/Tests/UserCredentialsTests.swift
@@ -14,47 +14,39 @@
 
 import Foundation
 import Testing
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
+import AsyncHTTPClient
 @testable import GoogleCloudAuth
 
 typealias UserCredentials = UserCredentialsGeneric<TestClock>
 
-@Suite(.serialized) struct UserCredentialsTest {
-  private let mockSession: URLSession
-
-  init() {
-    let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [MockURLProtocol.self]
-    self.mockSession = URLSession(configuration: config)
-  }
-
+@Suite struct UserCredentialsTest {
   @Test func userProviderHeadersAndUniverseDomain() async throws {
     let targetURL = URL(string: "https://mock.example.com")!
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, Data("{}".utf8))
-    }
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        #expect(request.url == targetURL.absoluteString)
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: Data("{}".utf8))),
+        )
+      }
+    ])
 
     let mockData = UserAccountData(
       type: "authorized_user",
       clientId: "mock-id",
       clientSecret: "mock-secret",
       refreshToken: "mock-token",
-      tokenUri: "https://mock.example.com",
+      tokenUri: targetURL.absoluteString,
       quotaProjectId: "mock-project"
     )
 
     let provider = try UserCredentials(
       user: mockData,
       universeDomain: defaultUniverseDomain,
-      httpClient: AuthHTTPClient(session: self.mockSession),
+      httpClient: AuthHTTPClient(mock: mock),
       retryConfiguration: .defaultConfiguration,
       clock: TestClock()
     )
@@ -77,20 +69,20 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let encodedData = try encoder.encode(responsePayload)
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "POST")
-      #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
-      #expect(request.cachePolicy == .reloadIgnoringLocalCacheData)
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .POST)
+        #expect(request.headers["Content-Type"] == ["application/json"])
 
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, encodedData)
-    }
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData)),
+        )
+      }
+    ])
 
     let data = UserAccountData(
       type: "authorized_user",
@@ -103,7 +95,7 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
     let source = try UserCredentials(
       user: data,
       scopes: nil,
-      httpClient: AuthHTTPClient(session: self.mockSession),
+      httpClient: AuthHTTPClient(mock: mock),
       retryConfiguration: .defaultConfiguration,
       clock: TestClock()
     )
@@ -126,35 +118,36 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let encodedData = try encoder.encode(responsePayload)
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "POST")
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) async throws in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .POST)
 
-      // Read request body and verify scopes are space-separated
-      guard let bodyData = request.bodyData else {
-        fatalError("Expected HTTP body")
-      }
-      let decoder = JSONDecoder()
-      decoder.keyDecodingStrategy = .convertFromSnakeCase
-      do {
-        let requestPayload = try decoder.decode(Oauth2RefreshRequest.self, from: bodyData)
-        #expect(requestPayload.scopes == "scope1 scope2")
-        #expect(requestPayload.clientId == "test-client-id")
-        #expect(requestPayload.clientSecret == "test-client-secret")
-        #expect(requestPayload.refreshToken == "test-refresh-token")
-        #expect(requestPayload.grantType == "refresh_token")
-      } catch {
-        Issue.record("Failed to decode request body: \(error)")
-      }
+        // Read request body and verify scopes are space-separated
+        guard let bodyData = try await request.body?.collect(upTo: 1024 * 1024) else {
+          fatalError("Expected HTTP body")
+        }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        do {
+          let requestPayload = try decoder.decode(Oauth2RefreshRequest.self, from: bodyData)
+          #expect(requestPayload.scopes == "scope1 scope2")
+          #expect(requestPayload.clientId == "test-client-id")
+          #expect(requestPayload.clientSecret == "test-client-secret")
+          #expect(requestPayload.refreshToken == "test-refresh-token")
+          #expect(requestPayload.grantType == "refresh_token")
+        } catch {
+          Issue.record("Failed to decode request body: \(error)")
+        }
 
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, encodedData)
-    }
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData)),
+        )
+      }
+    ])
 
     let data = UserAccountData(
       type: "authorized_user",
@@ -166,7 +159,7 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
     let source = try UserCredentials(
       user: data,
       scopes: ["scope1", "scope2"],
-      httpClient: AuthHTTPClient(session: self.mockSession),
+      httpClient: AuthHTTPClient(mock: mock),
       retryConfiguration: .defaultConfiguration,
       clock: TestClock()
     )
@@ -183,15 +176,15 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
   @Test func credentialProviderRetryableError() async throws {
     let targetURL = URL(string: "https://oauth2.googleapis.com/token")!
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 503,
-        httpVersion: nil as String?,
-        headerFields: nil as [String: String]?
-      )!
-      return (response, Data())
-    }
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        #expect(request.url == targetURL.absoluteString)
+        return HTTPClientResponse(
+          version: .http2,
+          status: .serviceUnavailable,
+        )
+      }
+    ])
 
     let data = UserAccountData(
       type: "authorized_user",
@@ -211,7 +204,7 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
     let source = try UserCredentials(
       user: data,
       scopes: nil,
-      httpClient: AuthHTTPClient(session: self.mockSession),
+      httpClient: AuthHTTPClient(mock: mock),
       retryConfiguration: retryConfig,
       clock: TestClock()
     )
@@ -224,15 +217,15 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
   @Test func tokenProviderNonretryableError() async throws {
     let targetURL = URL(string: "https://oauth2.googleapis.com/token")!
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 401,
-        httpVersion: nil as String?,
-        headerFields: nil as [String: String]?
-      )!
-      return (response, Data())
-    }
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        #expect(request.url == targetURL.absoluteString)
+        return HTTPClientResponse(
+          version: .http2,
+          status: .unauthorized,
+        )
+      }
+    ])
 
     let data = UserAccountData(
       type: "authorized_user",
@@ -244,7 +237,7 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
     let source = try UserCredentials(
       user: data,
       scopes: nil,
-      httpClient: AuthHTTPClient(session: self.mockSession),
+      httpClient: AuthHTTPClient(mock: mock),
       retryConfiguration: .defaultConfiguration,
       clock: TestClock()
     )
@@ -255,19 +248,19 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
   }
 
   @Test func tokenProviderMalformedResponseIsNonretryable() async throws {
-    let targetURL = URL(string: "https://oauth2.googleapis.com/token")!
     let malformedPayload = "invalid-json"
     let encodedData = Data(malformedPayload.utf8)
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, encodedData)
-    }
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData)),
+        )
+      }
+    ])
 
     let data = UserAccountData(
       type: "authorized_user",
@@ -279,7 +272,7 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
     let source = try UserCredentials(
       user: data,
       scopes: nil,
-      httpClient: AuthHTTPClient(session: self.mockSession),
+      httpClient: AuthHTTPClient(mock: mock),
       retryConfiguration: .defaultConfiguration,
       clock: TestClock()
     )
@@ -322,23 +315,24 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
 
     let requestCount = CallCounter()
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      #expect(request.url == targetURL)
-      #expect(request.httpMethod == "POST")
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) async throws in
+        #expect(request.url == targetURL.absoluteString)
+        #expect(request.method == .POST)
 
-      // Artificial small delay to let concurrent tasks spawn and queue up on the active refresh task
-      Thread.sleep(forTimeInterval: 0.05)
+        // Artificial small delay to let concurrent tasks spawn and queue up on the active refresh task
+        try await Task.sleep(until: ContinuousClock.Instant.now + .milliseconds(50))
 
-      requestCount.increment()
+        requestCount.increment()
 
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 200,
-        httpVersion: nil as String?,
-        headerFields: ["Content-Type": "application/json"]
-      )!
-      return (response, encodedData)
-    }
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData)),
+        )
+      }
+    ])
 
     let data = UserAccountData(
       type: "authorized_user",
@@ -350,7 +344,7 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
     let source = try UserCredentials(
       user: data,
       scopes: nil,
-      httpClient: AuthHTTPClient(session: self.mockSession),
+      httpClient: AuthHTTPClient(mock: mock),
       retryConfiguration: .defaultConfiguration,
       clock: TestClock()
     )
@@ -383,20 +377,19 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
   }
 
   @Test func testReproNonRetryableRetry() async throws {
-    let targetURL = URL(string: "https://oauth2.googleapis.com/token")!
     let attempts = CallCounter()
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      attempts.increment()
-      let response = HTTPURLResponse(
-        url: targetURL,
-        statusCode: 401,
-        httpVersion: nil as String?,
-        headerFields: nil as [String: String]?
-      )!
-      let errorPayload = Data("{\"error\": \"invalid_grant\"}".utf8)
-      return (response, errorPayload)
-    }
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        attempts.increment()
+        let errorPayload = Data("{\"error\": \"invalid_grant\"}".utf8)
+        return HTTPClientResponse(
+          version: .http2,
+          status: .unauthorized,
+          body: .bytes(.init(data: errorPayload)),
+        )
+      }
+    ])
 
     let data = UserAccountData(
       type: "authorized_user",
@@ -417,7 +410,7 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
     let source = try UserCredentials(
       user: data,
       scopes: nil,
-      httpClient: AuthHTTPClient(session: self.mockSession),
+      httpClient: AuthHTTPClient(mock: mock),
       retryConfiguration: retryConfig,
       clock: clock
     )
@@ -447,12 +440,13 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
       clientSecret: "mock-secret",
       refreshToken: "mock-token"
     )
+    let mock = MockHTTPClient([])
 
     #expect {
       try UserCredentials(
         user: mockData,
         universeDomain: "custom.com",
-        httpClient: AuthHTTPClient(session: self.mockSession),
+        httpClient: AuthHTTPClient(mock: mock),
         retryConfiguration: .defaultConfiguration,
         clock: TestClock()
       )
@@ -466,7 +460,6 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
   }
 
   @Test func testRetryOnTransientNetworkError() async throws {
-    let targetURL = URL(string: "https://oauth2.googleapis.com/token")!
     let attempts = CallCounter()
     let responsePayload = Oauth2RefreshResponse(
       accessToken: "recovered-timeout-token",
@@ -477,20 +470,21 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
     encoder.keyEncodingStrategy = .convertToSnakeCase
     let encodedData = try encoder.encode(responsePayload)
 
-    MockURLProtocol.requestHandler = { (request: URLRequest) in
-      attempts.increment()
-      if attempts.getCount() == 1 {
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        attempts.increment()
         throw URLError(.timedOut)
-      } else {
-        let response = HTTPURLResponse(
-          url: targetURL,
-          statusCode: 200,
-          httpVersion: nil as String?,
-          headerFields: ["Content-Type": "application/json"]
-        )!
-        return (response, encodedData)
-      }
-    }
+      },
+      { (request: HTTPClientRequest) in
+        attempts.increment()
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData)),
+        )
+      },
+    ])
 
     let data = UserAccountData(
       type: "authorized_user",
@@ -511,7 +505,7 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
     let source = try UserCredentials(
       user: data,
       scopes: nil,
-      httpClient: AuthHTTPClient(session: self.mockSession),
+      httpClient: AuthHTTPClient(mock: mock),
       retryConfiguration: retryConfig,
       clock: clock
     )
@@ -535,28 +529,4 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
       headers.contains { $0.0 == "Authorization" && $0.1 == "Bearer recovered-timeout-token" })
     #expect(attempts.getCount() == 2)
   }
-}
-
-private final class MockURLProtocol: URLProtocol {
-  nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (URLResponse, Data))?
-
-  override class func canInit(with request: URLRequest) -> Bool { true }
-  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-  override func startLoading() {
-    guard let handler = Self.requestHandler else {
-      fatalError("Handler is not set.")
-    }
-
-    do {
-      let (response, data) = try handler(request)
-      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-      client?.urlProtocol(self, didLoad: data)
-      client?.urlProtocolDidFinishLoading(self)
-    } catch {
-      client?.urlProtocol(self, didFailWithError: error)
-    }
-  }
-
-  override func stopLoading() {}
 }

--- a/packages/auth/docs/DESIGN.md
+++ b/packages/auth/docs/DESIGN.md
@@ -256,18 +256,15 @@ token providers while keeping `GoogleCloudAuth` completely isolated from
 
 This internal client encapsulates the following networking policies:
 
--   **Linux Portability**: Conditionally imports `FoundationNetworking` under
-    `#if canImport(FoundationNetworking)` to support Linux targets.
--   **Secure Ephemeral Sessions**: Forces the use of `URLSession(configuration:
-    .ephemeral)` for its underlying session, preventing the OS from caching
-    sensitive tokens locally.
--   **Defense-in-Depth Request Caching Bypass**: Centralizes request-level
-    overrides by explicitly setting `request.cachePolicy =
-    .reloadIgnoringLocalCacheData` on all outbound queries.
--   **Acyclic Boundary Safety**: Performs raw network queries directly via
-    `URLSession`, ensuring `GoogleCloudAuth` remains independent of
-    `GoogleCloudGax`.
--   **Generic Decoding**: Decodes generic JSON responses using a default
+- **Portability**: use `AsyncHTTPClient.HTTPClient` because it is more portable
+    across different platforms (macOS, Windows, Linux).
+- **PQC Support**: use `AsyncHTTPClient.HTTPClient` because it supports
+    post-quantum cryptography across platforms.
+- **Easier Mocking**: implement our own HTTPClientProtocol to mock `HTTPClient`.
+- **Acyclic Boundary Safety**: Performs raw network queries directly via
+    `AsyncHTTPClient.HTTPClient`, ensuring `GoogleCloudAuth` remains independent
+    of `GoogleCloudGax`.
+- **Generic Decoding**: Decodes generic JSON responses using a default
     `JSONDecoder` configured with a `.convertFromSnakeCase` key decoding
     strategy.
 -   **Plain-Text Support**: Supports retrieving raw UTF-8 string responses

--- a/packages/auth/docs/MDS_DESIGN.md
+++ b/packages/auth/docs/MDS_DESIGN.md
@@ -29,8 +29,7 @@ credential provider that integrates seamlessly with the `TokenCache` actor and
 # Requirements
 
 -   **Requirement**: Implement the native `TokenProvider` protocol.
--   **Requirement**: Query the MDS `/token` endpoint using a secure `URLSession`
-    injected from the `AuthHTTPClient`.
+-   **Requirement**: Query the MDS `/token` endpoint using `AuthHTTPClient`.
 -   **Requirement**: Append the `Metadata-Flavor: Google` header to all MDS
     requests.
 -   **Requirement**: Parse the returned JSON response to extract the token and


### PR DESCRIPTION
Switch the (internal only) AuthHTTPClient type to use `AsyncHTTPClient.HTTPClient`.

Most of the changes are in the tests: the new implementation more easily supports mocks, no need for global state.

I refactored the mock to a single file, and use a `Deque` of closures to control the behavior of the mock. They can be async, throw errors, if you use named closures you can also repeat the same action a few times.

Fixes #81 
