### PR TITLE
chore: update librarian circa 2026-08-04

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: swift
-version: v0.31.2-0.20260804184707-3ee87fcd7ad6
+version: v0.32.1-0.20260805024539-3cacaacd0552
 repo: googleapis/google-cloud-swift
 sources:
   conformance:


### PR DESCRIPTION
This version produces no changes in the generated code. It contains features that will be needed on the next googleapis SHA updates.