### PR TITLE
docs(guide): add override endpoint section

### DIFF
--- a/guide/Snippets/OverrideEndpoint.swift
+++ b/guide/Snippets/OverrideEndpoint.swift
@@ -1,0 +1,45 @@
+// snippet.hide
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// snippet.show
+// snippet.imports
+import Foundation
+import GoogleCloudGax
+import GoogleCloudSecretManagerV1
+// snippet.end
+
+// snippet.function [START swift_override_endpoint_function]
+func sample(projectId: String, region: String) async throws {
+// snippet.end [END swift_override_endpoint_function]
+  // snippet.client [START swift_override_endpoint_client]
+  let client = try SecretManagerServiceClient(ClientOptions().with {
+    $0.endpoint = "https://secretmanager.\(region).rep.googleapis.com"
+  })
+  // snippet.end [END swift_override_endpoint_client]
+  // snippet.list [START swift_override_endpoint_list]
+  let secrets = try client.listSecrets(
+    byItem: ListSecretsRequest().with { $0.parent = "projects/\(projectId)/locations/\(region)" })
+  for try await item in secrets {
+    print("  \(item)")
+  }
+  // snippet.end [START swift_override_endpoint_list]
+}
+
+// snippet.hide
+@main struct SnippetRunner {
+  static func main() async throws {
+    try await sample(projectId: "[placeholder]", region: "us-central1")
+  }
+}

--- a/guide/Snippets/OverrideEndpoint.swift
+++ b/guide/Snippets/OverrideEndpoint.swift
@@ -34,7 +34,7 @@ func sample(projectId: String, region: String) async throws {
   for try await item in secrets {
     print("  \(item)")
   }
-  // snippet.end [START swift_override_endpoint_list]
+  // snippet.end [END swift_override_endpoint_list]
 }
 
 // snippet.hide

--- a/guide/Sources/UserGuide/UserGuide.docc/UserGuide.md
+++ b/guide/Sources/UserGuide/UserGuide.docc/UserGuide.md
@@ -11,6 +11,18 @@ best-practices to retry failed requests.
 The client libraries use Swift 6.0 to provide asynchronous, thread-safe, and
 memory-safe APIs.
 
-## Topics
+<!-- TODO(https://github.com/googleapis/google-cloud-swift/issues/135)
+## Discover
+
+- <doc:overview>
+- <doc:supported-versions>
+
+-->
+
+## Get started
 
 - <doc:quickstart>
+
+## Develop
+
+- <doc:override-endpoint>

--- a/guide/Sources/UserGuide/UserGuide.docc/override-endpoint.md
+++ b/guide/Sources/UserGuide/UserGuide.docc/override-endpoint.md
@@ -1,0 +1,51 @@
+# Override the default endpoint
+
+<!--
+    It seems that swift-docc does not support reference-style links at the bottom of the file:
+
+    https://github.com/swiftlang/swift-docc/issues/685
+-->
+[Installing Swift]: https://www.swift.org/getting-started/
+[Getting Started with Swift]: <doc:quickstart>
+[locational endpoints]: /storage/docs/locational-endpoints
+[private access options]: /vpc/docs/private-access-options
+[regional endpoints]: https://cloud.google.com/sovereign-controls-by-partners/docs/regional-endpoints
+[secret manager api]: https://cloud.google.com/secret-manager
+[service quickstart]: https://cloud.google.com/secret-manager/docs/quickstart
+
+The Swift client libraries automatically configure the endpoint for each
+service. Some applications may need to override the default endpoint either
+because their network has specific requirements, or because they need to use
+regional versions of the service. This guide shows you how to override the
+default.
+
+## Prerequisites
+
+This guide uses the [Secret Manager API]. To enable this API, follow the
+[service quickstart].
+
+For complete setup instructions for the Swift client libraries, see
+[Getting started with Swift].
+
+## Override the default endpoint
+
+In this example you configure the client library to use secret manager's
+[regional endpoints]. The same override can be used to configure the endpoint
+with one of the [private access options], or for [locational endpoints] in the
+services that support them.
+
+1. Add the imports needed to use the client library
+   @Snippet(path: "OverrideEndpoint", slice: "imports")
+2. Write a function that receives the project ID and region as parameters
+   @Snippet(path: "OverrideEndpoint", slice: "function")
+3. Initialize a client and override the endpoint to use a regional endpoint:
+   @Snippet(path: "OverrideEndpoint", slice: "client")
+4. Use the client to retrieve the list of secrets in a region, and iterate over
+   the results:
+   @Snippet(path: "OverrideEndpoint", slice: "list")
+
+## Next steps
+
+<!-- TODO(https://github.com/googleapis/google-cloud-swift/issues/137) - lint the credentials override guide -->
+<!-- TODO(https://github.com/googleapis/google-cloud-swift/issues/144) - lint the retry policy override guide -->
+<!-- TODO(https://github.com/googleapis/google-cloud-swift/issues/145) - lint the polling policy override guide -->

--- a/guide/Sources/UserGuide/UserGuide.docc/quickstart.md
+++ b/guide/Sources/UserGuide/UserGuide.docc/quickstart.md
@@ -1,4 +1,4 @@
-# Quickstart
+# Getting started with Swift
 
 <!-- 
     It seems that swift-docc does not support reference-style links at the bottom of the file:
@@ -9,6 +9,8 @@
 [Authenticate for using client libraries]: https://cloud.google.com/docs/authentication/client-libraries
 [Application Default Credentials]: https://cloud.google.com/docs/authentication/application-default-credentials
 [Get started with Google Cloud]: https://docs.cloud.google.com/docs/get-started
+[secret manager api]: https://cloud.google.com/secret-manager
+[service quickstart]: https://cloud.google.com/secret-manager/docs/quickstart
 
 ## Install Swift
 
@@ -20,11 +22,16 @@ instructions.
 If you do not have a Google Cloud project, follow the
 [Get started with Google Cloud] guide.
 
+## Enable the Secret Manager service
+
+This guide uses the [Secret Manager API]. To enable this API, follow the
+[service quickstart].
+
 ## Authenticate to Google Cloud
 
 Follow the instructions in the [Authenticate for using client libraries] guide.
-This guide will show you how to login to configure [Application Default Credentials]
-used in this guide.
+This guide will show you how to login to Google Cloud, and configure the
+[Application Default Credentials] used in this guide.
 
 ## Create a Swift project
 


### PR DESCRIPTION
Add a new section and a code snippets showing how to override the default endpoint.

I had to reorganize the top-level doc to make room, which I think would help anyway.

Fixes #138 towards #135 