### PR TITLE
ci: create minimum docs build

### DIFF
--- a/ci/gcb/builds/triggers/main.tf
+++ b/ci/gcb/builds/triggers/main.tf
@@ -39,6 +39,10 @@ locals {
       script  = "full"
       pool_id = "swift-sdk-pool-large"
     }
+    docs = {
+      config  = "scripted.yaml"
+      script  = "docs"
+    }
   }
 
   # These are builds that only run during Pull Requests.

--- a/ci/gcb/scripts/docs.sh
+++ b/ci/gcb/scripts/docs.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "--- SWIFT VERSION ---"
+swift --version
+echo "--- Initial disk space"
+df -h
+echo
+echo
+
+errors=0
+count=0
+
+flags=(
+    --warnings-as-errors
+)
+targets=(
+    GoogleCloudWkt
+    GoogleCloudAuth
+    GoogleCloudGax
+    GoogleCloudSecretManagerV1
+)
+echo "--- Building ${#targets[@]} targets"
+for target in "${targets[@]}"; do
+    count=$((count + 1))
+
+    echo; echo "================ Building ${target} ================"
+    if swift package generate-documentation "${flags[@]}" --target "${target}"; then
+        echo "✓ ${target} built successfully"
+    else
+        echo; echo "✗ ${target} failed to build"
+        errors=$((errors + 1))
+        continue
+    fi
+done
+
+# TODO(https://github.com/googleapis/google-cloud-swift/issues/308) - the xref links need fixing
+# after that we can merge this to the main loop
+echo; echo "================ Building GoogleCloudStorage ================"
+if swift package generate-documentation  --target "GoogleCloudStorage"; then
+    echo "✓ GoogleCloudStorage built successfully"
+else
+    echo; echo "✗ GoogleCloudStorage failed to build"
+    errors=$((errors + 1))
+    continue
+fi
+
+echo; echo; echo "${count} local targets(s) built, ${errors} failure(s)."
+echo "--- Remaining disk space"
+df -h
+
+if [[ ${errors} -gt 0 ]]; then
+    exit 1
+fi

--- a/ci/gcb/scripts/docs.sh
+++ b/ci/gcb/scripts/docs.sh
@@ -55,12 +55,12 @@ done
 # TODO(https://github.com/googleapis/google-cloud-swift/issues/308) - the xref links need fixing
 # after that we can merge this to the main loop
 echo; echo "================ Building GoogleCloudStorage ================"
+count=$((count + 1))
 if swift package generate-documentation  --target "GoogleCloudStorage"; then
     echo "✓ GoogleCloudStorage built successfully"
 else
     echo; echo "✗ GoogleCloudStorage failed to build"
     errors=$((errors + 1))
-    continue
 fi
 
 echo; echo; echo "${count} local targets(s) built, ${errors} failure(s)."


### PR DESCRIPTION
Validate the hand-crafted libraries and some generated libraries.
Validating all the generated libraries requires more machinery, and most
likely will succeed (or fail) in the same way.

Fixes #302 towards #12 