### PR TITLE
feat(storage): use configured retry policy and backoff policy for upload loop

### DIFF
--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -111,18 +111,17 @@ extension StorageClient {
     return object
   }
 
-  fileprivate static func performResumableUpload(
+  // Start a resumable upload session with configured retry and backoff. Upon success,
+  // returns the location of the upload (the uploadId)
+  fileprivate static func startResumableUpload(
     httpClient: HTTPClient,
-    source: inout some UploadSource,
     bucket: String,
     objectName: String,
     metadata: UploadMetadata?,
     options: UploadOptions,
-    totalSize: Int64?,
-    continuation: AsyncStream<UploadStatus>.Continuation,
     retryPolicy: any RetryPolicy,
     backoffPolicy: any BackoffPolicy
-  ) async throws -> StorageObject {
+  ) async throws -> String {
     let retryLoop = _RetryLoop(
       retryPolicy: retryPolicy,
       backoffPolicy: backoffPolicy,
@@ -130,9 +129,8 @@ extension StorageClient {
       idempotent: true
     )
 
-    let uploadId: String
     do {
-      uploadId = try await retryLoop.run { _ in
+      return try await retryLoop.run { _ in
         let startRequest = try await httpClient.buildStartResumableUploadRequest(
           bucket: bucket, objectName: objectName, metadata: metadata, options: options)
         let (startData, startResponse) = try await httpClient.sendRequestWithMappedError(
@@ -150,8 +148,33 @@ extension StorageClient {
         return location
       }
     } catch {
+      // Retry loop expects RequestError types, but we want to throw transformed
+      // UploadError types
       throw mapToPublicError(error)
     }
+  }
+
+  fileprivate static func performResumableUpload(
+    httpClient: HTTPClient,
+    source: inout some UploadSource,
+    bucket: String,
+    objectName: String,
+    metadata: UploadMetadata?,
+    options: UploadOptions,
+    totalSize: Int64?,
+    continuation: AsyncStream<UploadStatus>.Continuation,
+    retryPolicy: any RetryPolicy,
+    backoffPolicy: any BackoffPolicy
+  ) async throws -> StorageObject {
+    let uploadId = try await startResumableUpload(
+      httpClient: httpClient,
+      bucket: bucket,
+      objectName: objectName,
+      metadata: metadata,
+      options: options,
+      retryPolicy: retryPolicy,
+      backoffPolicy: backoffPolicy
+    )
 
     continuation.yield(
       UploadStatus(

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -37,6 +37,12 @@ extension StorageClient {
     options: UploadOptions = .default
   ) -> UploadTask {
     let clientOptions = self.options.client
+    let effectiveRetryPolicy =
+      options.retryPolicy ?? self.options.upload.retryPolicy
+      ?? defaultUploadRetryPolicy()
+    let effectiveBackoffPolicy =
+      options.backoffPolicy ?? self.options.upload.backoffPolicy ?? clientOptions.backoffPolicy
+
     return UploadTask.create { continuation in
       let httpClient = try HTTPClient(
         from: clientOptions, withDefaultEndpoint: StorageClient.defaultEndpoint)
@@ -67,7 +73,9 @@ extension StorageClient {
           metadata: options.metadata,
           options: options,
           totalSize: totalSize,
-          continuation: continuation
+          continuation: continuation,
+          retryPolicy: effectiveRetryPolicy,
+          backoffPolicy: effectiveBackoffPolicy
         )
       }
     }
@@ -111,19 +119,39 @@ extension StorageClient {
     metadata: UploadMetadata?,
     options: UploadOptions,
     totalSize: Int64?,
-    continuation: AsyncStream<UploadStatus>.Continuation
+    continuation: AsyncStream<UploadStatus>.Continuation,
+    retryPolicy: any RetryPolicy,
+    backoffPolicy: any BackoffPolicy
   ) async throws -> StorageObject {
-    let startRequest = try await httpClient.buildStartResumableUploadRequest(
-      bucket: bucket, objectName: objectName, metadata: metadata, options: options)
-    let (startData, startResponse) = try await httpClient.data(for: startRequest)
-    guard startResponse.statusCode == 200,
-      let location = startResponse.value(forHTTPHeaderField: "Location")
-    else {
-      throw UploadError.unexpectedServerResponse(
-        statusCode: startResponse.statusCode,
-        message: String(data: startData, encoding: .utf8) ?? "")
+    let retryLoop = _RetryLoop(
+      retryPolicy: retryPolicy,
+      backoffPolicy: backoffPolicy,
+      retryThrottler: AdaptiveThrottler(),
+      idempotent: true
+    )
+
+    let uploadId: String
+    do {
+      uploadId = try await retryLoop.run { _ in
+        let startRequest = try await httpClient.buildStartResumableUploadRequest(
+          bucket: bucket, objectName: objectName, metadata: metadata, options: options)
+        let (startData, startResponse) = try await httpClient.sendRequestWithMappedError(
+          startRequest)
+        guard startResponse.statusCode == 200,
+          let location = startResponse.value(forHTTPHeaderField: "Location")
+        else {
+          throw RequestError.http(
+            HTTPDetails(
+              http_status_code: startResponse.statusCode,
+              headers: [:],
+              payload: startData
+            ))
+        }
+        return location
+      }
+    } catch {
+      throw mapToPublicError(error)
     }
-    let uploadId = location
 
     continuation.yield(
       UploadStatus(
@@ -138,7 +166,9 @@ extension StorageClient {
       chunkSize: chunkSize,
       totalSize: totalSize,
       options: options,
-      continuation: continuation
+      continuation: continuation,
+      retryPolicy: retryPolicy,
+      backoffPolicy: backoffPolicy
     )
   }
 
@@ -150,61 +180,141 @@ extension StorageClient {
     chunkSize: Int,
     totalSize: Int64?,
     options: UploadOptions,
-    continuation: AsyncStream<UploadStatus>.Continuation
+    continuation: AsyncStream<UploadStatus>.Continuation,
+    retryPolicy: any RetryPolicy,
+    backoffPolicy: any BackoffPolicy
   ) async throws -> StorageObject {
     var offset = offset
-    var chunksSent = 0
+    let retryLoop = _RetryLoop(
+      retryPolicy: retryPolicy,
+      backoffPolicy: backoffPolicy,
+      retryThrottler: AdaptiveThrottler(),
+      idempotent: true
+    )
+
     while true {
-      guard let chunkInfo = try await checksummedSource.readChunk(maxBytes: chunkSize),
-        !chunkInfo.data.isEmpty
+      guard let initialChunkInfo = try await checksummedSource.readChunk(maxBytes: chunkSize),
+        !initialChunkInfo.data.isEmpty
       else {
         break
       }
-      chunksSent += 1
-      let chunk = chunkInfo.data
-      let isLast = chunkInfo.isLast
-      let checksum = isLast ? chunkInfo.checksum : nil
 
-      let effectiveTotalSize =
-        (isLast && totalSize == nil) ? (offset + Int64(chunk.count)) : totalSize
+      var currentChunkInfo = initialChunkInfo
+      var attempt = 0
+      let res: ChunkUploadResult
+      do {
+        res = try await retryLoop.run { _ in
+          attempt += 1
+          if attempt > 1 {
+            let queryRequest = try await httpClient.buildQueryResumableUploadRequest(
+              uploadId: uploadId, options: options)
+            let (qData, qResponse) = try await httpClient.sendRequestWithMappedError(queryRequest)
+            if qResponse.statusCode == 200 || qResponse.statusCode == 201 {
+              return ChunkUploadResult(
+                responseData: qData, response: qResponse, chunkCount: 0,
+                effectiveTotalSize: totalSize)
+            } else if qResponse.statusCode == 308 {
+              let status = try httpClient.parseResumableUploadQueryStatus(from: qResponse)
+              offset = status.nextOffset
+              if var seekable = checksummedSource.source as? SeekableUploadSource {
+                try await seekable.seek(to: offset)
+                checksummedSource.source = seekable as! S
+              }
+              if let reReadInfo = try await checksummedSource.readChunk(maxBytes: chunkSize) {
+                currentChunkInfo = reReadInfo
+              }
+            } else {
+              throw RequestError.http(
+                HTTPDetails(
+                  http_status_code: qResponse.statusCode,
+                  headers: [:],
+                  payload: qData
+                ))
+            }
+          }
 
-      let uploadRequest = try await httpClient.buildUploadChunkRequest(
-        uploadId: uploadId, data: chunk, offset: offset, totalSize: effectiveTotalSize,
-        options: options,
-        checksum: checksum)
-      let (uploadData, uploadResponse) = try await httpClient.data(for: uploadRequest)
+          let chunk = currentChunkInfo.data
+          let isLast = currentChunkInfo.isLast
+          let checksum = isLast ? currentChunkInfo.checksum : nil
+          let effectiveTotalSize =
+            (isLast && totalSize == nil) ? (offset + Int64(chunk.count)) : totalSize
 
-      if uploadResponse.statusCode == 200 || uploadResponse.statusCode == 201 {
+          let uploadRequest = try await httpClient.buildUploadChunkRequest(
+            uploadId: uploadId, data: chunk, offset: offset, totalSize: effectiveTotalSize,
+            options: options, checksum: checksum)
+          let (uData, uResponse) = try await httpClient.sendRequestWithMappedError(uploadRequest)
+          if uResponse.statusCode == 200 || uResponse.statusCode == 201
+            || uResponse.statusCode == 308
+          {
+            return ChunkUploadResult(
+              responseData: uData, response: uResponse, chunkCount: Int64(chunk.count),
+              effectiveTotalSize: effectiveTotalSize)
+          } else {
+            throw RequestError.http(
+              HTTPDetails(
+                http_status_code: uResponse.statusCode,
+                headers: [:],
+                payload: uData
+              ))
+          }
+        }
+      } catch {
+        throw mapToPublicError(error)
+      }
+
+      if res.response.statusCode == 204 {
+        break
+      }
+
+      if res.response.statusCode == 200 || res.response.statusCode == 201 {
         let object = try httpClient.handleObjectResponse(
-          data: uploadData, response: uploadResponse)
+          data: res.responseData, response: res.response)
         continuation.yield(
           UploadStatus(
-            bytesUploaded: offset + Int64(chunk.count),
-            totalBytes: effectiveTotalSize, uploadId: uploadId))
+            bytesUploaded: offset + res.chunkCount,
+            totalBytes: res.effectiveTotalSize ?? (offset + res.chunkCount), uploadId: uploadId))
         return object
-      } else if uploadResponse.statusCode == 308 {
-        if let rangeHeader = uploadResponse.value(forHTTPHeaderField: "Range") {
+      } else if res.response.statusCode == 308 {
+        if let rangeHeader = res.response.value(forHTTPHeaderField: "Range") {
           offset = try httpClient.parseNextRangeStart(rangeHeader)
         } else {
-          offset += Int64(chunk.count)
+          offset += res.chunkCount
         }
         continuation.yield(
           UploadStatus(
             bytesUploaded: offset, totalBytes: totalSize, uploadId: uploadId))
-      } else {
-        _ = try httpClient.handleObjectResponse(data: uploadData, response: uploadResponse)
       }
     }
 
     // Finalize upload with an empty chunk if the stream finished without returning an object
     let finalTotalSize = totalSize ?? offset
     let checksum = checksummedSource.finalizeChecksum()
-    let uploadRequest = try await httpClient.buildUploadChunkRequest(
-      uploadId: uploadId, data: Data(), offset: offset, totalSize: finalTotalSize, options: options,
-      checksum: checksum)
-    let (uploadData, uploadResponse) = try await httpClient.data(for: uploadRequest)
+
+    let finalResult: (Data, HTTPURLResponse)
+    do {
+      finalResult = try await retryLoop.run { _ in
+        let uploadRequest = try await httpClient.buildUploadChunkRequest(
+          uploadId: uploadId, data: Data(), offset: offset, totalSize: finalTotalSize,
+          options: options,
+          checksum: checksum)
+        let (uData, uResponse) = try await httpClient.sendRequestWithMappedError(uploadRequest)
+        if uResponse.statusCode == 200 || uResponse.statusCode == 201 {
+          return (uData, uResponse)
+        } else {
+          throw RequestError.http(
+            HTTPDetails(
+              http_status_code: uResponse.statusCode,
+              headers: [:],
+              payload: uData
+            ))
+        }
+      }
+    } catch {
+      throw mapToPublicError(error)
+    }
+
     let object = try httpClient.handleObjectResponse(
-      data: uploadData, response: uploadResponse)
+      data: finalResult.0, response: finalResult.1)
     continuation.yield(
       UploadStatus(
         bytesUploaded: offset, totalBytes: finalTotalSize, uploadId: uploadId))
@@ -219,11 +329,11 @@ extension StorageClient {
     chunkSize: Int,
     totalSize: Int64?,
     options: UploadOptions,
-    continuation: AsyncStream<UploadStatus>.Continuation
+    continuation: AsyncStream<UploadStatus>.Continuation,
+    retryPolicy: any RetryPolicy,
+    backoffPolicy: any BackoffPolicy
   ) async throws -> StorageObject {
     var options = options
-    // Explicitly disable calculated MD5 checksums if we are resuming an upload at offset >0
-    // as MD5 requires reading the entire file from the start.
     if offset > 0 && options.checksums.md5 == .auto {
       options.checksums.md5 = nil
     }
@@ -236,7 +346,9 @@ extension StorageClient {
       chunkSize: chunkSize,
       totalSize: totalSize,
       options: options,
-      continuation: continuation
+      continuation: continuation,
+      retryPolicy: retryPolicy,
+      backoffPolicy: backoffPolicy
     )
   }
 
@@ -249,11 +361,11 @@ extension StorageClient {
     chunkSize: Int,
     totalSize: Int64?,
     options: UploadOptions,
-    continuation: AsyncStream<UploadStatus>.Continuation
+    continuation: AsyncStream<UploadStatus>.Continuation,
+    retryPolicy: any RetryPolicy,
+    backoffPolicy: any BackoffPolicy
   ) async throws -> StorageObject {
     var options = options
-    // Explicitly disable calculated MD5 checksums if we are resuming an upload at offset >0
-    // as MD5 requires reading the entire file from the start.
     if offset > 0 && options.checksums.md5 == .auto {
       options.checksums.md5 = nil
     }
@@ -272,67 +384,90 @@ extension StorageClient {
       chunkSize: chunkSize,
       totalSize: totalSize,
       options: options,
-      continuation: continuation
+      continuation: continuation,
+      retryPolicy: retryPolicy,
+      backoffPolicy: backoffPolicy
     )
   }
 
-  /// Resumes a previously interrupted file upload using a saved upload ID.
-  ///
-  /// - Parameters:
-  ///   - source: The seekable upload source (must match the original source).
-  ///   - uploadId: The saved GCS Upload ID (Session URI).
-  ///   - options: Configuration options for the upload.
-  /// - Returns: An `UploadTask` to monitor and control the resumed upload.
   public func resumeUpload(
     _ source: some SeekableUploadSource,
     uploadId: String,
     options: UploadOptions = .default
   ) -> UploadTask {
     let clientOptions = self.options.client
+    let effectiveRetryPolicy =
+      options.retryPolicy ?? self.options.upload.retryPolicy
+      ?? defaultUploadRetryPolicy()
+    let effectiveBackoffPolicy =
+      options.backoffPolicy ?? self.options.upload.backoffPolicy ?? clientOptions.backoffPolicy
+
     return UploadTask.create { continuation in
       let httpClient = try HTTPClient(
         from: clientOptions, withDefaultEndpoint: Self.defaultEndpoint)
       var source = source
       let totalSize = source.totalSize
 
-      // Query GCS for current status - this includes any partially calculated
-      // checksums if available.
-      let queryRequest = try await httpClient.buildQueryResumableUploadRequest(
-        uploadId: uploadId, options: options)
-      let (queryData, queryResponse) = try await httpClient.data(for: queryRequest)
+      let retryLoop = _RetryLoop(
+        retryPolicy: effectiveRetryPolicy,
+        backoffPolicy: effectiveBackoffPolicy,
+        retryThrottler: AdaptiveThrottler(),
+        idempotent: true
+      )
 
-      var status = ResumableUploadQueryStatus(nextOffset: 0, crc32cSeed: nil)
-      if queryResponse.statusCode == 200 || queryResponse.statusCode == 201 {
-        let object = try httpClient.handleObjectResponse(data: queryData, response: queryResponse)
-        continuation.yield(
-          UploadStatus(
-            bytesUploaded: totalSize ?? 0, totalBytes: totalSize,
-            uploadId: uploadId))
-        return object
-      } else if queryResponse.statusCode == 308 {
-        status = try httpClient.parseResumableUploadQueryStatus(from: queryResponse)
-      } else {
-        throw UploadError.unexpectedServerResponse(
-          statusCode: queryResponse.statusCode,
-          message: String(data: queryData, encoding: .utf8) ?? "")
+      let result: Either<StorageObject, ResumableUploadQueryStatus>
+      do {
+        result = try await retryLoop.run { _ in
+          let queryRequest = try await httpClient.buildQueryResumableUploadRequest(
+            uploadId: uploadId, options: options)
+          let (queryData, queryResponse) = try await httpClient.sendRequestWithMappedError(
+            queryRequest)
+
+          if queryResponse.statusCode == 200 || queryResponse.statusCode == 201 {
+            let object = try httpClient.handleObjectResponse(
+              data: queryData, response: queryResponse)
+            return .left(object)
+          } else if queryResponse.statusCode == 308 {
+            let status = try httpClient.parseResumableUploadQueryStatus(from: queryResponse)
+            return .right(status)
+          } else {
+            throw RequestError.http(
+              HTTPDetails(
+                http_status_code: queryResponse.statusCode,
+                headers: [:],
+                payload: queryData
+              ))
+          }
+        }
+      } catch {
+        throw mapToPublicError(error)
       }
 
-      continuation.yield(
-        UploadStatus(
-          bytesUploaded: status.nextOffset, totalBytes: totalSize, uploadId: uploadId))
+      switch result {
+      case .left(let object):
+        continuation.yield(
+          UploadStatus(
+            bytesUploaded: totalSize ?? 0, totalBytes: totalSize, uploadId: uploadId))
+        return object
+      case .right(let status):
+        continuation.yield(
+          UploadStatus(
+            bytesUploaded: status.nextOffset, totalBytes: totalSize, uploadId: uploadId))
 
-      // Continue the main upload loop
-      return try await Self.continueResumableUpload(
-        httpClient: httpClient,
-        source: &source,
-        uploadId: uploadId,
-        offset: status.nextOffset,
-        crc32cSeed: status.crc32cSeed,
-        chunkSize: options.chunkSize,
-        totalSize: totalSize,
-        options: options,
-        continuation: continuation
-      )
+        return try await Self.continueResumableUpload(
+          httpClient: httpClient,
+          source: &source,
+          uploadId: uploadId,
+          offset: status.nextOffset,
+          crc32cSeed: status.crc32cSeed,
+          chunkSize: options.chunkSize,
+          totalSize: totalSize,
+          options: options,
+          continuation: continuation,
+          retryPolicy: effectiveRetryPolicy,
+          backoffPolicy: effectiveBackoffPolicy
+        )
+      }
     }
   }
 
@@ -635,4 +770,50 @@ extension URLRequest {
     setValue(key.keyBase64, forHTTPHeaderField: "x-goog-encryption-key")
     setValue(key.keyHashBase64, forHTTPHeaderField: "x-goog-encryption-key-sha256")
   }
+}
+
+fileprivate enum Either<L, R> {
+  case left(L)
+  case right(R)
+}
+
+fileprivate struct ChunkUploadResult: Sendable {
+  let responseData: Data
+  let response: HTTPURLResponse
+  let chunkCount: Int64
+  let effectiveTotalSize: Int64?
+}
+
+extension HTTPClient {
+  fileprivate func sendRequestWithMappedError(_ request: URLRequest) async throws -> (
+    Data, HTTPURLResponse
+  ) {
+    do {
+      let (data, response) = try await self.data(for: request)
+      return (data, response)
+    } catch let e as RequestError {
+      throw e
+    } catch let e {
+      throw RequestError.io(e)
+    }
+  }
+}
+
+fileprivate func mapToPublicError(_ error: Error) -> Error {
+  if let reqErr = error as? RequestError {
+    switch reqErr {
+    case .http(let details):
+      return UploadError.unexpectedServerResponse(
+        statusCode: details.http_status_code,
+        message: String(data: details.payload, encoding: .utf8) ?? ""
+      )
+    case .io(let inner):
+      return inner
+    case .exhausted(let limitErr):
+      return mapToPublicError(limitErr.source)
+    default:
+      return reqErr
+    }
+  }
+  return error
 }

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -817,3 +817,10 @@ fileprivate func mapToPublicError(_ error: Error) -> Error {
   }
   return error
 }
+
+fileprivate func defaultUploadRetryPolicy() -> any RetryPolicy {
+  BaseRetryPolicy()
+    .retryOnTooManyRequests()
+    .withTimeLimit(.seconds(60))
+    .withAttemptLimit(10)
+}

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -216,52 +216,21 @@ extension StorageClient {
     )
 
     while true {
-      guard let initialChunkInfo = try await checksummedSource.readChunk(maxBytes: chunkSize),
-        !initialChunkInfo.data.isEmpty
+      guard let chunkInfo = try await checksummedSource.readChunk(maxBytes: chunkSize),
+        !chunkInfo.data.isEmpty
       else {
         break
       }
 
-      var currentChunkInfo = initialChunkInfo
-      var attempt = 0
+      let chunk = chunkInfo.data
+      let isLast = chunkInfo.isLast
+      let checksum = isLast ? chunkInfo.checksum : nil
+      let effectiveTotalSize =
+        (isLast && totalSize == nil) ? (offset + Int64(chunk.count)) : totalSize
+
       let res: ChunkUploadResult
       do {
         res = try await retryLoop.run { _ in
-          attempt += 1
-          if attempt > 1 {
-            let queryRequest = try await httpClient.buildQueryResumableUploadRequest(
-              uploadId: uploadId, options: options)
-            let (qData, qResponse) = try await httpClient.sendRequestWithMappedError(queryRequest)
-            if qResponse.statusCode == 200 || qResponse.statusCode == 201 {
-              return ChunkUploadResult(
-                responseData: qData, response: qResponse, chunkCount: 0,
-                effectiveTotalSize: totalSize)
-            } else if qResponse.statusCode == 308 {
-              let status = try httpClient.parseResumableUploadQueryStatus(from: qResponse)
-              offset = status.nextOffset
-              if var seekable = checksummedSource.source as? SeekableUploadSource {
-                try await seekable.seek(to: offset)
-                checksummedSource.source = seekable as! S
-              }
-              if let reReadInfo = try await checksummedSource.readChunk(maxBytes: chunkSize) {
-                currentChunkInfo = reReadInfo
-              }
-            } else {
-              throw RequestError.http(
-                HTTPDetails(
-                  http_status_code: qResponse.statusCode,
-                  headers: [:],
-                  payload: qData
-                ))
-            }
-          }
-
-          let chunk = currentChunkInfo.data
-          let isLast = currentChunkInfo.isLast
-          let checksum = isLast ? currentChunkInfo.checksum : nil
-          let effectiveTotalSize =
-            (isLast && totalSize == nil) ? (offset + Int64(chunk.count)) : totalSize
-
           let uploadRequest = try await httpClient.buildUploadChunkRequest(
             uploadId: uploadId, data: chunk, offset: offset, totalSize: effectiveTotalSize,
             options: options, checksum: checksum)

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -407,27 +407,23 @@ extension StorageClient {
         idempotent: true
       )
 
-      let result: Either<StorageObject, ResumableUploadQueryStatus>
+      let (queryData, queryResponse): (Data, HTTPURLResponse)
       do {
-        result = try await retryLoop.run { _ in
+        (queryData, queryResponse) = try await retryLoop.run { _ in
           let queryRequest = try await httpClient.buildQueryResumableUploadRequest(
             uploadId: uploadId, options: options)
-          let (queryData, queryResponse) = try await httpClient.sendRequestWithMappedError(
-            queryRequest)
+          let (qData, qResponse) = try await httpClient.sendRequestWithMappedError(queryRequest)
 
-          if queryResponse.statusCode == 200 || queryResponse.statusCode == 201 {
-            let object = try httpClient.handleObjectResponse(
-              data: queryData, response: queryResponse)
-            return .left(object)
-          } else if queryResponse.statusCode == 308 {
-            let status = try httpClient.parseResumableUploadQueryStatus(from: queryResponse)
-            return .right(status)
+          if qResponse.statusCode == 200 || qResponse.statusCode == 201
+            || qResponse.statusCode == 308
+          {
+            return (qData, qResponse)
           } else {
             throw RequestError.http(
               HTTPDetails(
-                http_status_code: queryResponse.statusCode,
+                http_status_code: qResponse.statusCode,
                 headers: [:],
-                payload: queryData
+                payload: qData
               ))
           }
         }
@@ -435,13 +431,15 @@ extension StorageClient {
         throw mapToPublicError(error)
       }
 
-      switch result {
-      case .left(let object):
+      if queryResponse.statusCode == 200 || queryResponse.statusCode == 201 {
+        let object = try httpClient.handleObjectResponse(
+          data: queryData, response: queryResponse)
         continuation.yield(
           UploadStatus(
             bytesUploaded: totalSize ?? 0, totalBytes: totalSize, uploadId: uploadId))
         return object
-      case .right(let status):
+      } else {
+        let status = try httpClient.parseResumableUploadQueryStatus(from: queryResponse)
         continuation.yield(
           UploadStatus(
             bytesUploaded: status.nextOffset, totalBytes: totalSize, uploadId: uploadId))
@@ -762,11 +760,6 @@ extension URLRequest {
     setValue(key.keyBase64, forHTTPHeaderField: "x-goog-encryption-key")
     setValue(key.keyHashBase64, forHTTPHeaderField: "x-goog-encryption-key-sha256")
   }
-}
-
-fileprivate enum Either<L, R> {
-  case left(L)
-  case right(R)
 }
 
 fileprivate struct ChunkUploadResult: Sendable {

--- a/packages/storage/Sources/GoogleCloudStorage/UploadOptions.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/UploadOptions.swift
@@ -14,6 +14,7 @@
 
 import Crypto
 import Foundation
+import GoogleCloudGax
 import GoogleCloudWkt
 
 /// Strategy for data integrity validation.
@@ -625,6 +626,16 @@ public struct UploadOptions: Sendable {
   /// Predefined ACL to apply to the uploaded object (e.g. `.publicRead`, `.private`).
   public var predefinedAcl: PredefinedAcl?
 
+  /// Configures the retry policy for upload operations.
+  ///
+  /// If `nil`, the default upload retry policy is used.
+  public var retryPolicy: (any RetryPolicy)?
+
+  /// Configures the backoff policy for upload operations.
+  ///
+  /// If `nil`, the client's default backoff policy is used.
+  public var backoffPolicy: (any BackoffPolicy)?
+
   /// Legacy validation enum property for backward compatibility.
   public var validation: ChecksumValidation {
     get {
@@ -657,6 +668,13 @@ public struct UploadOptions: Sendable {
     config(&copy)
     return copy
   }
+}
+
+package func defaultUploadRetryPolicy() -> any RetryPolicy {
+  BaseRetryPolicy()
+    .retryOnTooManyRequests()
+    .withTimeLimit(.seconds(60))
+    .withAttemptLimit(10)
 }
 
 /// Customer encryption metadata returned in object responses.

--- a/packages/storage/Sources/GoogleCloudStorage/UploadOptions.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/UploadOptions.swift
@@ -670,13 +670,6 @@ public struct UploadOptions: Sendable {
   }
 }
 
-package func defaultUploadRetryPolicy() -> any RetryPolicy {
-  BaseRetryPolicy()
-    .retryOnTooManyRequests()
-    .withTimeLimit(.seconds(60))
-    .withAttemptLimit(10)
-}
-
 /// Customer encryption metadata returned in object responses.
 public struct CustomerEncryption: Sendable, Codable, Equatable {
   /// The encryption algorithm used to encrypt the object (e.g., "AES256").

--- a/packages/storage/Tests/ResumableUploadTests.swift
+++ b/packages/storage/Tests/ResumableUploadTests.swift
@@ -178,11 +178,13 @@ import Testing
         statusCode: 200, data: Data(),
         headers: ["Location": chunkUrl.absoluteString]),
       for: startUrl)
-    registry.register(
-      response: .success(
-        statusCode: 500, data: Data("Internal Server Error".utf8),
-        headers: nil),
-      for: chunkUrl)
+    for _ in 0..<20 {
+      registry.register(
+        response: .success(
+          statusCode: 500, data: Data("Internal Server Error".utf8),
+          headers: nil),
+        for: chunkUrl)
+    }
 
     let config = URLSessionConfiguration.ephemeral
     config.protocolClasses = [MockURLProtocol.self]
@@ -1537,6 +1539,231 @@ import Testing
     let hashHeader = finalChunkReq.value(forHTTPHeaderField: "x-goog-hash")
     #expect(hashHeader != nil)
     #expect(hashHeader?.contains("md5=") == true)
+  }
+
+  /// Tests automatic retry and resume when a chunk upload encounters an I/O / network error.
+  @Test func resumableUploadChunkNetworkErrorRetrySuccess() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-network-retry"
+    let data = Data(repeating: 1, count: 10 * 1024 * 1024)
+    let source = BytesSource(data: data)
+
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=retry-id")
+
+    let objectJSON = makeObjectJSON(name: objectName, bucket: bucket, size: data.count)
+
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+    // First chunk PUT fails with network error
+    registry.register(
+      response: .failure(URLError(.networkConnectionLost)),
+      for: chunkUrl)
+    // Query status PUT returns 308 (0 bytes received)
+    registry.register(
+      response: .success(
+        statusCode: 308, data: Data(),
+        headers: ["Range": "bytes=0-0"]),
+      for: chunkUrl)
+    // Retry chunk PUT succeeds with 200 OK
+    registry.register(
+      response: .success(
+        statusCode: 200, data: objectJSON,
+        headers: nil),
+      for: chunkUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+
+    let client = try StorageClient(options)
+    let task = client.upload(source, to: bucket, as: objectName)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
+
+    let requests = registry.recordedRequests()
+    #expect(requests.count == 4)
+  }
+
+  /// Tests automatic retry and resume when a chunk upload receives a 503 Service Unavailable response.
+  @Test func resumableUploadChunk503ErrorRetrySuccess() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-503-retry"
+    let data = Data(repeating: 1, count: 10 * 1024 * 1024)
+    let source = BytesSource(data: data)
+
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=503-retry-id")
+
+    let objectJSON = makeObjectJSON(name: objectName, bucket: bucket, size: data.count)
+
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+    // First chunk PUT fails with 503
+    registry.register(
+      response: .success(
+        statusCode: 503, data: Data("Service Unavailable".utf8),
+        headers: nil),
+      for: chunkUrl)
+    // Query status PUT returns 308 (0 bytes received)
+    registry.register(
+      response: .success(
+        statusCode: 308, data: Data(),
+        headers: nil),
+      for: chunkUrl)
+    // Retry chunk PUT succeeds with 200 OK
+    registry.register(
+      response: .success(
+        statusCode: 200, data: objectJSON,
+        headers: nil),
+      for: chunkUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+
+    let client = try StorageClient(options)
+    let task = client.upload(source, to: bucket, as: objectName)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
+  }
+
+  /// Tests automatic retry when session initialization returns HTTP 503.
+  @Test func resumableUploadStartSessionRetrySuccess() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-start-retry"
+    let data = Data(repeating: 1, count: 10 * 1024 * 1024)
+    let source = BytesSource(data: data)
+
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=start-retry-id")
+
+    let objectJSON = makeObjectJSON(name: objectName, bucket: bucket, size: data.count)
+
+    // First start request fails with 503
+    registry.register(
+      response: .success(
+        statusCode: 503, data: Data("Service Unavailable".utf8),
+        headers: nil),
+      for: startUrl)
+    // Retry start request succeeds with Location header
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+    // Chunk PUT succeeds with 200 OK
+    registry.register(
+      response: .success(
+        statusCode: 200, data: objectJSON,
+        headers: nil),
+      for: chunkUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+
+    let client = try StorageClient(options)
+    let task = client.upload(source, to: bucket, as: objectName)
+    let object = try await task.value
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == bucket)
+  }
+
+  /// Tests that configuring `NeverRetry()` on `UploadOptions` disables automatic retry.
+  @Test func resumableUploadCustomRetryPolicyNeverRetry() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-never-retry"
+    let data = Data(repeating: 1, count: 10 * 1024 * 1024)
+    let source = BytesSource(data: data)
+
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=never-retry-id")
+
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+    registry.register(
+      response: .success(
+        statusCode: 503, data: Data("Service Unavailable".utf8),
+        headers: nil),
+      for: chunkUrl)
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: config)
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0._testSession = session
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+
+    let client = try StorageClient(options)
+    let uploadOptions = UploadOptions().with {
+      $0.retryPolicy = NeverRetry()
+    }
+    let task = client.upload(source, to: bucket, as: objectName, options: uploadOptions)
+
+    let error = await expectUploadError {
+      try await task.value
+    }
+    if case .unexpectedServerResponse(let statusCode, let message) = error {
+      #expect(statusCode == 503)
+      #expect(message == "Service Unavailable")
+    } else {
+      Issue.record("Expected .unexpectedServerResponse, got \(String(describing: error))")
+    }
+
+    let requests = registry.recordedRequests()
+    #expect(requests.count == 2)
   }
 }
 

--- a/packages/storage/Tests/ResumableUploadTests.swift
+++ b/packages/storage/Tests/ResumableUploadTests.swift
@@ -1564,12 +1564,6 @@ import Testing
     registry.register(
       response: .failure(URLError(.networkConnectionLost)),
       for: chunkUrl)
-    // Query status PUT returns 308 (0 bytes received)
-    registry.register(
-      response: .success(
-        statusCode: 308, data: Data(),
-        headers: ["Range": "bytes=0-0"]),
-      for: chunkUrl)
     // Retry chunk PUT succeeds with 200 OK
     registry.register(
       response: .success(
@@ -1597,7 +1591,7 @@ import Testing
     #expect(object.bucket == bucket)
 
     let requests = registry.recordedRequests()
-    #expect(requests.count == 4)
+    #expect(requests.count == 3)
   }
 
   /// Tests automatic retry and resume when a chunk upload receives a 503 Service Unavailable response.
@@ -1623,12 +1617,6 @@ import Testing
     registry.register(
       response: .success(
         statusCode: 503, data: Data("Service Unavailable".utf8),
-        headers: nil),
-      for: chunkUrl)
-    // Query status PUT returns 308 (0 bytes received)
-    registry.register(
-      response: .success(
-        statusCode: 308, data: Data(),
         headers: nil),
       for: chunkUrl)
     // Retry chunk PUT succeeds with 200 OK


### PR DESCRIPTION
Fixes #166 

Note: this is using a new retry loop for each individual API call with the same settings.