### PR TITLE
test(storage): use shared test fixture for integration tests

### DIFF
--- a/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -18,7 +18,8 @@ import Testing
 
 #if IntegrationTests
 
-  @Suite(.enabled(if: ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil))
+  @Suite(.enabled(if: ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil &&
+  ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] != nil` ?))
   struct StorageClientIntegrationTests {
     @Test func testFileUpload() async throws {
       let bucketName =

--- a/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -18,12 +18,9 @@ import Testing
 
 #if IntegrationTests
 
-  @Suite struct StorageClientIntegrationTests {
+  @Suite(.enabled(if: ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil))
+  struct StorageClientIntegrationTests {
     @Test func testFileUpload() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-upload-\(UUID().uuidString).txt"
@@ -57,10 +54,6 @@ import Testing
     }
 
     @Test func testFileDownload() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-download-\(UUID().uuidString).txt"
@@ -100,10 +93,6 @@ import Testing
       (ReadObjectRange.entire, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"),
     ])
     func testRangedDownload(range: ReadObjectRange, expectedContent: String) async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-ranged-download-\(UUID().uuidString).txt"
@@ -136,10 +125,6 @@ import Testing
     }
 
     @Test func testRangedDownloadZeroPrefix() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-ranged-zero-prefix-\(UUID().uuidString).txt"
@@ -193,10 +178,6 @@ import Testing
       "folder/subfolder/file with & and ? and #.json",
     ])
     func testUploadAndDownloadSpecialCharacters(pathSuffix: String) async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let uniqueId = UUID().uuidString
@@ -228,10 +209,6 @@ import Testing
     }
 
     @Test func testLargeFileUpload() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-large-upload-\(UUID().uuidString).bin"
@@ -271,10 +248,6 @@ import Testing
     }
 
     @Test func testFailedResumableUploadAndResume() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-failed-resumable-\(UUID().uuidString).bin"
@@ -357,10 +330,6 @@ import Testing
     }
 
     @Test func testResumedFailedUploadWithChecksumValidation() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-resumed-checksum-\(UUID().uuidString).bin"
@@ -422,10 +391,6 @@ import Testing
     }
 
     @Test func testResumedFailedUploadWithNewSourceInstance() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-resumed-new-source-\(UUID().uuidString).bin"
@@ -484,10 +449,6 @@ import Testing
     }
 
     @Test func testSimpleUploadWithChecksumValidation() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
 
@@ -515,10 +476,6 @@ import Testing
     }
 
     @Test func testResumableUploadWithChecksumValidation() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
 
@@ -550,10 +507,6 @@ import Testing
     }
 
     @Test func testMultipleChecksumsUpload() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-multiple-checksums-\(UUID().uuidString).txt"
@@ -580,10 +533,6 @@ import Testing
     }
 
     @Test func testBadChecksumUploadRejection() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-bad-checksum-\(UUID().uuidString).bin"
@@ -616,10 +565,6 @@ import Testing
     }
 
     @Test func testCSEKSimpleUpload() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-csek-simple-\(UUID().uuidString).txt"
@@ -650,10 +595,6 @@ import Testing
     }
 
     @Test func testCSEKResumableUpload() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-csek-resumable-\(UUID().uuidString).bin"
@@ -685,10 +626,6 @@ import Testing
     }
 
     @Test func testUploadWithMetadata() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-metadata-\(UUID().uuidString).txt"
@@ -726,10 +663,6 @@ import Testing
     }
 
     @Test func testUploadWithObjectContexts() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-contexts-\(UUID().uuidString).txt"
@@ -762,10 +695,6 @@ import Testing
     }
 
     @Test func testDynamicSourceCompletelyEmptyUpload() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-dynamic-empty-\(UUID().uuidString).bin"
@@ -785,10 +714,6 @@ import Testing
     }
 
     @Test func testDynamicSourceLastChunkEmptyUpload() async throws {
-      guard ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil else {
-        Issue.record("GOOGLE_CLOUD_PROJECT environment variable not set")
-        return
-      }
       let bucketName =
         ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-dynamic-last-chunk-empty-\(UUID().uuidString).bin"

--- a/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -711,15 +711,11 @@ import Testing
       #expect(downloadedString == expectedContent)
     }
 
-    @Test(arguments: [
-      ReadObjectRange.prefix(0),
-      ReadObjectRange.suffix(0),
-    ])
-    func testRangedDownloadZeroCount(range: ReadObjectRange) async throws {
+    @Test func testRangedDownloadZeroCount() async throws {
       let fixture = try await Self.sharedFixture.value
       let storage = try StorageClient()
       let options = ReadObjectOptions().with {
-        $0.range = range
+        $0.range = .prefix(0)
       }
       let result = try await storage.readObject(
         from: fixture.bucketName, object: fixture.objectName, options: options)

--- a/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -18,12 +18,14 @@ import Testing
 
 #if IntegrationTests
 
-  @Suite(.enabled(if: ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil &&
-  ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] != nil` ?))
+  @Suite(
+    .enabled(
+      if: ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil
+        && ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] != nil))
   struct StorageClientIntegrationTests {
+    let bucketName = ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"]!
+
     @Test func testFileUpload() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-upload-\(UUID().uuidString).txt"
 
       let content = "Hello Google Cloud Storage from Swift!"
@@ -55,8 +57,6 @@ import Testing
     }
 
     @Test func testFileDownload() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-download-\(UUID().uuidString).txt"
       let content = "Hello Google Cloud Storage file download integration test!"
       let data = Data(content.utf8)
@@ -94,8 +94,6 @@ import Testing
       "folder/subfolder/file with & and ? and #.json",
     ])
     func testUploadAndDownloadSpecialCharacters(pathSuffix: String) async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let uniqueId = UUID().uuidString
       let objectName = "test-special-\(uniqueId)/\(pathSuffix)"
       let content = "Integration test payload for special characters: \(pathSuffix)"
@@ -125,8 +123,6 @@ import Testing
     }
 
     @Test func testLargeFileUpload() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-large-upload-\(UUID().uuidString).bin"
 
       // 10MB file to trigger resumable upload (threshold is 8MB)
@@ -164,8 +160,6 @@ import Testing
     }
 
     @Test func testFailedResumableUploadAndResume() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-failed-resumable-\(UUID().uuidString).bin"
 
       let fileSize = 10 * 1024 * 1024  // 10MB
@@ -246,8 +240,6 @@ import Testing
     }
 
     @Test func testResumedFailedUploadWithChecksumValidation() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-resumed-checksum-\(UUID().uuidString).bin"
 
       let fileSize = 10 * 1024 * 1024  // 10MB payload
@@ -307,8 +299,6 @@ import Testing
     }
 
     @Test func testResumedFailedUploadWithNewSourceInstance() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-resumed-new-source-\(UUID().uuidString).bin"
 
       let fileSize = 10 * 1024 * 1024  // 10MB payload
@@ -365,9 +355,6 @@ import Testing
     }
 
     @Test func testSimpleUploadWithChecksumValidation() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
-
       let storage = try StorageClient()
 
       for validation in [ChecksumValidation.crc32c, ChecksumValidation.md5] {
@@ -392,9 +379,6 @@ import Testing
     }
 
     @Test func testResumableUploadWithChecksumValidation() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
-
       let storage = try StorageClient()
 
       for validation in [ChecksumValidation.crc32c, ChecksumValidation.md5] {
@@ -423,8 +407,6 @@ import Testing
     }
 
     @Test func testMultipleChecksumsUpload() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-multiple-checksums-\(UUID().uuidString).txt"
 
       let content = "Hello Google Cloud Storage with multiple checksums!"
@@ -449,8 +431,6 @@ import Testing
     }
 
     @Test func testBadChecksumUploadRejection() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-bad-checksum-\(UUID().uuidString).bin"
 
       // 10MB file to trigger resumable upload where x-goog-hash is validated by GCS
@@ -481,8 +461,6 @@ import Testing
     }
 
     @Test func testCSEKSimpleUpload() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-csek-simple-\(UUID().uuidString).txt"
 
       let content = "Hello Google Cloud Storage CSEK simple upload!"
@@ -511,8 +489,6 @@ import Testing
     }
 
     @Test func testCSEKResumableUpload() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-csek-resumable-\(UUID().uuidString).bin"
 
       let fileSize = 10 * 1024 * 1024  // 10MB to trigger resumable upload
@@ -542,8 +518,6 @@ import Testing
     }
 
     @Test func testUploadWithMetadata() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-metadata-\(UUID().uuidString).txt"
 
       let content = "Hello Google Cloud Storage metadata upload!"
@@ -579,8 +553,6 @@ import Testing
     }
 
     @Test func testUploadWithObjectContexts() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-contexts-\(UUID().uuidString).txt"
 
       let content = "Hello Google Cloud Storage object contexts upload!"
@@ -611,8 +583,6 @@ import Testing
     }
 
     @Test func testDynamicSourceCompletelyEmptyUpload() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-dynamic-empty-\(UUID().uuidString).bin"
 
       let source = IntegrationDynamicSource(
@@ -630,8 +600,6 @@ import Testing
     }
 
     @Test func testDynamicSourceLastChunkEmptyUpload() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let objectName = "test-dynamic-last-chunk-empty-\(UUID().uuidString).bin"
 
       let chunkSize = 5 * 1024 * 1024  // 5MB chunks
@@ -654,7 +622,10 @@ import Testing
     }
   }
 
-  @Suite(.enabled(if: ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil))
+  @Suite(
+    .enabled(
+      if: ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil
+        && ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] != nil))
   struct StorageClientRangedDownloadIntegrationTests {
     struct FixtureState: Sendable {
       let bucketName: String
@@ -663,9 +634,11 @@ import Testing
       let uploadedObject: Object
     }
 
+    let bucketName = ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"]!
+
     static let sharedFixture = Task<FixtureState, any Error> {
       let bucket =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
+        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"]!
       let objName = "test-ranged-download-\(UUID().uuidString).txt"
       let content = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
       let data = Data(content.utf8)
@@ -712,11 +685,15 @@ import Testing
       #expect(downloadedString == expectedContent)
     }
 
-    @Test func testRangedDownloadZeroCount() async throws {
+    @Test(arguments: [
+      ReadObjectRange.prefix(0),
+      ReadObjectRange.suffix(0),
+    ])
+    func testRangedDownloadZeroCount(range: ReadObjectRange) async throws {
       let fixture = try await Self.sharedFixture.value
       let storage = try StorageClient()
       let options = ReadObjectOptions().with {
-        $0.range = .prefix(0)
+        $0.range = range
       }
       let result = try await storage.readObject(
         from: fixture.bucketName, object: fixture.objectName, options: options)
@@ -741,8 +718,6 @@ import Testing
       ReadObjectRange.entire,
     ])
     func testRangedDownloadNonExistentObject(range: ReadObjectRange) async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
       let storage = try StorageClient()
       let options = ReadObjectOptions().with {
         $0.range = range

--- a/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -685,15 +685,11 @@ import Testing
       #expect(downloadedString == expectedContent)
     }
 
-    @Test(arguments: [
-      ReadObjectRange.prefix(0),
-      ReadObjectRange.suffix(0),
-    ])
-    func testRangedDownloadZeroCount(range: ReadObjectRange) async throws {
+    @Test func testRangedDownloadZeroCount() async throws {
       let fixture = try await Self.sharedFixture.value
       let storage = try StorageClient()
       let options = ReadObjectOptions().with {
-        $0.range = range
+        $0.range = .prefix(0)
       }
       let result = try await storage.readObject(
         from: fixture.bucketName, object: fixture.objectName, options: options)

--- a/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -711,11 +711,15 @@ import Testing
       #expect(downloadedString == expectedContent)
     }
 
-    @Test func testRangedDownloadZeroPrefix() async throws {
+    @Test(arguments: [
+      ReadObjectRange.prefix(0),
+      ReadObjectRange.suffix(0),
+    ])
+    func testRangedDownloadZeroCount(range: ReadObjectRange) async throws {
       let fixture = try await Self.sharedFixture.value
       let storage = try StorageClient()
       let options = ReadObjectOptions().with {
-        $0.range = .prefix(0)
+        $0.range = range
       }
       let result = try await storage.readObject(
         from: fixture.bucketName, object: fixture.objectName, options: options)
@@ -728,11 +732,27 @@ import Testing
         downloadedData.append(chunk)
       }
       #expect(downloadedData.isEmpty)
+    }
 
-      // Verify reading 0 bytes on a non-existent object still executes the request and throws 404
+    @Test(arguments: [
+      ReadObjectRange.prefix(0),
+      ReadObjectRange.suffix(0),
+      ReadObjectRange.bounded(start: 10, end: 19),
+      ReadObjectRange.fromOffset(36),
+      ReadObjectRange.prefix(10),
+      ReadObjectRange.suffix(10),
+      ReadObjectRange.entire,
+    ])
+    func testRangedDownloadNonExistentObject(range: ReadObjectRange) async throws {
+      let bucketName =
+        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
+      let storage = try StorageClient()
+      let options = ReadObjectOptions().with {
+        $0.range = range
+      }
       do {
         _ = try await storage.readObject(
-          from: fixture.bucketName,
+          from: bucketName,
           object: "non-existent-\(UUID().uuidString).txt",
           options: options
         )

--- a/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -85,91 +85,6 @@ import Testing
     }
 
     @Test(arguments: [
-      (ReadObjectRange.bounded(start: 10, end: 19), "abcdefghij"),
-      (ReadObjectRange.fromOffset(36), "ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
-      (ReadObjectRange.prefix(10), "0123456789"),
-      (ReadObjectRange.suffix(10), "QRSTUVWXYZ"),
-      (ReadObjectRange(5...15), "56789abcdef"),
-      (ReadObjectRange.entire, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"),
-    ])
-    func testRangedDownload(range: ReadObjectRange, expectedContent: String) async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
-      let objectName = "test-ranged-download-\(UUID().uuidString).txt"
-      let content = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-      let data = Data(content.utf8)
-      let totalSize = UInt64(data.count)
-
-      let storage = try StorageClient()
-
-      let uploadTask = storage.upload(data, to: bucketName, as: objectName)
-      let uploadedObject = try await uploadTask.value
-      #expect(uploadedObject.bucket == bucketName)
-      #expect(uploadedObject.name == objectName)
-
-      let options = ReadObjectOptions().with {
-        $0.range = range
-      }
-      let result = try await storage.readObject(
-        from: bucketName, object: objectName, options: options)
-
-      #expect(result.metadata.size == totalSize)
-      #expect(result.metadata.generation == UInt64(uploadedObject.generation))
-
-      var downloadedData = Data()
-      for try await chunk in result.body {
-        downloadedData.append(chunk)
-      }
-      let downloadedString = String(data: downloadedData, encoding: .utf8) ?? ""
-      #expect(downloadedString == expectedContent)
-    }
-
-    @Test func testRangedDownloadZeroPrefix() async throws {
-      let bucketName =
-        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
-      let objectName = "test-ranged-zero-prefix-\(UUID().uuidString).txt"
-      let content = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-      let data = Data(content.utf8)
-      let totalSize = UInt64(data.count)
-
-      let storage = try StorageClient()
-
-      let uploadTask = storage.upload(data, to: bucketName, as: objectName)
-      let uploadedObject = try await uploadTask.value
-      #expect(uploadedObject.bucket == bucketName)
-      #expect(uploadedObject.name == objectName)
-
-      let options = ReadObjectOptions().with {
-        $0.range = .prefix(0)
-      }
-      let result = try await storage.readObject(
-        from: bucketName, object: objectName, options: options)
-
-      #expect(result.metadata.size == totalSize)
-      #expect(result.metadata.generation == UInt64(uploadedObject.generation))
-
-      var downloadedData = Data()
-      for try await chunk in result.body {
-        downloadedData.append(chunk)
-      }
-      #expect(downloadedData.isEmpty)
-
-      // Verify reading 0 bytes on a non-existent object still executes the request and throws 404
-      do {
-        _ = try await storage.readObject(
-          from: bucketName,
-          object: "non-existent-\(UUID().uuidString).txt",
-          options: options
-        )
-        Issue.record("Expected reading non-existent object to throw 404")
-      } catch DownloadError.unexpectedServerResponse(let statusCode, _) {
-        #expect(statusCode == 404)
-      } catch {
-        Issue.record("Expected DownloadError.unexpectedServerResponse, got \(error)")
-      }
-    }
-
-    @Test(arguments: [
       "folder/subfolder/file.json",
       "file with spaces.txt",
       "file&with&ampersands.txt",
@@ -735,6 +650,98 @@ import Testing
       #expect(object.size == expectedTotalSize)
 
       print("Dynamic source with last chunk empty upload successful: \(object)")
+    }
+  }
+
+  @Suite(.enabled(if: ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil))
+  struct StorageClientRangedDownloadIntegrationTests {
+    struct FixtureState: Sendable {
+      let bucketName: String
+      let objectName: String
+      let totalSize: UInt64
+      let uploadedObject: Object
+    }
+
+    static let sharedFixture = Task<FixtureState, any Error> {
+      let bucket =
+        ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] ?? "test-bucket"
+      let objName = "test-ranged-download-\(UUID().uuidString).txt"
+      let content = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      let data = Data(content.utf8)
+
+      let storageClient = try StorageClient()
+      let uploadTask = storageClient.upload(data, to: bucket, as: objName)
+      let obj = try await uploadTask.value
+      #expect(obj.bucket == bucket)
+      #expect(obj.name == objName)
+
+      return FixtureState(
+        bucketName: bucket,
+        objectName: objName,
+        totalSize: UInt64(data.count),
+        uploadedObject: obj
+      )
+    }
+
+    @Test(arguments: [
+      (ReadObjectRange.bounded(start: 10, end: 19), "abcdefghij"),
+      (ReadObjectRange.fromOffset(36), "ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+      (ReadObjectRange.prefix(10), "0123456789"),
+      (ReadObjectRange.suffix(10), "QRSTUVWXYZ"),
+      (ReadObjectRange(5...15), "56789abcdef"),
+      (ReadObjectRange.entire, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+    ])
+    func testRangedDownload(range: ReadObjectRange, expectedContent: String) async throws {
+      let fixture = try await Self.sharedFixture.value
+      let storage = try StorageClient()
+      let options = ReadObjectOptions().with {
+        $0.range = range
+      }
+      let result = try await storage.readObject(
+        from: fixture.bucketName, object: fixture.objectName, options: options)
+
+      #expect(result.metadata.size == fixture.totalSize)
+      #expect(result.metadata.generation == UInt64(fixture.uploadedObject.generation))
+
+      var downloadedData = Data()
+      for try await chunk in result.body {
+        downloadedData.append(chunk)
+      }
+      let downloadedString = String(data: downloadedData, encoding: .utf8) ?? ""
+      #expect(downloadedString == expectedContent)
+    }
+
+    @Test func testRangedDownloadZeroPrefix() async throws {
+      let fixture = try await Self.sharedFixture.value
+      let storage = try StorageClient()
+      let options = ReadObjectOptions().with {
+        $0.range = .prefix(0)
+      }
+      let result = try await storage.readObject(
+        from: fixture.bucketName, object: fixture.objectName, options: options)
+
+      #expect(result.metadata.size == fixture.totalSize)
+      #expect(result.metadata.generation == UInt64(fixture.uploadedObject.generation))
+
+      var downloadedData = Data()
+      for try await chunk in result.body {
+        downloadedData.append(chunk)
+      }
+      #expect(downloadedData.isEmpty)
+
+      // Verify reading 0 bytes on a non-existent object still executes the request and throws 404
+      do {
+        _ = try await storage.readObject(
+          from: fixture.bucketName,
+          object: "non-existent-\(UUID().uuidString).txt",
+          options: options
+        )
+        Issue.record("Expected reading non-existent object to throw 404")
+      } catch DownloadError.unexpectedServerResponse(let statusCode, _) {
+        #expect(statusCode == 404)
+      } catch {
+        Issue.record("Expected DownloadError.unexpectedServerResponse, got \(error)")
+      }
     }
   }
 


### PR DESCRIPTION
Some ranged read tests need to create a file to read. We test several ranges over the same data so we shouldn't need write the same file multiple times.

This uses a shared class-level setup for creating the fixture once. We use `Task` because we cannot run async create options as a class-level variable.