### PR TITLE
docs(guide): add overview pages

### DIFF
--- a/guide/Sources/UserGuide/UserGuide.docc/UserGuide.md
+++ b/guide/Sources/UserGuide/UserGuide.docc/UserGuide.md
@@ -1,23 +1,20 @@
-# Google Cloud Client Libraries for Swift - User Guide
+# ``UserGuide``
+
+The client libraries use Swift 6.0 to access Google Cloud using asynchronous,
+memory-safe, and thread-safe APIs.
 
 ## Overview
 
 The Google Cloud Client Libraries for Swift is a collection of libraries that
 simplify access to Google Cloud services for Swift developers. The libraries
 take care of establishing connections, providing and refreshing authentication
-tokens, simplify calls to long-running and paginated APIs, implement
-best-practices to retry failed requests.
+tokens, simplify calls to long-running and paginated APIs, and implement
+best-practices to retry transient RPC errors.
 
-The client libraries use Swift 6.0 to provide asynchronous, thread-safe, and
-memory-safe APIs.
-
-<!-- TODO(https://github.com/googleapis/google-cloud-swift/issues/135)
 ## Discover
 
 - <doc:overview>
 - <doc:supported-versions>
-
--->
 
 ## Get started
 

--- a/guide/Sources/UserGuide/UserGuide.docc/overview.md
+++ b/guide/Sources/UserGuide/UserGuide.docc/overview.md
@@ -1,0 +1,46 @@
+# Swift for Google Cloud SDK overview
+
+The Official Google Cloud Server-Side Swift SDK allows you to build and manage
+backend services on Google Cloud using the Swift programming language. This SDK
+is designed for developers building enterprise server infrastructure in Linux or
+Windows environments.
+
+## Full-stack Swift development
+
+You can use a single language across your entire application stack. By pairing
+the Google Cloud Server-Side Swift SDK with the Firebase SDK for Apple
+platforms, you can manage both your mobile frontend and your cloud backend with
+Swift.
+
+## Performance and safety
+
+Swift is a modern, strongly-typed language that offers high performance and
+memory safety. These features make it suitable for performance-critical
+server-side workloads and secure system programming.
+
+## Developer efficiency
+
+Building with a unified language ecosystem eliminates the need for
+context-switching between different programming languages. This reduces
+cognitive load for full-stack developers and allows frontend teams to leverage
+their existing Swift expertise to build backend services.
+
+## Product boundaries
+
+Google provides two distinct Swift SDKs to serve different development needs.
+
+| Feature | Firebase Apple SDKs | Google Cloud Server-Side Swift SDK |
+| :---- | :---- | :---- |
+| **Primary Use** | Client-side mobile and web development. | Backend server-side infrastructure. |
+| **Environment** | Apple client ecosystem (iOS, watchOS, etc.). | Deploy on Server environments (Linux, Windows). Develop on Linux, macOS or Windows. |
+| **Authentication** | User-based authentication and security rules. | Service Accounts, ADC, and Workload Identity Federation. |
+| **Service Scope** | Mobile-centric tools (Analytics, Firestore, etc.). | 140+ GCP APIs (Storage, GKE, Compute, etc.). |
+
+## Key features
+
+The Swift SDK is designed to feel native to your existing development workflow.
+
+* **Idiomatic Swift:** The SDK uses modern Swift features, including async/await for concurrency.  
+* **Native Networking:** It uses Apple’s Swift NIO and AsyncHTTPClient for seamless integration with your Swift-native servers.
+* **Secure Authentication:** You can securely authenticate using Application Default Credentials (ADC), Service Accounts, and Workload Identity Federation (WIF).  
+* **Standard Integration:** The SDK integrates with standard Swift ecosystem tools like Swift Package Manager (SPM).

--- a/guide/Sources/UserGuide/UserGuide.docc/quickstart.md
+++ b/guide/Sources/UserGuide/UserGuide.docc/quickstart.md
@@ -12,6 +12,9 @@
 [secret manager api]: https://cloud.google.com/secret-manager
 [service quickstart]: https://cloud.google.com/secret-manager/docs/quickstart
 
+Follow this guide to create a small Swift project using the Google Cloud client
+libraries for Swift.
+
 ## Install Swift
 
 If you have not installed the Swift toolchain, follow the [Installing Swift]

--- a/guide/Sources/UserGuide/UserGuide.docc/supported-versions.md
+++ b/guide/Sources/UserGuide/UserGuide.docc/supported-versions.md
@@ -1,0 +1,39 @@
+# Supported Swift versions
+
+[Client libraries explained]: https://cloud.google.com/apis/docs/client-libraries-explained
+[semantic versioning]: https://semver.org/
+[swift package update]: https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/resolvingpackageversions/
+[swiftly update]: https://www.swift.org/swiftly/documentation/swiftly/update-toolchain/
+[README]: https://github.com/googleapis/google-cloud-swift#readme
+
+<!-- reference links at the top for Swift DocC -->
+
+The Swift client libraries support Swift 6.3 and higher. This document provides
+additional information and best practices to keep your toolchain and libraries
+up-to-date.
+
+## Minimum supported Swift version
+
+The Swift client libraries support Swift 6.3 and higher. For more information on
+Cloud client libraries, see [Client libraries explained].
+
+Our Swift client libraries increment the major version when dropping
+compatibility with a Swift major version. For more information about the use
+of major and minor versions, see [Semantic Versioning].
+
+The libraries are tested against Swift versions released at the time the client
+libraries were released. To find out what versions we used in our testing,
+consult the projects [README] file.
+
+## Recommended version for new development
+
+When starting a new project, we recommend choosing the current release of Swift.
+This ensures that your runtime is within the supported Swift releases and
+receives critical security patches.
+
+## Keep your production systems current
+
+Ensure that you receive critical security and bug fixes by keeping your
+production systems on supported Swift toolchains. Use [swiftly update]
+to automatically update your version of Swift and [swift package update] to
+automatically update the Rust dependencies in your project.


### PR DESCRIPTION
Add an overview and a supported version page.

Reorganize the `UserGuide.md` so it works as a landing page in DocC.

Fixes #135.

<details><summary>Some screenshoots if you want them</summary>
<img width="1212" height="1208" alt="image" src="https://github.com/user-attachments/assets/1d134e12-fc9e-40e6-88e9-fd2b6bcc7528" />


<img width="1223" height="1251" alt="image" src="https://github.com/user-attachments/assets/0b2cff6e-066c-418a-8585-537fe229c672" />

</details>