### PR TITLE
ci: build all the things

### DIFF
--- a/ci/gcb/builds/build-resources/main.tf
+++ b/ci/gcb/builds/build-resources/main.tf
@@ -69,8 +69,19 @@ resource "google_cloudbuild_worker_pool" "pool32" {
   name     = "swift-sdk-pool-large"
   location = "us-central1"
   worker_config {
-    disk_size_gb   = 256
+    disk_size_gb   = 2048
     machine_type   = "e2-standard-32"
+    no_external_ip = false
+  }
+}
+
+# We do not plan to use this much, but it is useful in testing.
+resource "google_cloudbuild_worker_pool" "pool64" {
+  name     = "swift-sdk-pool-xlarge"
+  location = "us-central1"
+  worker_config {
+    disk_size_gb   = 2048
+    machine_type   = "n2d-standard-64"
     no_external_ip = false
   }
 }

--- a/ci/gcb/builds/triggers/main.tf
+++ b/ci/gcb/builds/triggers/main.tf
@@ -34,6 +34,11 @@ locals {
       config = "scripted.yaml"
       script = "integration-tests"
     }
+    full = {
+      config  = "scripted.yaml"
+      script  = "full"
+      pool_id = "swift-sdk-pool-large"
+    }
   }
 
   # These are builds that only run during Pull Requests.
@@ -106,6 +111,7 @@ resource "google_cloudbuild_trigger" "post-merge" {
     for k, v in local.pm_builds : k => {
       config         = v.config,
       script         = try(v.script, "")
+      pool_id        = try(v.pool_id, "")
       flags          = try(v.flags, "")
       swift_version  = try(v.swift_version, null)
       included_files = try(v.included_files, [])
@@ -129,6 +135,7 @@ resource "google_cloudbuild_trigger" "post-merge" {
   substitutions = {
     _SCRIPT        = lookup(each.value, "script", "")
     _SWIFT_VERSION = lookup(each.value, "swift_version", null)
+    _POOL_ID       = lookup(each.value, "pool_id", null)
   }
 }
 

--- a/ci/gcb/scripted.yaml
+++ b/ci/gcb/scripted.yaml
@@ -34,3 +34,6 @@ substitutions:
   _POOL_REGION: us-central1
   _POOL_ID: swift-sdk-pool
   _SWIFT_VERSION: '6.3'
+# Increase the default timeout. Building all the packages
+# takes about 1h15m or 4500s, go with 3h (10800s) for a big margin.
+timeout: 10800s

--- a/ci/gcb/scripts/full.sh
+++ b/ci/gcb/scripts/full.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "--- SWIFT VERSION ---"
+swift --version
+echo "--- Initial disk space"
+df -h
+echo
+echo
+
+errors=0
+count=0
+
+flags=(
+    -Xswiftc -warnings-as-errors
+    -Xswiftc -Wwarning
+    -Xswiftc DeprecatedDeclaration
+    --scratch-path "/workspace/.build-cache"
+    --build-path   "/workspace/.build"
+)
+# By default, build all the packages. We search for `Package.swift` files
+mapfile -t packages < <(find . \( -name Sources -o -name .build -o -name .build-cache \) -prune -o -type f -name Package.swift -exec dirname {} \; | sort -u)
+# On PRs, detect any new libraries and compile their documentation. Without this
+# step the post-merge build may break, and we prefer to avoid this problem.
+if [[ "${GCB_TRIGGER_NAME:-}" != gcb-pm-* ]]; then
+    echo "--- Building a subset because this is a PR"
+    # Add some standard packages.
+    packages=('.')
+    mapfile -t always < <(find packages -type f -name 'Package.swift' | xargs -I{} dirname {} | sort)
+    packages+=("${always[@]}")
+    if [[ -d .git ]]; then
+        git fetch --unshallow
+        mapfile -t new < <(git diff "origin/main...HEAD" --name-only --diff-filter=A | grep '/Package.swift' | grep -v /Sources/ | xargs -I{} dirname {})
+        packages+=("${new[@]}")
+        echo "--- Discovered new directories in this PR: ${new[@]}"
+    fi
+fi
+echo "--- Building ${#packages[@]} packages"
+for dir in "${packages[@]}"; do
+    [[ -f "${dir}/Package.swift" ]] || continue
+    count=$((count + 1))
+    name=${dir}
+    if [[ ${dir} == . ]]; then
+        name="top-level package"
+    fi
+
+    echo; echo "--- Building ${name} ---"
+    if swift build --build-tests "${flags[@]}" --package-path "${dir}" >"${dir}/.test.log" 2>&1; then
+        echo "✓ ${name} built successfully"
+    else
+        cat "${dir}/.test.log"
+        echo; echo "✗ ${name} failed to build"
+        errors=$((errors + 1))
+        continue
+    fi
+done
+
+echo; echo; echo "${count} local package(s) built, ${errors} failure(s)."
+echo "--- Remaining disk space"
+df -h
+
+if [[ ${errors} -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
Introduce a build that compiles everything on pushes (after the PR). On PRs this build compiles new packages and the things we change manually.

Fixes #215 