### PR TITLE
feat(storage): implement ranged reads

### DIFF
--- a/packages/storage/Sources/GoogleCloudStorage/DownloadError.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/DownloadError.swift
@@ -19,8 +19,8 @@ public enum DownloadError: Error, Sendable, Equatable {
   /// The downloaded payload checksum did not match the expected checksum.
   case checksumMismatch(expected: String, actual: String, algorithm: String)
 
-  /// The requested byte range specification is invalid or malformed.
-  case invalidRange(String)
+  /// The range header returned by GCS is invalid or malformed.
+  case invalidRangeHeader(String)
 
   /// Transparent download auto-resumption failed after a network interruption.
   case resumeFailed(bytesReceived: UInt64, message: String)

--- a/packages/storage/Sources/GoogleCloudStorage/DownloadError.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/DownloadError.swift
@@ -19,7 +19,7 @@ public enum DownloadError: Error, Sendable, Equatable {
   /// The downloaded payload checksum did not match the expected checksum.
   case checksumMismatch(expected: String, actual: String, algorithm: String)
 
-  /// The range header returned by GCS is invalid or malformed.
+  /// The range header returned by Cloud Storage is invalid or malformed.
   case invalidRangeHeader(String)
 
   /// Transparent download auto-resumption failed after a network interruption.

--- a/packages/storage/Sources/GoogleCloudStorage/DownloadOptions.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/DownloadOptions.swift
@@ -53,6 +53,52 @@ public enum ReadObjectRange: Sendable, Hashable, Equatable {
   }
 }
 
+/// Represents a parsed HTTP `Content-Range` response header.
+struct HttpContentRange: Sendable, Hashable, Equatable {
+  let start: UInt64
+  let end: UInt64
+  let totalSize: UInt64?
+
+  init(start: UInt64, end: UInt64, totalSize: UInt64? = nil) {
+    self.start = start
+    self.end = end
+    self.totalSize = totalSize
+  }
+
+  /// Parses an HTTP `Content-Range` header value (e.g., `"bytes 0-499/1000"`).
+  static func parse(_ header: String) throws -> HttpContentRange {
+    let trimmed = header.trimmingCharacters(in: .whitespaces)
+    guard trimmed.hasPrefix("bytes ") else {
+      throw DownloadError.invalidRangeHeader(header)
+    }
+    let spec = trimmed.dropFirst("bytes ".count).trimmingCharacters(in: .whitespaces)
+    let parts = spec.split(separator: "/")
+    guard parts.count == 2 else {
+      throw DownloadError.invalidRangeHeader(header)
+    }
+    let rangeParts = parts[0].split(separator: "-")
+    guard rangeParts.count == 2,
+      let start = UInt64(rangeParts[0]),
+      let end = UInt64(rangeParts[1])
+    else {
+      throw DownloadError.invalidRangeHeader(header)
+    }
+    guard start <= end else {
+      throw DownloadError.invalidRangeHeader(header)
+    }
+    let totalSizeStr = parts[1]
+    let totalSize: UInt64?
+    if totalSizeStr == "*" {
+      totalSize = nil
+    } else if let total = UInt64(totalSizeStr) {
+      totalSize = total
+    } else {
+      throw DownloadError.invalidRangeHeader(header)
+    }
+    return HttpContentRange(start: start, end: end, totalSize: totalSize)
+  }
+}
+
 /// Configuration options for object download (`readObject`) requests.
 public struct ReadObjectOptions: Sendable {
   /// Object generation (`UInt64?`) to read a specific revision of an object.
@@ -99,13 +145,13 @@ public struct ReadObjectMetadata: Sendable, Hashable, Equatable {
   public var object: String = ""
 
   /// Content size of the object payload in bytes.
-  public var size: Int64 = 0
+  public var size: UInt64 = 0
 
   /// Generation revision number of the object.
-  public var generation: Int64 = 0
+  public var generation: UInt64 = 0
 
   /// Metageneration revision number of the object metadata.
-  public var metageneration: Int64?
+  public var metageneration: UInt64?
 
   /// HTTP ETag representing the object's entity state.
   public var etag: String?

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Download.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Download.swift
@@ -52,7 +52,11 @@ extension StorageClient {
       from: response, bucket: bucket, object: object)
 
     let stream = AsyncThrowingStream<Data, Error> { continuation in
-      if !data.isEmpty {
+      if case .prefix(0) = options.range {
+        // Requested 0 bytes
+      } else if case .suffix(0) = options.range {
+        // Requested 0 bytes
+      } else if !data.isEmpty {
         continuation.yield(data)
       }
       continuation.finish()

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Download.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Download.swift
@@ -31,6 +31,21 @@ extension StorageClient {
     object: String,
     options: ReadObjectOptions = .init()
   ) async throws -> ReadObjectResult {
+    // TODO(#219): validate range upon construction
+    if case .bounded(let start, let end) = options.range {
+      guard start <= end else {
+        throw DownloadError.invalidRangeHeader("Range start (\(start)) must be <= end (\(end)).")
+      }
+    }
+
+    // short-circuit if no data is needed
+    if case .prefix(0) = options.range {
+      return emptyReadResult(bucket: bucket, object: object, options: options)
+    }
+    if case .suffix(0) = options.range {
+      return emptyReadResult(bucket: bucket, object: object, options: options)
+    }
+
     let request = try await inner.buildReadObjectRequest(
       bucket: bucket, object: object, options: options)
     let (data, response) = try await inner.data(for: request)
@@ -41,7 +56,7 @@ extension StorageClient {
         statusCode: response.statusCode, message: message)
     }
 
-    let metadata = Self.parseReadObjectMetadata(
+    let metadata = try Self.parseReadObjectMetadata(
       from: response, bucket: bucket, object: object)
 
     let stream = AsyncThrowingStream<Data, Error> { continuation in
@@ -63,30 +78,60 @@ extension StorageClient {
     }
   }
 
+  fileprivate func emptyReadResult(
+    bucket: String,
+    object: String,
+    options: ReadObjectOptions
+  ) -> ReadObjectResult {
+    let metadata = ReadObjectMetadata().with {
+      $0.bucket = bucket
+      $0.object = object
+      $0.size = 0
+    }
+    let stream = AsyncThrowingStream<Data, Error> { continuation in
+      continuation.finish()
+    }
+    let sequence = ReadObjectSequence().with {
+      $0.bucket = bucket
+      $0.object = object
+      $0.options = options
+      $0.stream = stream
+    }
+    return ReadObjectResult().with {
+      $0.metadata = metadata
+      $0.body = sequence
+    }
+  }
+
   fileprivate static func parseReadObjectMetadata(
     from response: HTTPURLResponse,
     bucket: String,
     object: String
-  ) -> ReadObjectMetadata {
+  ) throws -> ReadObjectMetadata {
     var metadata = ReadObjectMetadata()
     metadata.bucket = bucket
     metadata.object = object
 
-    if let sizeStr = response.value(forHTTPHeaderField: "x-goog-stored-content-length")
+    if let contentRangeHeader = response.value(forHTTPHeaderField: "Content-Range") {
+      let contentRange = try HttpContentRange.parse(contentRangeHeader)
+      if let total = contentRange.totalSize {
+        metadata.size = total
+      }
+    } else if let sizeStr = response.value(forHTTPHeaderField: "x-goog-stored-content-length")
       ?? response.value(forHTTPHeaderField: "Content-Length"),
-      let size = Int64(sizeStr)
+      let size = UInt64(sizeStr)
     {
       metadata.size = size
     }
 
     if let genStr = response.value(forHTTPHeaderField: "x-goog-generation"),
-      let gen = Int64(genStr)
+      let gen = UInt64(genStr)
     {
       metadata.generation = gen
     }
 
     if let metaGenStr = response.value(forHTTPHeaderField: "x-goog-metageneration"),
-      let metaGen = Int64(metaGenStr)
+      let metaGen = UInt64(metaGenStr)
     {
       metadata.metageneration = metaGen
     }
@@ -176,6 +221,10 @@ extension HTTPClient {
     var request = try await self.Request(
       percentEncodedPath: "/storage/v1/b/\(encodedBucket)/o/\(encodedObject)", query: queryItems)
     request.httpMethod = "GET"
+
+    if let rangeHeader = options.range.headerValue {
+      request.setValue(rangeHeader, forHTTPHeaderField: "Range")
+    }
 
     request.applyCustomerSuppliedEncryptionHeaders(options.customerEncryptionKey)
 

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Download.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Download.swift
@@ -38,14 +38,6 @@ extension StorageClient {
       }
     }
 
-    // short-circuit if no data is needed
-    if case .prefix(0) = options.range {
-      return emptyReadResult(bucket: bucket, object: object, options: options)
-    }
-    if case .suffix(0) = options.range {
-      return emptyReadResult(bucket: bucket, object: object, options: options)
-    }
-
     let request = try await inner.buildReadObjectRequest(
       bucket: bucket, object: object, options: options)
     let (data, response) = try await inner.data(for: request)
@@ -66,31 +58,6 @@ extension StorageClient {
       continuation.finish()
     }
 
-    let sequence = ReadObjectSequence().with {
-      $0.bucket = bucket
-      $0.object = object
-      $0.options = options
-      $0.stream = stream
-    }
-    return ReadObjectResult().with {
-      $0.metadata = metadata
-      $0.body = sequence
-    }
-  }
-
-  fileprivate func emptyReadResult(
-    bucket: String,
-    object: String,
-    options: ReadObjectOptions
-  ) -> ReadObjectResult {
-    let metadata = ReadObjectMetadata().with {
-      $0.bucket = bucket
-      $0.object = object
-      $0.size = 0
-    }
-    let stream = AsyncThrowingStream<Data, Error> { continuation in
-      continuation.finish()
-    }
     let sequence = ReadObjectSequence().with {
       $0.bucket = bucket
       $0.object = object

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -310,7 +310,7 @@ extension StorageClient {
     } else if uploadResponse.statusCode == 308 {
       let nextOffset: Int64
       if let rangeHeader = uploadResponse.value(forHTTPHeaderField: "Range") {
-        nextOffset = try httpClient.parseNextRangeStart(rangeHeader)
+        nextOffset = Int64(try HttpRange.parseNextRangeStart(rangeHeader))
       } else {
         nextOffset = Int64(committedBytes) + Int64(chunk.count)
       }
@@ -793,7 +793,7 @@ extension HTTPClient {
   {
     var nextOffset: Int64 = 0
     if let rangeHeader = response.value(forHTTPHeaderField: "Range") {
-      nextOffset = try parseNextRangeStart(rangeHeader)
+      nextOffset = Int64(try HttpRange.parseNextRangeStart(rangeHeader))
     }
 
     var crc32cSeed: UInt32? = nil
@@ -816,41 +816,6 @@ extension HTTPClient {
       }
     }
     return nil
-  }
-
-  internal func parseNextRangeStart(_ rangeHeader: String) throws -> Int64 {
-    let range = try parseRangeHeader(rangeHeader)
-    guard let end = range.end else {
-      throw UploadError.invalidRangeHeader(rangeHeader)
-    }
-    return end + 1
-  }
-
-  internal func parseRangeHeader(_ rangeHeader: String) throws -> (start: Int64?, end: Int64?) {
-    guard rangeHeader.hasPrefix("bytes=") else {
-      throw UploadError.invalidRangeHeader(rangeHeader)
-    }
-    let rangeStr = rangeHeader.dropFirst(6)
-    let parts = rangeStr.split(separator: "-", omittingEmptySubsequences: false)
-    guard parts.count == 2 else {
-      throw UploadError.invalidRangeHeader(rangeHeader)
-    }
-
-    let startStr = parts[0]
-    let endStr = parts[1]
-
-    let start = startStr.isEmpty ? nil : Int64(startStr)
-    let end = endStr.isEmpty ? nil : Int64(endStr)
-
-    if start == nil && end == nil {
-      throw UploadError.invalidRangeHeader(rangeHeader)
-    }
-
-    if let s = start, let e = end, s > e {
-      throw UploadError.invalidRangeHeader(rangeHeader)
-    }
-
-    return (start, end)
   }
 
   fileprivate func handleObjectResponse(data: Data, response: HTTPURLResponse) throws

--- a/packages/storage/Sources/GoogleCloudStorage/UploadOptions.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/UploadOptions.swift
@@ -576,3 +576,60 @@ extension CustomerEncryption {
     }
   }
 }
+
+/// Represents a parsed HTTP `Range` header (e.g. `bytes=0-1999`).
+struct HttpRange: Sendable, Hashable, Equatable {
+  let start: UInt64?
+  let end: UInt64?
+
+  init(start: UInt64? = nil, end: UInt64? = nil) {
+    self.start = start
+    self.end = end
+  }
+
+  /// Parses an HTTP `Range` header and returns the next byte offset (`end + 1`).
+  static func parseNextRangeStart(_ header: String) throws -> UInt64 {
+    let range = try parse(header)
+    guard let end = range.end else {
+      throw UploadError.invalidRangeHeader(header)
+    }
+    return end + 1
+  }
+
+  /// Parses an HTTP `Range` header value (e.g., `"bytes=0-1999"`).
+  static func parse(_ header: String) throws -> HttpRange {
+    let trimmed = header.trimmingCharacters(in: .whitespaces)
+    guard trimmed.hasPrefix("bytes=") else {
+      throw UploadError.invalidRangeHeader(header)
+    }
+    let rangeStr = trimmed.dropFirst("bytes=".count).trimmingCharacters(in: .whitespaces)
+    let parts = rangeStr.split(separator: "-", omittingEmptySubsequences: false)
+    guard parts.count == 2 else {
+      throw UploadError.invalidRangeHeader(header)
+    }
+
+    let startStr = parts[0]
+    let endStr = parts[1]
+
+    let start = startStr.isEmpty ? nil : UInt64(startStr)
+    let end = endStr.isEmpty ? nil : UInt64(endStr)
+
+    if startStr.isEmpty && endStr.isEmpty {
+      throw UploadError.invalidRangeHeader(header)
+    }
+    if !startStr.isEmpty && start == nil {
+      throw UploadError.invalidRangeHeader(header)
+    }
+    if !endStr.isEmpty && end == nil {
+      throw UploadError.invalidRangeHeader(header)
+    }
+    if start == nil && end == nil {
+      throw UploadError.invalidRangeHeader(header)
+    }
+    if let s = start, let e = end, s > e {
+      throw UploadError.invalidRangeHeader(header)
+    }
+
+    return HttpRange(start: start, end: end)
+  }
+}

--- a/packages/storage/Tests/DownloadOptionsTests.swift
+++ b/packages/storage/Tests/DownloadOptionsTests.swift
@@ -123,7 +123,7 @@ import Testing
   @Test func downloadErrorEquality() {
     let err1 = DownloadError.checksumMismatch(expected: "a", actual: "b", algorithm: "crc32c")
     let err2 = DownloadError.checksumMismatch(expected: "a", actual: "b", algorithm: "crc32c")
-    let err3 = DownloadError.invalidRange("bytes=1-0")
+    let err3 = DownloadError.invalidRangeHeader("bytes=1-0")
 
     #expect(err1 == err2)
     #expect(err1 != err3)

--- a/packages/storage/Tests/DownloadTests.swift
+++ b/packages/storage/Tests/DownloadTests.swift
@@ -399,15 +399,35 @@ import Testing
 
   @Test func rangedDownloadZeroCountRanges() async throws {
     let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test.txt"
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+
+    registry.register(
+      response: .success(
+        statusCode: 206,
+        data: Data([0x42]),
+        headers: [
+          "Content-Range": "bytes 0-0/50",
+          "x-goog-generation": "123",
+        ]
+      ),
+      for: downloadUrl
+    )
+
     let client = try makeClient(endpoint: registry.endpoint)
 
     // Prefix 0
     let prefixResult = try await client.readObject(
-      from: "test-bucket",
-      object: "test.txt",
+      from: bucket,
+      object: objectName,
       options: ReadObjectOptions().with { $0.range = .prefix(0) }
     )
-    #expect(prefixResult.metadata.size == 0)
+    #expect(prefixResult.metadata.size == 50)
+    #expect(prefixResult.metadata.generation == 123)
+    #expect(
+      registry.lastRequest(for: downloadUrl)?.value(forHTTPHeaderField: "Range") == "bytes=0-0")
+
     var prefixData = Data()
     for try await chunk in prefixResult.body {
       prefixData.append(chunk)
@@ -416,15 +436,38 @@ import Testing
 
     // Suffix 0
     let suffixResult = try await client.readObject(
-      from: "test-bucket",
-      object: "test.txt",
+      from: bucket,
+      object: objectName,
       options: ReadObjectOptions().with { $0.range = .suffix(0) }
     )
-    #expect(suffixResult.metadata.size == 0)
+    #expect(suffixResult.metadata.size == 50)
+    #expect(suffixResult.metadata.generation == 123)
+    #expect(
+      registry.lastRequest(for: downloadUrl)?.value(forHTTPHeaderField: "Range") == "bytes=-0")
+
     var suffixData = Data()
     for try await chunk in suffixResult.body {
       suffixData.append(chunk)
     }
     #expect(suffixData.isEmpty)
+
+    // 0-byte read on non-existent object throws 404
+    let notFoundUrl = registry.url("/storage/v1/b/\(bucket)/o/nonexistent.txt?alt=media")
+    registry.register(
+      response: .success(statusCode: 404, data: Data("Not Found".utf8), headers: nil),
+      for: notFoundUrl
+    )
+    do {
+      _ = try await client.readObject(
+        from: bucket,
+        object: "nonexistent.txt",
+        options: ReadObjectOptions().with { $0.range = .prefix(0) }
+      )
+      Issue.record("Expected unexpectedServerResponse error to be thrown for 404")
+    } catch DownloadError.unexpectedServerResponse(let statusCode, _) {
+      #expect(statusCode == 404)
+    } catch {
+      Issue.record("Expected unexpectedServerResponse, got \(error)")
+    }
   }
 }

--- a/packages/storage/Tests/DownloadTests.swift
+++ b/packages/storage/Tests/DownloadTests.swift
@@ -72,7 +72,7 @@ import Testing
 
     #expect(result.metadata.bucket == bucket)
     #expect(result.metadata.object == objectName)
-    #expect(result.metadata.size == Int64(payload.count))
+    #expect(result.metadata.size == UInt64(payload.count))
     #expect(result.metadata.generation == 17123456789)
     #expect(result.metadata.metageneration == 3)
     #expect(result.metadata.etag == "\"CPv1234\"")
@@ -191,5 +191,240 @@ import Testing
     } else {
       Issue.record("Expected unexpectedServerResponse error")
     }
+  }
+
+  @Test func downloadObjectWithRangeFromOffset() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "range-offset.txt"
+    let fullPayload = Data((0..<50).map { UInt8($0) })
+    let rangePayload = fullPayload.subdata(in: 10..<50)
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+
+    registry.register(
+      response: .success(
+        statusCode: 206,
+        data: rangePayload,
+        headers: [
+          "Content-Range": "bytes 10-49/50",
+          "Content-Length": String(rangePayload.count),
+          "x-goog-generation": "123",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(endpoint: registry.endpoint)
+    let options = ReadObjectOptions().with {
+      $0.range = .fromOffset(10)
+    }
+
+    let result = try await client.readObject(from: bucket, object: objectName, options: options)
+    #expect(result.metadata.size == 50)
+    #expect(result.metadata.generation == 123)
+
+    let lastReq = registry.lastRequest(for: downloadUrl)
+    #expect(lastReq?.value(forHTTPHeaderField: "Range") == "bytes=10-")
+
+    var downloaded = Data()
+    for try await chunk in result.body {
+      downloaded.append(chunk)
+    }
+    #expect(downloaded == rangePayload)
+  }
+
+  @Test func downloadObjectWithRangePrefix() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "range-prefix.txt"
+    let fullPayload = Data((0..<50).map { UInt8($0) })
+    let rangePayload = fullPayload.subdata(in: 0..<20)
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+
+    registry.register(
+      response: .success(
+        statusCode: 206,
+        data: rangePayload,
+        headers: [
+          "Content-Range": "bytes 0-19/50",
+          "Content-Length": String(rangePayload.count),
+          "x-goog-generation": "124",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(endpoint: registry.endpoint)
+    let options = ReadObjectOptions().with {
+      $0.range = .prefix(20)
+    }
+
+    let result = try await client.readObject(from: bucket, object: objectName, options: options)
+    #expect(result.metadata.size == 50)
+
+    let lastReq = registry.lastRequest(for: downloadUrl)
+    #expect(lastReq?.value(forHTTPHeaderField: "Range") == "bytes=0-19")
+
+    var downloaded = Data()
+    for try await chunk in result.body {
+      downloaded.append(chunk)
+    }
+    #expect(downloaded == rangePayload)
+  }
+
+  @Test func downloadObjectWithRangeSuffix() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "range-suffix.txt"
+    let fullPayload = Data((0..<50).map { UInt8($0) })
+    let rangePayload = fullPayload.subdata(in: 35..<50)
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+
+    registry.register(
+      response: .success(
+        statusCode: 206,
+        data: rangePayload,
+        headers: [
+          "Content-Range": "bytes 35-49/50",
+          "Content-Length": String(rangePayload.count),
+          "x-goog-generation": "125",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(endpoint: registry.endpoint)
+    let options = ReadObjectOptions().with {
+      $0.range = .suffix(15)
+    }
+
+    let result = try await client.readObject(from: bucket, object: objectName, options: options)
+    #expect(result.metadata.size == 50)
+
+    let lastReq = registry.lastRequest(for: downloadUrl)
+    #expect(lastReq?.value(forHTTPHeaderField: "Range") == "bytes=-15")
+
+    var downloaded = Data()
+    for try await chunk in result.body {
+      downloaded.append(chunk)
+    }
+    #expect(downloaded == rangePayload)
+  }
+
+  @Test func downloadObjectWithRangeBounded() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "range-bounded.txt"
+    let fullPayload = Data((0..<50).map { UInt8($0) })
+    let rangePayload = fullPayload.subdata(in: 10..<30)
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+
+    registry.register(
+      response: .success(
+        statusCode: 206,
+        data: rangePayload,
+        headers: [
+          "Content-Range": "bytes 10-29/50",
+          "Content-Length": String(rangePayload.count),
+          "x-goog-generation": "126",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(endpoint: registry.endpoint)
+    let options = ReadObjectOptions().with {
+      $0.range = .bounded(start: 10, end: 29)
+    }
+
+    let result = try await client.readObject(from: bucket, object: objectName, options: options)
+    #expect(result.metadata.size == 50)
+
+    let lastReq = registry.lastRequest(for: downloadUrl)
+    #expect(lastReq?.value(forHTTPHeaderField: "Range") == "bytes=10-29")
+
+    var downloaded = Data()
+    for try await chunk in result.body {
+      downloaded.append(chunk)
+    }
+    #expect(downloaded == rangePayload)
+  }
+
+  @Test func downloadObjectWithClosedRange() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "range-closed.txt"
+    let payload = Data("0123456789".utf8)
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    let client = try makeClient(endpoint: registry.endpoint)
+
+    registry.register(
+      response: .success(
+        statusCode: 206,
+        data: payload,
+        headers: ["Content-Range": "bytes 0-9/10"]
+      ),
+      for: downloadUrl
+    )
+
+    _ = try await client.readObject(
+      from: bucket, object: objectName,
+      options: ReadObjectOptions().with { $0.range = ReadObjectRange(10...29) })
+    #expect(
+      registry.lastRequest(for: downloadUrl)?.value(forHTTPHeaderField: "Range") == "bytes=10-29")
+  }
+
+  @Test func rangedDownloadInvalidRangeThrows() async throws {
+    let registry = MockRegistry.create()
+    let client = try makeClient(endpoint: registry.endpoint)
+    let options = ReadObjectOptions().with {
+      $0.range = .bounded(start: 30, end: 10)
+    }
+
+    do {
+      _ = try await client.readObject(from: "test-bucket", object: "test.txt", options: options)
+      Issue.record("Expected invalidRangeHeader error to be thrown")
+    } catch let DownloadError.invalidRangeHeader(msg) {
+      #expect(msg.contains("30"))
+      #expect(msg.contains("10"))
+    } catch {
+      Issue.record("Expected invalidRangeHeader, but got \(error)")
+    }
+  }
+
+  @Test func rangedDownloadZeroCountRanges() async throws {
+    let registry = MockRegistry.create()
+    let client = try makeClient(endpoint: registry.endpoint)
+
+    // Prefix 0
+    let prefixResult = try await client.readObject(
+      from: "test-bucket",
+      object: "test.txt",
+      options: ReadObjectOptions().with { $0.range = .prefix(0) }
+    )
+    #expect(prefixResult.metadata.size == 0)
+    var prefixData = Data()
+    for try await chunk in prefixResult.body {
+      prefixData.append(chunk)
+    }
+    #expect(prefixData.isEmpty)
+
+    // Suffix 0
+    let suffixResult = try await client.readObject(
+      from: "test-bucket",
+      object: "test.txt",
+      options: ReadObjectOptions().with { $0.range = .suffix(0) }
+    )
+    #expect(suffixResult.metadata.size == 0)
+    var suffixData = Data()
+    for try await chunk in suffixResult.body {
+      suffixData.append(chunk)
+    }
+    #expect(suffixData.isEmpty)
   }
 }

--- a/packages/storage/Tests/DownloadTests.swift
+++ b/packages/storage/Tests/DownloadTests.swift
@@ -400,9 +400,11 @@ import Testing
   @Test func rangedDownloadZeroCountRanges() async throws {
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
-    let objectName = "test.txt"
-    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    let client = try makeClient(endpoint: registry.endpoint)
 
+    // Prefix 0
+    let prefixObject = "test-prefix.txt"
+    let prefixUrl = registry.url("/storage/v1/b/\(bucket)/o/\(prefixObject)?alt=media")
     registry.register(
       response: .success(
         statusCode: 206,
@@ -412,21 +414,18 @@ import Testing
           "x-goog-generation": "123",
         ]
       ),
-      for: downloadUrl
+      for: prefixUrl
     )
 
-    let client = try makeClient(endpoint: registry.endpoint)
-
-    // Prefix 0
     let prefixResult = try await client.readObject(
       from: bucket,
-      object: objectName,
+      object: prefixObject,
       options: ReadObjectOptions().with { $0.range = .prefix(0) }
     )
     #expect(prefixResult.metadata.size == 50)
     #expect(prefixResult.metadata.generation == 123)
     #expect(
-      registry.lastRequest(for: downloadUrl)?.value(forHTTPHeaderField: "Range") == "bytes=0-0")
+      registry.lastRequest(for: prefixUrl)?.value(forHTTPHeaderField: "Range") == "bytes=0-0")
 
     var prefixData = Data()
     for try await chunk in prefixResult.body {
@@ -435,15 +434,29 @@ import Testing
     #expect(prefixData.isEmpty)
 
     // Suffix 0
+    let suffixObject = "test-suffix.txt"
+    let suffixUrl = registry.url("/storage/v1/b/\(bucket)/o/\(suffixObject)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 206,
+        data: Data([0x42]),
+        headers: [
+          "Content-Range": "bytes 0-0/50",
+          "x-goog-generation": "123",
+        ]
+      ),
+      for: suffixUrl
+    )
+
     let suffixResult = try await client.readObject(
       from: bucket,
-      object: objectName,
+      object: suffixObject,
       options: ReadObjectOptions().with { $0.range = .suffix(0) }
     )
     #expect(suffixResult.metadata.size == 50)
     #expect(suffixResult.metadata.generation == 123)
     #expect(
-      registry.lastRequest(for: downloadUrl)?.value(forHTTPHeaderField: "Range") == "bytes=-0")
+      registry.lastRequest(for: suffixUrl)?.value(forHTTPHeaderField: "Range") == "bytes=-0")
 
     var suffixData = Data()
     for try await chunk in suffixResult.body {

--- a/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -77,8 +77,8 @@ import Testing
       let result = try await storage.readObject(from: bucketName, object: objectName)
       #expect(result.metadata.bucket == bucketName)
       #expect(result.metadata.object == objectName)
-      #expect(result.metadata.size == Int64(data.count))
-      #expect(result.metadata.generation == uploadedObject.generation)
+      #expect(result.metadata.size == UInt64(data.count))
+      #expect(result.metadata.generation == UInt64(uploadedObject.generation))
 
       var downloadedData = Data()
       for try await chunk in result.body {
@@ -89,6 +89,58 @@ import Testing
       #expect(downloadedString == content)
 
       print("File download integration test successful: \(result.metadata)")
+    }
+
+    @Test(arguments: [
+      (ReadObjectRange.bounded(start: 10, end: 19), "abcdefghij"),
+      (ReadObjectRange.fromOffset(36), "ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+      (ReadObjectRange.prefix(10), "0123456789"),
+      (ReadObjectRange.suffix(10), "QRSTUVWXYZ"),
+      (ReadObjectRange(5...15), "56789abcdef"),
+      (ReadObjectRange.prefix(0), ""),
+      (ReadObjectRange.suffix(0), ""),
+      (ReadObjectRange.entire, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+    ])
+    func testRangedDownload(range: ReadObjectRange, expectedContent: String) async throws {
+      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
+        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
+        return
+      }
+      let bucketName =
+        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
+      let objectName = "test-ranged-download-\(UUID().uuidString).txt"
+      let content = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      let data = Data(content.utf8)
+      let totalSize = UInt64(data.count)
+
+      let storage = try StorageClient()
+
+      let uploadTask = storage.upload(data, to: bucketName, as: objectName)
+      let uploadedObject = try await uploadTask.value
+      #expect(uploadedObject.bucket == bucketName)
+      #expect(uploadedObject.name == objectName)
+
+      let options = ReadObjectOptions().with {
+        $0.range = range
+      }
+      let result = try await storage.readObject(
+        from: bucketName, object: objectName, options: options)
+
+      if case .prefix(0) = range {
+        #expect(result.metadata.size == 0)
+      } else if case .suffix(0) = range {
+        #expect(result.metadata.size == 0)
+      } else {
+        #expect(result.metadata.size == totalSize)
+        #expect(result.metadata.generation == UInt64(uploadedObject.generation))
+      }
+
+      var downloadedData = Data()
+      for try await chunk in result.body {
+        downloadedData.append(chunk)
+      }
+      let downloadedString = String(data: downloadedData, encoding: .utf8) ?? ""
+      #expect(downloadedString == expectedContent)
     }
 
     @Test(arguments: [
@@ -122,8 +174,8 @@ import Testing
       let result = try await storage.readObject(from: bucketName, object: objectName)
       #expect(result.metadata.bucket == bucketName)
       #expect(result.metadata.object == objectName)
-      #expect(result.metadata.size == Int64(data.count))
-      #expect(result.metadata.generation == uploadedObject.generation)
+      #expect(result.metadata.size == UInt64(data.count))
+      #expect(result.metadata.generation == UInt64(uploadedObject.generation))
 
       var downloadedData = Data()
       for try await chunk in result.body {

--- a/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -97,8 +97,6 @@ import Testing
       (ReadObjectRange.prefix(10), "0123456789"),
       (ReadObjectRange.suffix(10), "QRSTUVWXYZ"),
       (ReadObjectRange(5...15), "56789abcdef"),
-      (ReadObjectRange.prefix(0), ""),
-      (ReadObjectRange.suffix(0), ""),
       (ReadObjectRange.entire, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"),
     ])
     func testRangedDownload(range: ReadObjectRange, expectedContent: String) async throws {
@@ -135,21 +133,54 @@ import Testing
       }
       let downloadedString = String(data: downloadedData, encoding: .utf8) ?? ""
       #expect(downloadedString == expectedContent)
+    }
+
+    @Test func testRangedDownloadZeroPrefix() async throws {
+      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
+        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
+        return
+      }
+      let bucketName =
+        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
+      let objectName = "test-ranged-zero-prefix-\(UUID().uuidString).txt"
+      let content = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      let data = Data(content.utf8)
+      let totalSize = UInt64(data.count)
+
+      let storage = try StorageClient()
+
+      let uploadTask = storage.upload(data, to: bucketName, as: objectName)
+      let uploadedObject = try await uploadTask.value
+      #expect(uploadedObject.bucket == bucketName)
+      #expect(uploadedObject.name == objectName)
+
+      let options = ReadObjectOptions().with {
+        $0.range = .prefix(0)
+      }
+      let result = try await storage.readObject(
+        from: bucketName, object: objectName, options: options)
+
+      #expect(result.metadata.size == totalSize)
+      #expect(result.metadata.generation == UInt64(uploadedObject.generation))
+
+      var downloadedData = Data()
+      for try await chunk in result.body {
+        downloadedData.append(chunk)
+      }
+      #expect(downloadedData.isEmpty)
 
       // Verify reading 0 bytes on a non-existent object still executes the request and throws 404
-      if case .prefix(0) = range {
-        do {
-          _ = try await storage.readObject(
-            from: bucketName,
-            object: "non-existent-\(UUID().uuidString).txt",
-            options: options
-          )
-          Issue.record("Expected reading non-existent object to throw 404")
-        } catch DownloadError.unexpectedServerResponse(let statusCode, _) {
-          #expect(statusCode == 404)
-        } catch {
-          Issue.record("Expected DownloadError.unexpectedServerResponse, got \(error)")
-        }
+      do {
+        _ = try await storage.readObject(
+          from: bucketName,
+          object: "non-existent-\(UUID().uuidString).txt",
+          options: options
+        )
+        Issue.record("Expected reading non-existent object to throw 404")
+      } catch DownloadError.unexpectedServerResponse(let statusCode, _) {
+        #expect(statusCode == 404)
+      } catch {
+        Issue.record("Expected DownloadError.unexpectedServerResponse, got \(error)")
       }
     }
 

--- a/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -126,14 +126,8 @@ import Testing
       let result = try await storage.readObject(
         from: bucketName, object: objectName, options: options)
 
-      if case .prefix(0) = range {
-        #expect(result.metadata.size == 0)
-      } else if case .suffix(0) = range {
-        #expect(result.metadata.size == 0)
-      } else {
-        #expect(result.metadata.size == totalSize)
-        #expect(result.metadata.generation == UInt64(uploadedObject.generation))
-      }
+      #expect(result.metadata.size == totalSize)
+      #expect(result.metadata.generation == UInt64(uploadedObject.generation))
 
       var downloadedData = Data()
       for try await chunk in result.body {
@@ -141,6 +135,22 @@ import Testing
       }
       let downloadedString = String(data: downloadedData, encoding: .utf8) ?? ""
       #expect(downloadedString == expectedContent)
+
+      // Verify reading 0 bytes on a non-existent object still executes the request and throws 404
+      if case .prefix(0) = range {
+        do {
+          _ = try await storage.readObject(
+            from: bucketName,
+            object: "non-existent-\(UUID().uuidString).txt",
+            options: options
+          )
+          Issue.record("Expected reading non-existent object to throw 404")
+        } catch DownloadError.unexpectedServerResponse(let statusCode, _) {
+          #expect(statusCode == 404)
+        } catch {
+          Issue.record("Expected DownloadError.unexpectedServerResponse, got \(error)")
+        }
+      }
     }
 
     @Test(arguments: [

--- a/packages/storage/Tests/RangeHeaderTests.swift
+++ b/packages/storage/Tests/RangeHeaderTests.swift
@@ -18,58 +18,66 @@ import GoogleCloudGax
 import Testing
 
 @Suite struct RangeHeaderTests {
-  @Test func parseRangeHeader() throws {
-    let httpClient = try GoogleCloudGax.HTTPClient(
-      from: .init(), withDefaultEndpoint: "https://example.com")
+  @Test(arguments: [
+    ("bytes=0-1999", HttpRange(start: 0, end: 1999)),
+    ("bytes=2000-", HttpRange(start: 2000, end: nil)),
+    ("bytes=-2000", HttpRange(start: nil, end: 2000)),
+  ])
+  func parseRangeHeader(header: String, expected: HttpRange) throws {
+    let parsed = try HttpRange.parse(header)
+    #expect(parsed == expected)
+  }
 
-    // Valid full range
-    let range1 = try httpClient.parseRangeHeader("bytes=0-1999")
-    #expect(range1.start == 0)
-    #expect(range1.end == 1999)
-
-    // Valid start only
-    let range2 = try httpClient.parseRangeHeader("bytes=2000-")
-    #expect(range2.start == 2000)
-    #expect(range2.end == nil)
-
-    // Valid end only
-    let range3 = try httpClient.parseRangeHeader("bytes=-2000")
-    #expect(range3.start == nil)
-    #expect(range3.end == 2000)
-
-    // Invalid prefix
+  @Test(arguments: [
+    "foo=0-1999",
+    "bytes=abc-def",
+    "bytes=-",
+    "bytes=2000-1000",
+  ])
+  func parseRangeHeaderInvalid(header: String) {
     #expect(throws: UploadError.self) {
-      _ = try httpClient.parseRangeHeader("foo=0-1999")
-    }
-
-    // Invalid format
-    #expect(throws: UploadError.self) {
-      _ = try httpClient.parseRangeHeader("bytes=abc-def")
-    }
-
-    #expect(throws: UploadError.self) {
-      _ = try httpClient.parseRangeHeader("bytes=-")
-    }
-
-    #expect(throws: UploadError.self) {
-      _ = try httpClient.parseRangeHeader("bytes=2000-1000")
+      _ = try HttpRange.parse(header)
     }
   }
 
-  @Test func parseNextRangeStart() throws {
-    let httpClient = try GoogleCloudGax.HTTPClient(
-      from: .init(), withDefaultEndpoint: "https://example.com")
+  @Test(arguments: [
+    ("bytes=0-1999", UInt64(2000)),
+    ("bytes=-2000", UInt64(2001)),
+  ])
+  func parseNextRangeStart(header: String, expectedNextStart: UInt64) throws {
+    let nextStart = try HttpRange.parseNextRangeStart(header)
+    #expect(nextStart == expectedNextStart)
+  }
 
-    #expect(try httpClient.parseNextRangeStart("bytes=0-1999") == 2000)
-
+  @Test(arguments: [
+    "bytes=2000-",
+    "bytes=abc-def",
+  ])
+  func parseNextRangeStartInvalid(header: String) {
     #expect(throws: UploadError.self) {
-      _ = try httpClient.parseNextRangeStart("bytes=2000-")
+      _ = try HttpRange.parseNextRangeStart(header)
     }
+  }
 
-    #expect(try httpClient.parseNextRangeStart("bytes=-2000") == 2001)
+  @Test(arguments: [
+    ("bytes 0-1999/5000", HttpContentRange(start: 0, end: 1999, totalSize: 5000)),
+    ("bytes 100-200/*", HttpContentRange(start: 100, end: 200, totalSize: nil)),
+  ])
+  func parseContentRangeHeader(header: String, expected: HttpContentRange) throws {
+    let parsed = try HttpContentRange.parse(header)
+    #expect(parsed == expected)
+  }
 
-    #expect(throws: UploadError.self) {
-      _ = try httpClient.parseNextRangeStart("bytes=abc-def")
+  @Test(arguments: [
+    "bytes */5000",
+    "invalid",
+    "bytes 200-100/5000",
+    "bytes 0-1999/abc",
+    "foo 0-1999/5000",
+  ])
+  func parseContentRangeHeaderInvalid(header: String) {
+    #expect(throws: DownloadError.self) {
+      _ = try HttpContentRange.parse(header)
     }
   }
 }


### PR DESCRIPTION
Fixes #354

Note: we are making the `Range` header (used in uploads) parsing code mirror the `Content-Range` header (used in downloads) parsing code.