### PR TITLE
docs(guide): override credentials

### DIFF
--- a/guide/Package.swift
+++ b/guide/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
     .package(path: "../packages/gax"),
     .package(path: "../packages/auth"),
     .package(path: "../generated/google-cloud-secretmanager-v1"),
+    .package(path: "../generated/google-cloud-language-v2"),
     .package(url: "https://github.com/apple/swift-log", from: "1.12.0"),
   ],
   targets: [
@@ -37,6 +38,7 @@ let package = Package(
         .product(name: "GoogleCloudAuth", package: "auth"),
         .product(name: "GoogleCloudGax", package: "gax"),
         .product(name: "GoogleCloudSecretManagerV1", package: "google-cloud-secretmanager-v1"),
+        .product(name: "GoogleCloudLanguageV2", package: "google-cloud-language-v2"),
         .product(name: "Logging", package: "swift-log"),
       ]
     )

--- a/guide/Snippets/OverrideCredentials.swift
+++ b/guide/Snippets/OverrideCredentials.swift
@@ -1,0 +1,49 @@
+// snippet.hide
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// snippet.show
+// snippet.imports
+import Foundation
+import GoogleCloudAuth
+import GoogleCloudGax
+import GoogleCloudLanguageV2
+// snippet.end
+
+// snippet.function [START swift_override_credentials_function]
+func sample(apiKey: String) async throws {
+  // snippet.end [END swift_override_credentials_function]
+  // snippet.client [START swift_override_credentials_client]
+  let credentials = try Credentials(configuration: .apiKey(apiKey))
+  let client = try LanguageServiceClient(
+    ClientOptions().with { $0.credentials = credentials }
+  )
+  // snippet.end [END swift_override_credentials_client]
+  // snippet.call [START swift_override_credentials_call]
+  let document = Document().with {
+    $0.type = .plainText
+    $0.source = .content("Hello World!")
+  }
+  let response = try await client.analyzeSentiment(
+    request: .init().with { $0.document = document })
+  print("response=\(response)")
+  // snippet.end [END swift_override_credentials_call]
+}
+
+// snippet.hide
+@main struct SnippetRunner {
+  static func main() async throws {
+    try await sample(apiKey: "[placeholder]")
+  }
+}

--- a/guide/Sources/UserGuide/UserGuide.docc/UserGuide.md
+++ b/guide/Sources/UserGuide/UserGuide.docc/UserGuide.md
@@ -23,3 +23,4 @@ best-practices to retry transient RPC errors.
 ## Develop
 
 - <doc:override-endpoint>
+- <doc:override-credentials>

--- a/guide/Sources/UserGuide/UserGuide.docc/override-credentials.md
+++ b/guide/Sources/UserGuide/UserGuide.docc/override-credentials.md
@@ -1,0 +1,56 @@
+# Override the default authentication credentials
+
+<!--
+    It seems that swift-docc does not support reference-style links at the bottom of the file:
+
+    https://github.com/swiftlang/swift-docc/issues/685
+-->
+[Installing Swift]: https://www.swift.org/getting-started/
+[Getting Started with Swift]: <doc:quickstart>
+[cloud natural language api]: https://cloud.google.com/natural-language
+[service quickstart]: https://cloud.google.com/natural-language/docs/setup
+[API keys]: https://cloud.google.com/docs/authentication/api-keys
+[authentication methods]: https://cloud.google.com/docs/authentication
+[best practices for managing api keys]: https://cloud.google.com/docs/authentication/api-keys-best-practices
+
+The Swift client libraries automatically configure the authentication
+credentials used to access Google Cloud. Some applications may need to override
+the default credentials. This guide shows you how to override the default.
+
+## Prerequisites
+
+This guide uses the [Cloud Natural Language API]. To enable this API, follow the
+[service quickstart].
+
+For complete setup instructions for the Swift client libraries, see
+[Getting started with Swift].
+
+## Override the default credentials: API keys
+
+[API keys] are text strings that grant access to some Google Cloud services.
+Using API keys may simplify development as they require less configuration than
+other [authentication methods]. There are some risks associated with API keys,
+we recommended you read [Best practices for managing API keys] if you plan to
+use them.
+
+In this example you configure the client library to use a service account key
+file for authentication. In general, service account keys should be The same override can be used to configure the endpoint
+with one of the [private access options], or for [locational endpoints] in the
+services that support them.
+
+1. Add the imports needed to use the client library
+   @Snippet(path: "OverrideCredentials", slice: "imports")
+2. Write a function that receives the project ID and region as parameters
+   @Snippet(path: "OverrideCredentials", slice: "function")
+3. Initialize a client and override the endpoint to use a regional endpoint:
+   @Snippet(path: "OverrideCredentials", slice: "client")
+4. Use the client to retrieve the list of secrets in a region, and iterate over
+   the results:
+   @Snippet(path: "OverrideCredentials", slice: "call")
+
+## Next steps
+
+* [Override the default endpoint](override-endpoint.md) describes how to change
+  the default endpoint used by the Swift client libraries.
+<!-- TODO(https://github.com/googleapis/google-cloud-swift/issues/144) - lint the retry policy override guide -->
+<!-- TODO(https://github.com/googleapis/google-cloud-swift/issues/145) - lint the polling policy override guide -->

--- a/guide/Sources/UserGuide/UserGuide.docc/override-endpoint.md
+++ b/guide/Sources/UserGuide/UserGuide.docc/override-endpoint.md
@@ -46,6 +46,7 @@ services that support them.
 
 ## Next steps
 
-<!-- TODO(https://github.com/googleapis/google-cloud-swift/issues/137) - lint the credentials override guide -->
+* [Override the default credentials](override-credentials.md) describes how to
+  change the default credentials used by the Swift client libraries.
 <!-- TODO(https://github.com/googleapis/google-cloud-swift/issues/144) - lint the retry policy override guide -->
 <!-- TODO(https://github.com/googleapis/google-cloud-swift/issues/145) - lint the polling policy override guide -->


### PR DESCRIPTION
Introduce a new article in the user guide to override credentials. It uses API keys because those are easy to explain. The downside is that Secret Manager does not support them, so use an API that does: Natural Language is not too large and convenient enough.

Fixes #137 