### PR TITLE
ci: issues on post-merge builds

### DIFF
--- a/.github/actions/create-issue-on-failure/action.yaml
+++ b/.github/actions/create-issue-on-failure/action.yaml
@@ -1,0 +1,50 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: 'Create Issue on Failure'
+description: 'Creates or updates a GitHub issue when a workflow fails'
+inputs:
+  title:
+    description: "The title of the issue to create or search for."
+    required: true
+  body:
+    description: "The body content for a new issue."
+    required: true
+  labels:
+    description: "Comma-separated list of labels to apply to a new issue."
+    required: false
+    default: ":rotating_light: critical"
+  assignee:
+    description: "The GitHub username to assign the issue to."
+    required: false
+    default: ${{ github.actor }}
+  mention:
+    description: "A user or team to mention in a follow-up comment if a new issue is created."
+    required: false
+    default: "@googleapis/cloud-sdk-librarian-team"
+runs:
+  using: "composite"
+  steps:
+    - name: Create or comment on issue
+      shell: bash
+      run: "${{ github.action_path }}/create-issue-on-failure.sh"
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_REPO: ${{ github.repository }}
+        GITHUB_SERVER_URL: ${{ github.server_url }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        ISSUE_TITLE: ${{ inputs.title }}
+        ISSUE_BODY: ${{ inputs.body }}
+        ISSUE_LABELS: ${{ inputs.labels }}
+        ISSUE_ASSIGNEE: ${{ inputs.assignee }}
+        ISSUE_MENTION: ${{ inputs.mention }}

--- a/.github/actions/create-issue-on-failure/create-issue-on-failure.sh
+++ b/.github/actions/create-issue-on-failure/create-issue-on-failure.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -e
+
+# Search for an existing open issue with the same title
+EXISTING_ISSUE=$(gh issue list --repo "$GITHUB_REPO" --search "$ISSUE_TITLE in:title" --state open --json number --jq '.[0].number')
+
+if [[ -n "$EXISTING_ISSUE" && "$EXISTING_ISSUE" != "null" ]]; then
+  echo "Found existing open issue #$EXISTING_ISSUE. Adding comment."
+  gh issue comment "$EXISTING_ISSUE" --repo "$GITHUB_REPO" --body "The build failed again. Workflow Run: $GITHUB_SERVER_URL/$GITHUB_REPO/actions/runs/$GITHUB_RUN_ID"
+else
+  echo "Creating new issue."
+  ISSUE_LINK=$(gh issue create \
+    --title "$ISSUE_TITLE" \
+    --body "$ISSUE_BODY" \
+    --label "$ISSUE_LABELS" \
+    --assignee "$ISSUE_ASSIGNEE" \
+    --repo "$GITHUB_REPO")
+
+  if [[ -n "$ISSUE_MENTION" ]]; then
+    ISSUE_NUM=${ISSUE_LINK##*/}
+    gh issue comment "$ISSUE_NUM" --repo "$GITHUB_REPO" --body "$ISSUE_MENTION The workflow failed. Workflow Run: $GITHUB_SERVER_URL/$GITHUB_REPO/actions/runs/$GITHUB_RUN_ID"
+  fi
+fi

--- a/.github/workflows/build-monitor.yml
+++ b/.github/workflows/build-monitor.yml
@@ -22,9 +22,11 @@ jobs:
   create-issue-on-gcb-failure:
     runs-on: ubuntu-24.04
     # Only run for GCB check suites that failed/timed out/cancelled on the main branch.
-    if: >
-      github.repository == 'googleapis/google-cloud-swift' && github.event.check_suite.head_branch == 'main' && github.event.check_suite.app.name == 'Google Cloud Build' && (github.event.check_suite.conclusion == 'failure' ||
-
+    if: |
+      github.repository == 'googleapis/google-cloud-swift' &&
+      github.event.check_suite.head_branch == 'main' &&
+      github.event.check_suite.app.name == 'Google Cloud Build' &&
+      (github.event.check_suite.conclusion == 'failure' ||
        github.event.check_suite.conclusion == 'timed_out' ||
        github.event.check_suite.conclusion == 'cancelled')
     steps:

--- a/.github/workflows/build-monitor.yml
+++ b/.github/workflows/build-monitor.yml
@@ -1,0 +1,76 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Build Monitor
+on:
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  create-issue-on-gcb-failure:
+    runs-on: ubuntu-24.04
+    # Only run for GCB check suites that failed/timed out/cancelled on the main branch.
+    if: >
+      github.repository == 'googleapis/google-cloud-swift' &&
+      github.event.check_suite.head_branch == 'main' &&
+      github.event.check_suite.app.name == 'Google Cloud Build' &&
+      (github.event.check_suite.conclusion == 'failure' ||
+       github.event.check_suite.conclusion == 'timed_out' ||
+       github.event.check_suite.conclusion == 'cancelled')
+    steps:
+      - name: Create or update CI failure issue
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          CHECK_SUITE_URL: ${{ github.event.check_suite.url }}
+          COMMIT_SHA: ${{ github.event.check_suite.head_sha }}
+          PR_LIST: ${{ toJson(github.event.check_suite.pull_requests) }}
+        run: |
+          ISSUE_TITLE="google-cloud-swift: CI (GCB) failure on main branch"
+
+          # Format the PR list for the body
+          PR_TEXT=""
+          if [[ "$PR_LIST" != "[]" ]]; then
+            PR_TEXT="**Associated Pull Requests:**"
+            # Extract PR numbers and turn them into links
+            PRS=$(echo "$PR_LIST" | jq -r '.[] | "#" + (.number | toString)')
+            for pr in $PRS; do
+              PR_TEXT="$PR_TEXT"$'\n'"- $pr"
+            done
+          fi
+
+          BODY="The CI failed on the \`main\` branch.
+
+          **Failure in Google Cloud Build:**
+          - **Check Suite:** $CHECK_SUITE_URL
+          - **Commit:** $COMMIT_SHA
+
+          $PR_TEXT"
+
+          # Check for an existing open issue with the same title.
+          EXISTING_ISSUE=$(gh issue list --repo $GH_REPO --search "$ISSUE_TITLE in:title" --state open --json number --jq '.[0].number')
+
+          if [[ -n "$EXISTING_ISSUE" && "$EXISTING_ISSUE" != "null" ]]; then
+            echo "Found existing open issue #$EXISTING_ISSUE. Adding comment."
+            gh issue comment "$EXISTING_ISSUE" --repo $GH_REPO --body "The build failed again in GCB. Details: $CHECK_SUITE_URL (Commit: $COMMIT_SHA). $PR_TEXT"
+          else
+            echo "Creating new issue."
+            ISSUE_LINK=$(gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label ":rotating_light: critical" --assignee ${{ github.actor }} -R $GH_REPO)
+            ISSUE_NUM=${ISSUE_LINK##*/}
+            gh issue comment $ISSUE_NUM --repo $GH_REPO --body "@googleapis/cloud-sdk-swift-team A critical issue has been created, please respond immediately."
+          fi

--- a/.github/workflows/build-monitor.yml
+++ b/.github/workflows/build-monitor.yml
@@ -15,20 +15,16 @@ name: Build Monitor
 on:
   check_suite:
     types: [completed]
-
 permissions:
   contents: read
   issues: write
-
 jobs:
   create-issue-on-gcb-failure:
     runs-on: ubuntu-24.04
     # Only run for GCB check suites that failed/timed out/cancelled on the main branch.
     if: >
-      github.repository == 'googleapis/google-cloud-swift' &&
-      github.event.check_suite.head_branch == 'main' &&
-      github.event.check_suite.app.name == 'Google Cloud Build' &&
-      (github.event.check_suite.conclusion == 'failure' ||
+      github.repository == 'googleapis/google-cloud-swift' && github.event.check_suite.head_branch == 'main' && github.event.check_suite.app.name == 'Google Cloud Build' && (github.event.check_suite.conclusion == 'failure' ||
+
        github.event.check_suite.conclusion == 'timed_out' ||
        github.event.check_suite.conclusion == 'cancelled')
     steps:

--- a/.github/workflows/build-monitor.yml
+++ b/.github/workflows/build-monitor.yml
@@ -36,6 +36,7 @@ jobs:
           CHECK_SUITE_URL: ${{ github.event.check_suite.url }}
           COMMIT_SHA: ${{ github.event.check_suite.head_sha }}
           PR_LIST: ${{ toJson(github.event.check_suite.pull_requests) }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           ISSUE_TITLE="google-cloud-swift: CI (GCB) failure on main branch"
 
@@ -66,7 +67,7 @@ jobs:
             gh issue comment "$EXISTING_ISSUE" --repo $GH_REPO --body "The build failed again in GCB. Details: $CHECK_SUITE_URL (Commit: $COMMIT_SHA). $PR_TEXT"
           else
             echo "Creating new issue."
-            ISSUE_LINK=$(gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label ":rotating_light: critical" --assignee ${{ github.actor }} -R $GH_REPO)
+            ISSUE_LINK=$(gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label ":rotating_light: critical" --assignee ${GITHUB_ACTOR} -R $GH_REPO)
             ISSUE_NUM=${ISSUE_LINK##*/}
             gh issue comment $ISSUE_NUM --repo $GH_REPO --body "@googleapis/cloud-sdk-swift-team A critical issue has been created, please respond immediately."
           fi


### PR DESCRIPTION
Post-merge builds failures can go unnoticed. With this PR a Google Cloud Build failure post-merge (not PRs) results in an issue. Since the same (or similar / sampled) builds have to pass on the PR this is unexpected and needs quick resolution,

Fixes #132 