### PR TITLE
impl(Gax): new types for the HTTP client

### DIFF
--- a/packages/gax/Package.swift
+++ b/packages/gax/Package.swift
@@ -30,21 +30,28 @@ let package = Package(
   dependencies: [
     .package(path: "../auth"),
     .package(path: "../../generated/google-rpc"),
-    .package(url: "https://github.com/apple/swift-log", from: "1.12.0"),
+    .package(url: "https://github.com/apple/swift-log", from: "1.14.0"),
+    .package(url: "https://github.com/apple/swift-collections", from: "1.6.0"),
+    .package(url: "https://github.com/apple/swift-nio", from: "2.101.0"),
+    .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.36.0"),
   ],
   targets: [
     .target(
       name: "GoogleCloudGax",
       dependencies: [
+        .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "GoogleCloudAuth", package: "auth"),
         .product(name: "GoogleRpc", package: "google-rpc"),
         .product(name: "Logging", package: "swift-log"),
+        .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOFoundationCompat", package: "swift-nio"),
       ]
     ),
     .testTarget(
       name: "GoogleCloudGaxTests",
       dependencies: [
         "GoogleCloudGax",
+        .product(name: "DequeModule", package: "swift-collections"),
         .product(name: "GoogleRpc", package: "google-rpc"),
       ],
       path: "Tests",

--- a/packages/gax/Sources/GoogleCloudGax/CredentialsProtocol.swift
+++ b/packages/gax/Sources/GoogleCloudGax/CredentialsProtocol.swift
@@ -1,0 +1,26 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import struct GoogleCloudAuth.AuthHeaders
+import struct GoogleCloudAuth.Credentials
+
+/// Dependency injection for `_HTTPClient`.
+///
+/// Allow testing `_HTTPClient` with mock credentials.
+protocol CredentialsProtocol {
+  func headers() async throws -> GoogleCloudAuth.AuthHeaders
+}
+
+extension GoogleCloudAuth.Credentials: CredentialsProtocol {}

--- a/packages/gax/Sources/GoogleCloudGax/ErrorWrapper.swift
+++ b/packages/gax/Sources/GoogleCloudGax/ErrorWrapper.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import struct AsyncHTTPClient.HTTPClientResponse
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
@@ -22,6 +23,13 @@ import GoogleRpc
 /// The services send errors using this structure.
 struct ErrorWrapper: Decodable {
   init?(data: Data, response: HTTPURLResponse) {
+    let decoder = GoogleCloudWkt._ProtoJSONDecoder()
+    guard let w = try? decoder.decode(Self.self, from: data) else {
+      return nil
+    }
+    self = w
+  }
+  init?(data: Data) {
     let decoder = GoogleCloudWkt._ProtoJSONDecoder()
     guard let w = try? decoder.decode(Self.self, from: data) else {
       return nil

--- a/packages/gax/Sources/GoogleCloudGax/HTTPClientHolder.swift
+++ b/packages/gax/Sources/GoogleCloudGax/HTTPClientHolder.swift
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import class AsyncHTTPClient.HTTPClient
+import struct AsyncHTTPClient.HTTPClientRequest
+import struct AsyncHTTPClient.HTTPClientResponse
+import struct Logging.Logger
+
+/// Automatically call shutdown() on a HTTPClient.
+///
+/// HTTPClient requires an (asynchronous) call to `shutdown()` or it leaks resources.
+/// This class automates the call.
+///
+/// SAFETY: calling `shutdown()` requires all requests to be finished. In the AuthHTTPClient struct
+/// each HTTP request is executed within a function, therefore the object is live while the HTTP
+/// request is in progress. By the time deinit starts, all starting a call requires having a
+/// reference to the object, so shutdown
+final class HTTPClientHolder: HTTPClientProtocol {
+  let inner = AsyncHTTPClient.HTTPClient()
+  deinit {
+    // Use a background task to shutdown the inner client. In most cases, the application will
+    // continue running and the HTTPClient is shutdown "eventually". Except for (maybe) some false
+    // positives in leak detectors, there is no harm if the application terminates before this gets
+    // to run.
+    let copy = inner
+    Task {
+      // Note how we make a copy of `inner` to avoid capturing `self`.
+      do {
+        try await copy.shutdown()
+      } catch {
+        // Ignore any exceptions. If `shutdown()` failed there is nothing the application can do.
+      }
+    }
+  }
+
+  func execute(request: HTTPClientRequest, timeout: Duration) async throws -> HTTPClientResponse {
+    try await self.inner.execute(request, timeout: .init(timeout), logger: nil)
+  }
+}

--- a/packages/gax/Sources/GoogleCloudGax/HTTPClientProtocol.swift
+++ b/packages/gax/Sources/GoogleCloudGax/HTTPClientProtocol.swift
@@ -1,0 +1,24 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import struct AsyncHTTPClient.HTTPClientRequest
+import struct AsyncHTTPClient.HTTPClientResponse
+import struct Logging.Logger
+
+/// A module-private protocol to mock `AsyncHTTPClient.HTTPClient`.
+///
+/// The tests for `GoogleCloudGax.HttpClient`
+protocol HTTPClientProtocol: Sendable {
+  func execute(request: HTTPClientRequest, timeout: Duration) async throws -> HTTPClientResponse
+}

--- a/packages/gax/Sources/GoogleCloudGax/HTTPClientRequest.swift
+++ b/packages/gax/Sources/GoogleCloudGax/HTTPClientRequest.swift
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import struct AsyncHTTPClient.HTTPClientRequest
+import struct NIOHTTP1.HTTPHeaders
+import enum NIOHTTP1.HTTPMethod
+import struct Logging.Logger
+
+/// Represents an HTTP request.
+///
+/// The generated code uses this type directly. It exposes the methods we
+/// need, and nothing else.
+@_spi(GoogleCloudInternal) public struct _HTTPClientRequest {
+  let client: any HTTPClientProtocol
+  var components: URLComponents
+  var headers: NIOHTTP1.HTTPHeaders
+  var method: NIOHTTP1.HTTPMethod = .GET
+  var body: Data? = nil
+
+  // If the application and retry policy does not set a limit for each attempt we use this. The
+  // expectation is that any RPC that takes this long or longer should be an LRO.
+  static let defaultTimeout: Duration = .seconds(60)
+
+  // Limit the maximum error response size. Note that most gRPC client libraries limit response
+  // sizes to 4 MiB, including successful value responses. Setting a limit that is 8 times as large
+  // seems fine.
+  static let maximumErrorSize: Int = 32 * 1024 * 1024
+
+  init(_ client: HTTPClientProtocol, url: URLComponents) {
+    self.client = client
+    self.components = url
+    self.headers = NIOHTTP1.HTTPHeaders()
+  }
+
+  public mutating func setMethod(_ method: NIOHTTP1.HTTPMethod) {
+    self.method = method
+  }
+
+  public mutating func addHeader(name: String, value: String) {
+    self.headers.add(name: name, value: value)
+  }
+
+  public mutating func setBody(data: Data, ofContentType: String) {
+    self.body = data
+    self.headers.add(name: "Content-Type", value: ofContentType)
+  }
+
+  consuming func execute(timeout: Duration) async throws
+    -> _HTTPClientResponse
+  {
+    guard let url = self.components.url else {
+      throw RequestError.binding("bad URL for components=\(components)")
+    }
+    var request = AsyncHTTPClient.HTTPClientRequest(url: url.absoluteString)
+    request.headers = self.headers
+    request.method = self.method
+    if let b = self.body {
+      request.body = .bytes(.init(data: b))
+    }
+    let response = try await self.client.execute(request: request, timeout: timeout)
+    return _HTTPClientResponse(response)
+  }
+
+  public consuming func rpc(timeout: Duration? = nil) async
+    -> Result<_HTTPClientResponse, RequestError>
+  {
+    do {
+      let response = try await self.execute(timeout: timeout ?? Self.defaultTimeout)
+      if !(200..<300).contains(response.status.code) {
+        let data = try await response.data(upTo: Self.maximumErrorSize)
+        return .failure(Self.parseError(data: data, response: response))
+      }
+      return .success(response)
+    } catch let e as RequestError {
+      return .failure(e)
+    } catch let e {
+      return .failure(.io(e))
+    }
+  }
+
+  static func parseError(data: Data, response: _HTTPClientResponse) -> RequestError {
+    let values = response.headers["Content-Type"]
+    if values.contains(where: { $0.contains("application/json") }) {
+      if let w = ErrorWrapper(data: data) {
+        return RequestError.service(ServiceError(wrapper: w))
+      }
+    }
+    let headers = Dictionary(
+      grouping: response.headers,
+      by: { $0.name }
+    )
+    .mapValues { values in values.map { $0.value } }
+    .mapValues { values in values.joined(separator: ";") }
+    return GoogleCloudGax.RequestError.http(
+      GoogleCloudGax.HTTPDetails(
+        http_status_code: Int(response.status.code),
+        headers: headers,
+        payload: data,
+      ))
+  }
+}

--- a/packages/gax/Sources/GoogleCloudGax/HTTPClientResponse.swift
+++ b/packages/gax/Sources/GoogleCloudGax/HTTPClientResponse.swift
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import struct AsyncHTTPClient.HTTPClientResponse
+import struct NIOHTTP1.HTTPHeaders
+import enum NIOHTTP1.HTTPResponseStatus
+
+/// Represents an HTTP response.
+///
+/// The generated code uses this type directly. It exposes the methods we
+/// need, and nothing else.
+@_spi(GoogleCloudInternal) public struct _HTTPClientResponse {
+  let response: AsyncHTTPClient.HTTPClientResponse
+
+  init(_ response: AsyncHTTPClient.HTTPClientResponse) {
+    self.response = response
+  }
+
+  public var status: NIOHTTP1.HTTPResponseStatus {
+    self.response.status
+  }
+
+  public var headers: NIOHTTP1.HTTPHeaders {
+    self.response.headers
+  }
+
+  public func data(upTo: Int) async throws -> Data {
+    let buffer = try await self.response.body.collect(upTo: upTo)
+    return Data(buffer: buffer)
+  }
+}

--- a/packages/gax/Sources/GoogleCloudGax/HTTPClientV2.swift
+++ b/packages/gax/Sources/GoogleCloudGax/HTTPClientV2.swift
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import struct GoogleCloudAuth.Credentials
+import class AsyncHTTPClient.HTTPClient
+import struct AsyncHTTPClient.HTTPClientRequest
+import struct AsyncHTTPClient.HTTPClientResponse
+import struct Logging.Logger
+
+/// Implements a HTTP-only client for the Swift SDK client libraries.
+@_spi(GoogleCloudInternal) public struct _HTTPClient {
+  let baseURL: URLComponents
+  let credentials: any CredentialsProtocol
+  let logger: Logger?
+  let inner: any HTTPClientProtocol
+
+  // Creates a new client.
+  public init(from: ClientOptions, withDefaultEndpoint: String) throws {
+    self.credentials = try from.credentials ?? GoogleCloudAuth.Credentials()
+    self.logger = from.logger
+    let endpoint = from.endpoint ?? withDefaultEndpoint
+    self.baseURL = try Self.validateEndpoint(endpoint)
+    self.inner = HTTPClientHolder()
+  }
+
+  // Creates a new testing client.
+  init(
+    _ inner: any HTTPClientProtocol, endpoint: String,
+    credentials: (any CredentialsProtocol)? = nil,
+    logger: Logging.Logger? = nil,
+  ) throws {
+    self.baseURL = try Self.validateEndpoint(endpoint)
+    self.credentials = try credentials ?? GoogleCloudAuth.Credentials(configuration: .anonymous)
+    self.logger = logger
+    self.inner = inner
+  }
+
+  static func validateEndpoint(_ endpoint: String) throws -> URLComponents {
+    guard var parsed = URLComponents(string: endpoint) else {
+      throw ClientError.invalidEndpoint(endpoint)
+    }
+    parsed.queryItems = nil
+    parsed.path = ""
+    guard let scheme = parsed.scheme, (scheme == "http" || scheme == "https") else {
+      throw ClientError.invalidEndpoint(endpoint)
+    }
+    guard let host = parsed.host, !host.isEmpty else {
+      throw ClientError.invalidEndpoint(endpoint)
+    }
+    return parsed
+  }
+
+  public func newRequest(path: String, query: [URLQueryItem]) async throws -> _HTTPClientRequest {
+    var components = self.baseURL
+    components.path = path
+    components.queryItems = query
+    var request = _HTTPClientRequest(self.inner, url: components)
+    let headers = try await self.credentials.headers()
+    for (key, value) in headers {
+      request.addHeader(name: key, value: value)
+    }
+    return request
+  }
+}

--- a/packages/gax/Tests/HTTPClientV2Tests.swift
+++ b/packages/gax/Tests/HTTPClientV2Tests.swift
@@ -1,0 +1,558 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+import struct Logging.Logger
+@_spi(GoogleCloudInternal) @testable import GoogleCloudGax
+import GoogleCloudAuth
+import GoogleRpc
+import AsyncHTTPClient
+import NIOCore
+import NIOHTTP1
+
+@Suite struct HTTPClientV2Tests {
+  @Test(arguments: [
+    // A `?` in the path results in a percent-encoded `?` == %3F
+    ("/path?$name=value", "path%3F$name=value"),
+    // A percent-encoded `?` in the path results in a percent-encoded `%` == %25
+    ("/path%3F$name=value", "path%253F$name=value"),
+  ]) func escapePath(
+    inputPath: String, wantPath: String
+  ) async throws {
+    let endpoint = "http://localhost:1234"
+    let credentials = try Credentials(configuration: .anonymous)
+    let options = ClientOptions().with { $0.credentials = credentials }
+    let client = try _HTTPClient(from: options, withDefaultEndpoint: endpoint)
+    let query = [URLQueryItem(name: "$alt", value: "json")]
+    let request = try await client.newRequest(path: inputPath, query: query)
+    // Note the percent-escaped `?`
+    #expect(
+      request.components.url?.absoluteString == "http://localhost:1234/\(wantPath)?$alt=json")
+  }
+
+  @Test(arguments: [
+    "bad-bad-bad",
+    "htt://localhost:1",
+    "file:///etc/passwd",
+    "http:///",
+    "https:///",
+  ]) func badEndpoint(input: String) throws {
+    let credentials = try Credentials(configuration: .anonymous)
+    let options = ClientOptions().with {
+      $0.credentials = credentials
+      $0.endpoint = input
+    }
+    let error = #expect(throws: ClientError.self) {
+      let _ = try _HTTPClient(from: options, withDefaultEndpoint: "https://localhost:1234")
+    }
+    guard case let .invalidEndpoint(msg) = error else {
+      Issue.record("Mismatched error type, want .invalidEndpoint, got=\(error).")
+      return
+    }
+    #expect(msg.contains(input), "error=\(error)")
+  }
+
+  @Test(arguments: [
+    "bad-bad-bad",
+    "htt://localhost:1",
+    "file:///etc/passwd",
+    "http:///",
+    "https:///",
+  ]) func badDefaultEndpoint(input: String) throws {
+    let credentials = try Credentials(configuration: .anonymous)
+    let options = ClientOptions().with {
+      $0.credentials = credentials
+    }
+    let error = #expect(throws: ClientError.self) {
+      let _ = try _HTTPClient(from: options, withDefaultEndpoint: input)
+    }
+    guard case let .invalidEndpoint(msg) = error else {
+      Issue.record("Mismatched error type, want .invalidEndpoint, got=\(error).")
+      return
+    }
+    #expect(msg.contains(input), "error=\(error)")
+  }
+
+  @Test func postRequest() async throws {
+    let mock = MockHTTPClient { (request, timeout) in
+      #expect(timeout == .seconds(1))
+      #expect(request.method == .POST)
+      #expect(request.url == "http://localhost:8080/v1/projects/my-project/secrets?$alt=json")
+
+      return HTTPClientResponse(
+        version: .http1_1,
+        status: .ok,
+        body: .bytes(.init(string: "{}"))
+      )
+    }
+
+    let endpoint = "http://localhost:8080"
+    let path = "/v1/projects/my-project/secrets"
+    let client = try _HTTPClient(mock, endpoint: endpoint)
+    var request = try await client.newRequest(
+      path: path,
+      query: [URLQueryItem(name: "$alt", value: "json")],
+    )
+    request.setMethod(.POST)
+    request.setBody(data: .init("{}".utf8), ofContentType: "application/json")
+    let response = try await request.execute(timeout: .seconds(1))
+    #expect(response.status == .ok)
+    let data = try await response.data(upTo: 1024)
+    #expect(data == .init("{}".utf8))
+  }
+
+  @Test func rpcNoTimeout() async throws {
+    let mock = MockHTTPClient { (request, timeout) in
+      #expect(timeout == _HTTPClientRequest.defaultTimeout)
+      #expect(request.method == .GET)
+      #expect(request.url == "http://localhost:8080/v1/projects/my-project/secrets?$alt=json")
+
+      return HTTPClientResponse(
+        version: .http1_1,
+        status: .ok,
+        body: .bytes(.init(string: "{}"))
+      )
+    }
+
+    let endpoint = "http://localhost:8080"
+    let path = "/v1/projects/my-project/secrets"
+    let client = try _HTTPClient(mock, endpoint: endpoint)
+    var request = try await client.newRequest(
+      path: path,
+      query: [URLQueryItem(name: "$alt", value: "json")],
+    )
+    request.setMethod(.GET)
+    guard case .success(let response) = await request.rpc() else {
+      Issue.record("expected a successful RPC")
+      return
+    }
+    #expect(response.status == .ok)
+    let data = try await response.data(upTo: 1024)
+    #expect(data == .init("{}".utf8))
+  }
+
+  @Test func getErrorDetails() async throws {
+    let endpoint = "http://localhost:8080"
+    let path = "/v1/projects/test-only-project/locations/us-central1/orchestrationClusters"
+    let url = "\(endpoint)\(path)?$alt=json"
+
+    let mock = MockHTTPClient { (request, timeout) in
+      #expect(request.method == .GET)
+      #expect(request.url == url)
+
+      return HTTPClientResponse(
+        version: .http1_1,
+        status: .forbidden,
+        headers: .init([("Content-Type", "application/json; charset=UTF-8")]),
+        body: .bytes(.init(string: errorResponseWithDetails))
+      )
+    }
+
+    let client = try _HTTPClient(mock, endpoint: endpoint)
+    let request = try await client.newRequest(
+      path: path, query: [URLQueryItem(name: "$alt", value: "json")])
+    let response = await request.rpc(timeout: .seconds(1))
+    guard case let .failure(.service(serviceError)) = response else {
+      Issue.record("expected an service error response, got=\(response)")
+      return
+    }
+    #expect(serviceError.code == Code.permissionDenied, "\(serviceError)")
+    #expect(serviceError.message.starts(with: "Telco Automation API"), "\(serviceError)")
+    #expect(serviceError.details == wantDetails, "\(serviceError)")
+  }
+
+  @Test func getHttpError() async throws {
+    let endpoint = "http://localhost:8080"
+    let path = "/v1/projects//locations/us-central1/orchestrationClusters"
+    let url = "\(endpoint)\(path)?$alt=json"
+
+    let mock = MockHTTPClient { (request, _) in
+      #expect(request.method == .GET)
+      #expect(request.url == url)
+
+      return HTTPClientResponse(
+        version: .http1_1,
+        status: .notFound,
+        headers: .init([("Content-Type", "text/html; charset=UTF-8")]),
+        body: .bytes(.init(string: "<!DOCTYPE html><html lang=en><title>Error 404</title></html>"))
+      )
+    }
+
+    let client = try _HTTPClient(mock, endpoint: endpoint)
+    let request = try await client.newRequest(
+      path: path, query: [URLQueryItem(name: "$alt", value: "json")])
+
+    let response = await request.rpc()
+    guard case let .failure(.http(httpError)) = response else {
+      Issue.record("expected an http error response, got=\(response)")
+      return
+    }
+    #expect(httpError.http_status_code == 404)
+  }
+
+  @Test("verify the client when used as GAPICs do for Create-like operations")
+  func useAsGAPICCreate() async throws {
+    let clientHeader = GoogleCloudGax._gapicApiClientHeader(packageVersion: "1.2.3")
+    var wantURL = URLComponents()
+    wantURL.scheme = "https"
+    wantURL.host = "test-only.googleapis.com"
+    wantURL.path = "/v1/projects/p/things"
+    wantURL.queryItems = [
+      URLQueryItem(name: "$alt", value: "json;enum-encoding=int"),
+      URLQueryItem(name: "thingId", value: "test-only-thing-id"),
+    ]
+    let wantURLString = wantURL.url?.absoluteString
+    let requestBody = Data(#"{"thingAttribute":"test-value"}"#.utf8)
+    let responseBody = #"{"name":"projects/p/things/test-only-thing-id"}"#
+
+    let mockCredentials = MockCredentials([
+      {
+        return [
+          ("authorization", "test-only-auth"),
+          ("x-goog-auth", "test-only-auth2"),
+        ]
+      }
+    ])
+    let mock = MockHTTPClient { @Sendable (request, _) in
+      #expect(request.method == .POST)
+      #expect(request.url == wantURLString)
+      #expect(request.headers["x-goog-api-client"] == [clientHeader])
+      #expect(request.headers["authorization"] == ["test-only-auth"])
+      #expect(request.headers["x-goog-auth"] == ["test-only-auth2"])
+      #expect(request.headers["content-type"] == ["application/json"])
+
+      let buffer = try await request.body!.collect(upTo: 1024)
+      #expect(Data(buffer: buffer) == requestBody)
+
+      return HTTPClientResponse(
+        version: .http2,
+        status: .ok,
+        headers: .init([("Content-Type", "application/json; charset=UTF-8")]),
+        body: .bytes(.init(string: responseBody))
+      )
+    }
+
+    let client = try _HTTPClient(
+      mock, endpoint: "https://test-only.googleapis.com", credentials: mockCredentials)
+
+    let path = "/v1/projects/p/things"
+    var query = [
+      URLQueryItem(name: "$alt", value: "json;enum-encoding=int")
+    ]
+    let encoder = GoogleCloudGax.QueryParameterEncoder()
+    query.append(contentsOf: try encoder.encode("test-only-thing-id", prefix: "thingId"))
+    var req = try await client.newRequest(path: path, query: query)
+    req.setMethod(.POST)
+    req.addHeader(name: "X-Goog-Api-Client", value: clientHeader)
+    req.setBody(data: requestBody, ofContentType: "application/json")
+    let response = try await req.rpc().get()
+    let data = try await response.data(upTo: 1024)
+    #expect(data == Data(responseBody.utf8))
+  }
+
+  @Test("verify the client when used as GAPICs do for Get-like operations")
+  func useAsGAPICGet() async throws {
+    let clientHeader = GoogleCloudGax._gapicApiClientHeader(packageVersion: "1.2.3")
+    var wantURL = URLComponents()
+    wantURL.scheme = "https"
+    wantURL.host = "test-only.googleapis.com"
+    wantURL.path = "/v1/projects/p/things/test-only-thing-id"
+    wantURL.queryItems = [
+      URLQueryItem(name: "$alt", value: "json;enum-encoding=int")
+    ]
+    let wantURLString = wantURL.url?.absoluteString
+    let responseBody = #"{"name":"projects/p/things/test-only-thing-id"}"#
+
+    let mockCredentials = MockCredentials([
+      {
+        return [
+          ("authorization", "test-only-auth"),
+          ("x-goog-auth", "test-only-auth2"),
+        ]
+      }
+    ])
+    let mock = MockHTTPClient { @Sendable (request, _) in
+      #expect(request.method == .GET)
+      #expect(request.url == wantURLString)
+      #expect(request.headers["x-goog-api-client"] == [clientHeader])
+      #expect(request.headers["authorization"] == ["test-only-auth"])
+      #expect(request.headers["x-goog-auth"] == ["test-only-auth2"])
+      #expect(request.headers["content-type"] == [])
+      #expect(request.body == nil)
+
+      return HTTPClientResponse(
+        version: .http2,
+        status: .ok,
+        headers: .init([("Content-Type", "application/json; charset=UTF-8")]),
+        body: .bytes(.init(string: responseBody))
+      )
+    }
+
+    let client = try _HTTPClient(
+      mock, endpoint: "https://test-only.googleapis.com", credentials: mockCredentials)
+
+    let path = "/v1/projects/p/things/test-only-thing-id"
+    let query = [
+      URLQueryItem(name: "$alt", value: "json;enum-encoding=int")
+    ]
+    var req = try await client.newRequest(path: path, query: query)
+    req.setMethod(.GET)
+    req.addHeader(name: "X-Goog-Api-Client", value: clientHeader)
+    let response = try await req.rpc().get()
+    let data = try await response.data(upTo: 1024)
+    #expect(data == Data(responseBody.utf8))
+  }
+
+  @Test("verify the client when used as GAPICs do for Delete-like operations")
+  func useAsGAPICDelete() async throws {
+    let clientHeader = GoogleCloudGax._gapicApiClientHeader(packageVersion: "1.2.3")
+    var wantURL = URLComponents()
+    wantURL.scheme = "https"
+    wantURL.host = "test-only.googleapis.com"
+    wantURL.path = "/v1/projects/p/things/test-only-thing-id"
+    wantURL.queryItems = [
+      URLQueryItem(name: "$alt", value: "json;enum-encoding=int")
+    ]
+    let wantURLString = wantURL.url?.absoluteString
+
+    let mockCredentials = MockCredentials([
+      {
+        return [
+          ("authorization", "test-only-auth"),
+          ("x-goog-auth", "test-only-auth2"),
+        ]
+      }
+    ])
+    let mock = MockHTTPClient { @Sendable (request, _) in
+      #expect(request.method == .GET)
+      #expect(request.url == wantURLString)
+      #expect(request.headers["x-goog-api-client"] == [clientHeader])
+      #expect(request.headers["authorization"] == ["test-only-auth"])
+      #expect(request.headers["x-goog-auth"] == ["test-only-auth2"])
+      #expect(request.headers["content-type"] == [])
+      #expect(request.body == nil)
+
+      return HTTPClientResponse(
+        version: .http2,
+        status: .ok,
+        headers: .init([("Content-Type", "application/json; charset=UTF-8")]),
+      )
+    }
+
+    let client = try _HTTPClient(
+      mock, endpoint: "https://test-only.googleapis.com", credentials: mockCredentials)
+
+    let path = "/v1/projects/p/things/test-only-thing-id"
+    let query = [
+      URLQueryItem(name: "$alt", value: "json;enum-encoding=int")
+    ]
+    var req = try await client.newRequest(path: path, query: query)
+    req.setMethod(.GET)
+    req.addHeader(name: "X-Goog-Api-Client", value: clientHeader)
+    _ = try await req.rpc().get()
+  }
+
+  @Test("verify the client when used as GAPICs do for Delete-like operations")
+  func useAsGAPICDeleteWithError() async throws {
+    let clientHeader = GoogleCloudGax._gapicApiClientHeader(packageVersion: "1.2.3")
+    var wantURL = URLComponents()
+    wantURL.scheme = "https"
+    wantURL.host = "test-only.googleapis.com"
+    wantURL.path = "/v1/projects/p/things/test-only-thing-id"
+    wantURL.queryItems = [
+      URLQueryItem(name: "$alt", value: "json;enum-encoding=int")
+    ]
+    let wantURLString = wantURL.url?.absoluteString
+
+    let mockCredentials = MockCredentials([
+      {
+        return [
+          ("authorization", "test-only-auth"),
+          ("x-goog-auth", "test-only-auth2"),
+        ]
+      }
+    ])
+    let mock = MockHTTPClient { @Sendable (request, _) in
+      #expect(request.method == .GET)
+      #expect(request.url == wantURLString)
+      #expect(request.headers["x-goog-api-client"] == [clientHeader])
+      #expect(request.headers["authorization"] == ["test-only-auth"])
+      #expect(request.headers["x-goog-auth"] == ["test-only-auth2"])
+      #expect(request.headers["content-type"] == [])
+      #expect(request.body == nil)
+
+      return HTTPClientResponse(
+        version: .http2,
+        status: .forbidden,
+        headers: .init([("Content-Type", "application/json; charset=UTF-8")]),
+        body: .bytes(.init(string: errorResponseWithDetails))
+      )
+    }
+
+    let client = try _HTTPClient(
+      mock, endpoint: "https://test-only.googleapis.com", credentials: mockCredentials)
+
+    let path = "/v1/projects/p/things/test-only-thing-id"
+    let query = [
+      URLQueryItem(name: "$alt", value: "json;enum-encoding=int")
+    ]
+    var req = try await client.newRequest(path: path, query: query)
+    req.setMethod(.GET)
+    req.addHeader(name: "X-Goog-Api-Client", value: clientHeader)
+    let e = await #expect(throws: GoogleCloudGax.RequestError.self) {
+      _ = try (await req.rpc()).get()
+    }
+    guard case .service(let serviceError) = e else {
+      Issue.record("expected service error , got \(e)")
+      return
+    }
+    #expect(serviceError.code == Code.permissionDenied, "\(serviceError)")
+    #expect(serviceError.message.starts(with: "Telco Automation API"), "\(serviceError)")
+    #expect(serviceError.details == wantDetails, "\(serviceError)")
+  }
+
+  @Test("verify the client when used as GAPICs do for Delete-like operations")
+  func useAsGAPICDeleteWithTransportError() async throws {
+    let clientHeader = GoogleCloudGax._gapicApiClientHeader(packageVersion: "1.2.3")
+    var wantURL = URLComponents()
+    wantURL.scheme = "https"
+    wantURL.host = "test-only.googleapis.com"
+    wantURL.path = "/invalid/path"
+    wantURL.queryItems = [
+      URLQueryItem(name: "$alt", value: "json;enum-encoding=int")
+    ]
+    let wantURLString = wantURL.url?.absoluteString
+    let responsePayload = "<!DOCTYPE html><html lang=en><title>Error 404</title></html>"
+
+    let mockCredentials = MockCredentials([
+      {
+        return [
+          ("authorization", "test-only-auth"),
+          ("x-goog-auth", "test-only-auth2"),
+        ]
+      }
+    ])
+    let mock = MockHTTPClient { @Sendable (request, _) in
+      #expect(request.method == .GET)
+      #expect(request.url == wantURLString)
+      #expect(request.headers["x-goog-api-client"] == [clientHeader])
+      #expect(request.headers["authorization"] == ["test-only-auth"])
+      #expect(request.headers["x-goog-auth"] == ["test-only-auth2"])
+      #expect(request.headers["content-type"] == [])
+      #expect(request.body == nil)
+
+      return HTTPClientResponse(
+        version: .http2,
+        status: .forbidden,
+        headers: .init([
+          ("Content-Type", "text/html; charset=UTF-8"),
+          ("x-goog-test-only", "test-header"),
+        ]),
+        body: .bytes(.init(string: responsePayload))
+      )
+    }
+
+    let client = try _HTTPClient(
+      mock, endpoint: "https://test-only.googleapis.com", credentials: mockCredentials)
+
+    let path = "/invalid/path"
+    let query = [
+      URLQueryItem(name: "$alt", value: "json;enum-encoding=int")
+    ]
+    var req = try await client.newRequest(path: path, query: query)
+    req.setMethod(.GET)
+    req.addHeader(name: "X-Goog-Api-Client", value: clientHeader)
+    let e = await #expect(throws: GoogleCloudGax.RequestError.self) {
+      _ = try (await req.rpc()).get()
+    }
+    guard case .http(let httpError) = e else {
+      Issue.record("expected service error , got \(e)")
+      return
+    }
+    #expect(httpError.http_status_code == HTTPResponseStatus.forbidden.code)
+    #expect(httpError.payload == Data(responsePayload.utf8))
+    #expect(httpError.headers["x-goog-test-only"] == "test-header")
+  }
+}
+
+fileprivate let errorResponseWithDetails = """
+  {
+    "error": {
+      "code": 403,
+      "message": "Telco Automation API has not been used in project test-only-project before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/telcoautomation.googleapis.com/overview?project=test-only-project then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
+      "status": "PERMISSION_DENIED",
+      "details": [
+        {
+          "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+          "reason": "SERVICE_DISABLED",
+          "domain": "googleapis.com",
+          "metadata": {
+            "activationUrl": "https://console.developers.google.com/apis/api/telcoautomation.googleapis.com/overview?project=test-only-project",
+            "service": "telcoautomation.googleapis.com",
+            "consumer": "projects/test-only-project",
+            "containerInfo": "test-only-project",
+            "serviceTitle": "Telco Automation API"
+          }
+        },
+        {
+          "@type": "type.googleapis.com/google.rpc.LocalizedMessage",
+          "locale": "en-US",
+          "message": "Telco Automation API has not been used in project test-only-project before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/telcoautomation.googleapis.com/overview?project=test-only-project then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry."
+        },
+        {
+          "@type": "type.googleapis.com/google.rpc.Help",
+          "links": [
+            {
+              "description": "Google developers console API activation",
+              "url": "https://console.developers.google.com/apis/api/telcoautomation.googleapis.com/overview?project=test-only-project"
+            }
+          ]
+        }
+      ]
+    }
+  }
+  """
+
+fileprivate let wantDetails: [StatusDetail] = [
+  .errorInfo(
+    ErrorInfo().with {
+      $0.reason = "SERVICE_DISABLED"
+      $0.domain = "googleapis.com"
+      $0.metadata = [
+        "activationUrl":
+          "https://console.developers.google.com/apis/api/telcoautomation.googleapis.com/overview?project=test-only-project",
+        "service": "telcoautomation.googleapis.com",
+        "consumer": "projects/test-only-project",
+        "containerInfo": "test-only-project",
+        "serviceTitle": "Telco Automation API",
+      ]
+    }),
+  .localizedMessage(
+    LocalizedMessage().with {
+      $0.locale = "en-US"
+      $0.message =
+        "Telco Automation API has not been used in project test-only-project before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/telcoautomation.googleapis.com/overview?project=test-only-project then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry."
+    }),
+  .help(
+    Help().with {
+      $0.links = [
+        Help.Link().with {
+          $0.description = "Google developers console API activation"
+          $0.url =
+            "https://console.developers.google.com/apis/api/telcoautomation.googleapis.com/overview?project=test-only-project"
+        }
+      ]
+    }),
+]

--- a/packages/gax/Tests/HttpClientTests.swift
+++ b/packages/gax/Tests/HttpClientTests.swift
@@ -225,7 +225,7 @@ import GoogleRpc
   }
 }
 
-let errorResponseWithDetails = """
+fileprivate let errorResponseWithDetails = """
   {
     "error": {
       "code": 403,
@@ -263,7 +263,7 @@ let errorResponseWithDetails = """
   }
   """
 
-let wantDetails: [StatusDetail] = [
+fileprivate let wantDetails: [StatusDetail] = [
   .errorInfo(
     ErrorInfo().with {
       $0.reason = "SERVICE_DISABLED"

--- a/packages/gax/Tests/IntegrationTests/IntegrationTests.swift
+++ b/packages/gax/Tests/IntegrationTests/IntegrationTests.swift
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 import Foundation
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
 import GoogleCloudAuth
 import GoogleCloudGax
 import Testing
@@ -23,7 +20,7 @@ import Testing
 #if IntegrationTests
 
   @Suite struct HTTPClientIntegrationTests {
-    @Test func UrlSessionTest() async {
+    @Test func concurrentRequests() async {
       func runOnce() async {
         do {
           let options = ClientOptions().with {
@@ -39,7 +36,7 @@ import Testing
       }
 
       let iterations = 100
-      print("Starting URLSession reproduction loop (\(iterations) iterations)...")
+      print("Starting concurrent requests stress tests for (\(iterations) iterations)...")
       for i in 1...iterations {
         await runOnce()
         // Give it a tiny sleep to allow concurrent scheduling

--- a/packages/gax/Tests/MockCredentials.swift
+++ b/packages/gax/Tests/MockCredentials.swift
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Synchronization
+import Testing
+import struct DequeModule.Deque
+import GoogleCloudAuth
+@testable import GoogleCloudGax
+
+final class MockCredentials: GoogleCloudGax.CredentialsProtocol {
+  typealias Handler = @Sendable () async throws -> GoogleCloudAuth.AuthHeaders
+  enum MockError: Error, Sendable {
+    case empty
+  }
+
+  let handlers: Mutex<Deque<Handler>>
+
+  init(_ handlers: [Handler]) {
+    self.handlers = Mutex(Deque(handlers))
+  }
+
+  deinit {
+    #expect(handlers.withLock { $0.isEmpty })
+  }
+
+  public func headers() async throws -> GoogleCloudAuth.AuthHeaders {
+    guard let handler = self.handlers.withLock({ $0.popFirst() }) else {
+      throw MockError.empty
+    }
+    return try await handler()
+  }
+}

--- a/packages/gax/Tests/MockHTTPClient.swift
+++ b/packages/gax/Tests/MockHTTPClient.swift
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Synchronization
+import Testing
+import struct Logging.Logger
+import struct DequeModule.Deque
+import GoogleCloudAuth
+import struct AsyncHTTPClient.HTTPClientRequest
+import struct AsyncHTTPClient.HTTPClientResponse
+@_spi(GoogleCloudInternal) @testable import GoogleCloudGax
+
+final class MockHTTPClient: HTTPClientProtocol, Sendable {
+  typealias Handler =
+    @Sendable (HTTPClientRequest, Duration) async throws -> HTTPClientResponse
+  private let handler: Handler
+
+  init(_ handler: @escaping Handler) {
+    self.handler = handler
+  }
+
+  func execute(request: HTTPClientRequest, timeout: Duration) async throws -> HTTPClientResponse {
+    try await handler(request, timeout)
+  }
+}


### PR DESCRIPTION
Introduce new types, based on [AsyncHTTPClient], to implement GAPIC clients (and veneers) using HTTP+JSON for their transport.

I introduced wrapper types the `_HTTPClient`, `_HTTPClientRequest` and `_HTTPClientResponse`. These are the only types that I expect we will use by name in the generated (or hand-crafted) client libraries. In a hypothetical future where we change the HTTP implementation these may change.

There are other types we will use, but not by name, e.g. `NIOHTTP1.Method` and `NIOHTTP1.ResponseStatus`. These may change too, but seems very unlikely.

I think using types by name from the foundation library (`URL`, `URLComponents`, `URLQueryItem`) are perfectly safe and stable. No need to wrap those.

I included tests showing how the generator will use the types.

Fixes #246 towards #247 