### PR TITLE
ci: support full builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -137,7 +137,10 @@ let package = Package(
 // A generated package description.
 //
 // This is just enough information to populate the `Package` data structure. It needs both the
-// package path and its
+// package path, its product [^1], and any (optional) traits that we enable for the tests in
+// `Tests/`.
+//
+// [^1]: in general, packages have many products, but our packages in `generated/*` only have one.
 struct Generated {
   public let name: String
   public let module: String
@@ -150,6 +153,7 @@ struct Generated {
   }
 }
 
+/// Finds the generated packages used for the build.
 func selectGeneratedPackages() -> [Generated] {
   let fullBuild = ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_FULL_BUILD"] == "true"
   if fullBuild {
@@ -158,6 +162,11 @@ func selectGeneratedPackages() -> [Generated] {
   return generatedPackagesStatic()
 }
 
+/// The packages required to build `Tests/`.
+///
+/// The tests, particularly the integration tests, use a relatively small set of packages. To find
+/// out how we picked which APIs and packages to use in the integration tests, see the README files
+/// for each test.
 func generatedPackagesStatic() -> [Generated] {
   return [
     .init(name: "google-cloud-location", module: "GoogleCloudLocation"),
@@ -171,6 +180,9 @@ func generatedPackagesStatic() -> [Generated] {
   ]
 }
 
+/// Finds all the packages available in the generated/ subdirectory.
+///
+/// These roughly corresponds to GAPICs, but also include type-only packages.
 func generatedPackagesFull() -> [Generated] {
   let prefix = "  name: \""
   let suffix = "\","

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Foundation
 import PackageDescription
+
+// The package file for the `google-cloud-swift` monorepo.
+//
+// This file is only used for development, each package in the `generated/*` and `packages/*`
+// subdirectories will have its own repository, this file will play no role in them.
+//
+// The file uses a helper function to create the full list of packages. The function returns a
+// different value in CI builds, so we can compile all the packages using SPM. In the development
+// environment this is too slow.
+
+let generated: [Generated] = selectGeneratedPackages()
+
+let generatedDependencies: [Package.Dependency] = generated.map {
+  let path = "./generated/\($0.name)"
+  if $0.traits.isEmpty {
+    return .package(path: path)
+  }
+  return .package(path: path, traits: $0.traits)
+}
+
+let generatedModules: [Target.Dependency] = generated.map {
+  .product(name: $0.module, package: $0.name)
+}
 
 let package = Package(
   name: "GoogleCloudSwift",
@@ -37,19 +61,10 @@ let package = Package(
     .package(path: "./packages/wkt"),
     .package(path: "./packages/storage"),
     .package(path: "./guide"),
-    .package(
-      path: "./generated/google-cloud-compute-v1",
-      traits: ["Instances", "Images", "ZoneOperations"],
-    ),
-    .package(path: "./generated/google-cloud-location"),
-    .package(path: "./generated/google-iam-v1"),
-    .package(path: "./generated/google-cloud-secretmanager-v1"),
-    .package(path: "./generated/google-cloud-security-publicca-v1"),
-    .package(path: "./generated/google-cloud-workflows-v1"),
     .package(url: "https://github.com/apple/swift-log", from: "1.12.0"),
     // Only used for development.
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-  ],
+  ] + generatedDependencies,
   targets: [
     .testTarget(
       name: "IntegrationTests",
@@ -59,7 +74,7 @@ let package = Package(
     ),
     .testTarget(
       name: "AllModules",
-      dependencies: [.product(name: "UserGuide", package: "guide")],
+      dependencies: [.product(name: "UserGuide", package: "guide")] + generatedModules,
     ),
     .testTarget(
       name: "Discovery",
@@ -118,3 +133,80 @@ let package = Package(
     ),
   ]
 )
+
+// A generated package description.
+//
+// This is just enough information to populate the `Package` data structure. It needs both the
+// package path and its
+struct Generated {
+  public let name: String
+  public let module: String
+  public var traits: Set<Package.Dependency.Trait>
+
+  init(name: String, module: String, traits: [String] = []) {
+    self.name = name
+    self.module = module
+    self.traits = Set(traits.map { .init(name: $0) })
+  }
+}
+
+func selectGeneratedPackages() -> [Generated] {
+  let fullBuild = ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_FULL_BUILD"] == "true"
+  if fullBuild {
+    return generatedPackagesFull()
+  }
+  return generatedPackagesStatic()
+}
+
+func generatedPackagesStatic() -> [Generated] {
+  return [
+    .init(name: "google-cloud-location", module: "GoogleCloudLocation"),
+    .init(name: "google-iam-v1", module: "GoogleIAMV1"),
+    .init(name: "google-cloud-secretmanager-v1", module: "GoogleCloudSecretManagerV1"),
+    .init(name: "google-cloud-security-publicca-v1", module: "GoogleCloudSecurityPublicCAV1"),
+    .init(name: "google-cloud-workflows-v1", module: "GoogleCloudWorkflowsV1"),
+    .init(
+      name: "google-cloud-compute-v1", module: "GoogleCloudComputeV1",
+      traits: ["Instances", "Images", "ZoneOperations"]),
+  ]
+}
+
+func generatedPackagesFull() -> [Generated] {
+  let prefix = "  name: \""
+  let suffix = "\","
+
+  var generated: [Generated] = generatedPackagesStatic()
+  let skipped = Set(generated.map { $0.name })
+
+  let generatedDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    .appendingPathComponent("generated")
+  let found = try? FileManager.default.contentsOfDirectory(
+    at: generatedDir, includingPropertiesForKeys: nil)
+  for name in (found ?? []) {
+    if skipped.contains(name.lastPathComponent) {
+      // The package is statically known, skip opening the directory.
+      continue
+    }
+    let packagePath = name.appendingPathComponent("Package.swift")
+    do {
+      let contents = try String(contentsOf: packagePath, encoding: .utf8)
+      let matching = contents.split(separator: "\n").first(where: {
+        $0.starts(with: prefix) && $0.hasSuffix(suffix)
+      }).map({ r in
+        var value = String(r)
+        value.removeFirst(prefix.count)
+        value.removeLast(suffix.count)
+        return value
+      })
+      if let pkg = matching {
+        generated.append(.init(name: name.lastPathComponent, module: pkg))
+      }
+    } catch {
+      // Ignore I/O errors, including missing files, in the development environment this is common,
+      // as working in multiple branches may create empty directories.
+      continue
+    }
+  }
+
+  return generated.sorted(by: { (a, b) in a.name < b.name })
+}


### PR DESCRIPTION
When the environment variable `GOOGLE_CLOUD_SWIFT_FULL_BUILD` is set to true, the top-level package discovers all the packages in `generated/*`. We can use this in CI builds to compile all the code in parallel, and to generate the documentation for any generated library.

Fixes #352 