### PR TITLE
feat(auth): support API key credentials

### DIFF
--- a/packages/auth/Sources/GoogleCloudAuth/Credentials.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/Credentials.swift
@@ -140,6 +140,15 @@ public enum CredentialsConfiguration: Sendable {
 
   /// Programmatic credentials configuration for Workforce Identity Federation (OIDC / Apple WIF).
   case programmaticExternalAccount(ExternalAccountConfig)
+
+  /// An API key credential that associates requests with a Google Cloud project.
+  ///
+  /// Note that only some Cloud APIs support API keys. Consult the documentation for the API you intend to use
+  /// before trying to use API keys.
+  ///
+  /// - Parameters:
+  ///   - apiKey: The API key string.
+  case apiKey(String)
 }
 
 /// Configuration options for external account credentials.
@@ -283,6 +292,8 @@ public struct Credentials: Sendable {
         scopes: config.scopes,
         universeDomain: config.universeDomain
       )
+    case let .apiKey(apiKey):
+      return ApiKeyCredentials(apiKey: apiKey)
     }
   }
 }

--- a/packages/auth/Sources/GoogleCloudAuth/Providers/ApiKeyCredentials.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/Providers/ApiKeyCredentials.swift
@@ -45,6 +45,6 @@ struct ApiKeyCredentials: CredentialsProvider, Sendable, CustomDebugStringConver
   // MARK: - CustomDebugStringConvertible
 
   var debugDescription: String {
-    return "ApiKeyCredentials(apiKey: \"[censored]\")"
+    return "ApiKeyCredentials(apiKey: \"[redacted]\")"
   }
 }

--- a/packages/auth/Sources/GoogleCloudAuth/Providers/ApiKeyCredentials.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/Providers/ApiKeyCredentials.swift
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Creates credentials backed by an API key.
+///
+/// An API key is a simple encrypted string that you can use when calling Google Cloud APIs. When you use API keys in
+/// your applications, ensure that they are kept secure during both storage and transmission.
+///
+/// API keys associate the request with a Google Cloud project for billing and quota purposes. Note that only some
+/// Cloud APIs support API keys. Consult the documentation of the API you intend to use before attempting to use
+/// API keys with it.
+struct ApiKeyCredentials: CredentialsProvider, Sendable, CustomDebugStringConvertible {
+  private let apiKey: String
+
+  /// Initializes credentials with the provided API key.
+  ///
+  /// - Parameter apiKey: The Google Cloud API key.
+  init(apiKey: String) {
+    self.apiKey = apiKey
+  }
+
+  // MARK: - CredentialsProvider
+
+  func headers() async throws -> AuthHeaders {
+    return [("x-goog-api-key", self.apiKey)]
+  }
+
+  func universeDomain() async -> String? {
+    return nil
+  }
+
+  // MARK: - CustomDebugStringConvertible
+
+  var debugDescription: String {
+    return "ApiKeyCredentials(apiKey: \"[censored]\")"
+  }
+}

--- a/packages/auth/Tests/ApiKeyCredentialsTests.swift
+++ b/packages/auth/Tests/ApiKeyCredentialsTests.swift
@@ -22,7 +22,7 @@ import Testing
     let description = String(reflecting: credentials)
 
     #expect(!description.contains("super-secret-api-key"))
-    #expect(description.contains("[censored]"))
+    #expect(description.contains("[redacted]"))
   }
 
   @Test func headersProducesExpectedApiKeyHeader() async throws {

--- a/packages/auth/Tests/ApiKeyCredentialsTests.swift
+++ b/packages/auth/Tests/ApiKeyCredentialsTests.swift
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+@testable import GoogleCloudAuth
+
+@Suite struct ApiKeyCredentialsTests {
+  @Test func debugDescriptionRedactsApiKey() {
+    let credentials = ApiKeyCredentials(apiKey: "super-secret-api-key")
+    let description = String(reflecting: credentials)
+
+    #expect(!description.contains("super-secret-api-key"))
+    #expect(description.contains("[censored]"))
+  }
+
+  @Test func headersProducesExpectedApiKeyHeader() async throws {
+    let credentials = ApiKeyCredentials(apiKey: "test-api-key")
+    let headers = try await credentials.headers()
+
+    #expect(headers.count == 1)
+    #expect(
+      headers.contains { $0.0 == "x-goog-api-key" && $0.1 == "test-api-key" },
+      "Missing x-goog-api-key header in \(headers)"
+    )
+  }
+
+  @Test func universeDomainReturnsNil() async {
+    let credentials = ApiKeyCredentials(apiKey: "test-api-key")
+    let universeDomain = await credentials.universeDomain()
+
+    #expect(universeDomain == nil)
+  }
+}

--- a/packages/auth/Tests/CredentialsTests.swift
+++ b/packages/auth/Tests/CredentialsTests.swift
@@ -85,4 +85,22 @@ import Testing
     let ud = await credentials.universeDomain()
     #expect(ud == "my-universe.com")
   }
+
+  @Test func resolveProviderForApiKey() async throws {
+    let credentials = try Credentials(configuration: .apiKey("test-api-key"))
+
+    #expect(
+      String(describing: type(of: credentials.credentialsProvider)).contains("ApiKeyCredentials")
+    )
+
+    let headers = try await credentials.headers()
+    #expect(headers.count == 1)
+    #expect(
+      headers.contains { $0.0 == "x-goog-api-key" && $0.1 == "test-api-key" },
+      "Missing x-goog-api-key header in \(headers)"
+    )
+
+    let ud = await credentials.universeDomain()
+    #expect(ud == nil)
+  }
 }


### PR DESCRIPTION
API key credentials are a simple string that authenticates a service account. They are about as dangerous as they sound, but some services support them, and even recommend them for initial development.