### PR TITLE
cleanup(gax)!: rename backoff policy argument

### DIFF
--- a/packages/gax/Sources/GoogleCloudGax/BackoffPolicy.swift
+++ b/packages/gax/Sources/GoogleCloudGax/BackoffPolicy.swift
@@ -35,7 +35,7 @@ public protocol BackoffPolicy: Sendable {
   /// Returns the backoff delay on a failure.
   ///
   /// - Parameters:
-  ///   - for: The current retry state.
+  ///   - state: The current retry state.
   /// - Returns: The delay before the next retry attempt.
-  func backoffDelay(for: RetryState) -> Duration
+  func backoffDelayFor(_ state: RetryState) -> Duration
 }

--- a/packages/gax/Sources/GoogleCloudGax/ExponentialBackoff.swift
+++ b/packages/gax/Sources/GoogleCloudGax/ExponentialBackoff.swift
@@ -105,7 +105,7 @@ public final class ExponentialBackoff: BackoffPolicy, Sendable {
     self.initialDelay = min(max(config.initialDelay, minInitial), self.maximumDelay)
   }
 
-  public func backoffDelay(for state: RetryState) -> Duration {
+  public func backoffDelayFor(_ state: RetryState) -> Duration {
     let d = delay(attemptCount: state.attemptCount)
     return Duration(attoseconds: Int128.random(in: 0...d.attoseconds))
   }

--- a/packages/gax/Sources/GoogleCloudGax/LinearBackoffPolicy.swift
+++ b/packages/gax/Sources/GoogleCloudGax/LinearBackoffPolicy.swift
@@ -26,7 +26,7 @@ public final class LinearBackoffPolicy: BackoffPolicy, Sendable {
     self.delay = delay
   }
 
-  public func backoffDelay(for _: RetryState) -> Duration {
+  public func backoffDelayFor(_ state: RetryState) -> Duration {
     return self.delay
   }
 }

--- a/packages/gax/Sources/GoogleCloudGax/LongRunningOperations.swift
+++ b/packages/gax/Sources/GoogleCloudGax/LongRunningOperations.swift
@@ -116,7 +116,7 @@ public final class _PollableOperationImpl<ResponseType>: PollableOperation {
     var pollingState = PollingState()
     while !state.done {
       try pollingPolicy.onInProgress(state: pollingState)
-      let delay = backoffPolicy.backoffDelay(for: pollingState.asRetryState())
+      let delay = backoffPolicy.backoffDelayFor(pollingState.asRetryState())
       try await sleep(delay)
       pollingState.attemptCount += 1
       do {

--- a/packages/gax/Sources/GoogleCloudGax/RetryLoop.swift
+++ b/packages/gax/Sources/GoogleCloudGax/RetryLoop.swift
@@ -107,7 +107,7 @@ public struct _RetryLoop: Sendable {
             throw e
           case .retry(let e):
             lastError = e
-            nextDelay = backoffPolicy.backoffDelay(for: state)
+            nextDelay = backoffPolicy.backoffDelayFor(state)
             continue
           }
         }
@@ -125,7 +125,7 @@ public struct _RetryLoop: Sendable {
           throw error
         }
         let flow = retryPolicy.onError(state: state, error: requestError)
-        nextDelay = backoffPolicy.backoffDelay(for: state)
+        nextDelay = backoffPolicy.backoffDelayFor(state)
         retryThrottler.onRetryFailure(flow: flow)
 
         switch flow {

--- a/packages/gax/Tests/ExponentialBackoffTests.swift
+++ b/packages/gax/Tests/ExponentialBackoffTests.swift
@@ -98,7 +98,7 @@ import Testing
     let backoff = ExponentialBackoff()
     let state = RetryState().with { $0.attemptCount = 1 }
     for _ in 0..<100 {
-      let d = backoff.backoffDelay(for: state)
+      let d = backoff.backoffDelayFor(state)
       #expect(d >= .seconds(0) && d <= .seconds(1))
     }
   }

--- a/packages/gax/Tests/MockBackoffPolicy.swift
+++ b/packages/gax/Tests/MockBackoffPolicy.swift
@@ -17,5 +17,5 @@ import GoogleCloudGax
 
 struct MockBackoff: BackoffPolicy {
   var delay: Duration = .zero
-  func backoffDelay(for: RetryState) -> Duration { delay }
+  func backoffDelayFor(_ state: RetryState) -> Duration { delay }
 }

--- a/packages/gax/Tests/RetryLoopTests.swift
+++ b/packages/gax/Tests/RetryLoopTests.swift
@@ -247,7 +247,7 @@ import Testing
     struct SeqBackoff: BackoffPolicy {
       let delays: [Duration]
       let index: AtomicCounter
-      func backoffDelay(for: RetryState) -> Duration {
+      func backoffDelayFor(_ state: RetryState) -> Duration {
         let i = index.increment()
         return i < delays.count ? delays[i] : .zero
       }


### PR DESCRIPTION
Yet another warning [^1] prompted me to review the naming convention for argument labels and parameters. I think the relevant guideline is:

> Otherwise, if the first argument forms part of a grammatical phrase,
  omit its label,
>
  https://www.swift.org/documentation/api-design-guidelines/#argument-labels

In this case, the phrase `backoffPolicy.backoffFor(state)` reads fine (to me).

[^1]: I got this thing: `error: External name 'for' used to document parameter --> packages/gax/Sources/GoogleCloudGax/BackoffPolicy.swift:38:11-38:14`


----

Towards #12 
