### PR TITLE
feat(storage): verify checksums on download

### DIFF
--- a/packages/gax/Sources/GoogleCloudGax/CRC32C.swift
+++ b/packages/gax/Sources/GoogleCloudGax/CRC32C.swift
@@ -41,6 +41,13 @@ import Foundation
     }
   }
 
+  public mutating func update(_ buffer: UnsafeRawBufferPointer) {
+    for byte in buffer {
+      let index = Int(UInt8(value & 0xFF) ^ byte)
+      value = (value >> 8) ^ Self.table[index]
+    }
+  }
+
   public func finalize() -> UInt32 {
     return value ^ 0xFFFF_FFFF
   }
@@ -48,6 +55,12 @@ import Foundation
   public static func compute(_ data: Data) -> UInt32 {
     var crc = Self()
     crc.update(data)
+    return crc.finalize()
+  }
+
+  public static func compute(_ buffer: UnsafeRawBufferPointer) -> UInt32 {
+    var crc = Self()
+    crc.update(buffer)
     return crc.finalize()
   }
 }

--- a/packages/storage/Sources/GoogleCloudStorage/ChecksumCalculator.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/ChecksumCalculator.swift
@@ -1,0 +1,118 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Crypto
+import Foundation
+@_spi(GoogleCloudInternal) import struct GoogleCloudGax._CRC32C
+
+/// A protocol for incremental checksum computation.
+protocol ChecksumCalculator: Sendable {
+  /// The algorithm name matching the HTTP header tag (e.g. "crc32c", "md5").
+  var algorithmName: String { get }
+
+  /// Incrementally updates the checksum state from raw memory.
+  mutating func update(_ buffer: UnsafeRawBufferPointer)
+
+  /// Finalizes the checksum and returns the Base64-encoded string.
+  func finalize() -> String
+}
+
+extension ChecksumCalculator {
+  /// Convenience helper for Data chunks.
+  mutating func update(_ data: Data) {
+    data.withUnsafeBytes { update($0) }
+  }
+}
+
+/// CRC32C (Castagnoli) checksum calculator.
+struct CRC32CCalculator: ChecksumCalculator {
+  let algorithmName = "crc32c"
+  private var crc32c: _CRC32C
+
+  init(seed: UInt32? = nil) {
+    self.crc32c = seed != nil ? _CRC32C(seed: seed!) : _CRC32C()
+  }
+
+  mutating func update(_ buffer: UnsafeRawBufferPointer) {
+    crc32c.update(buffer)
+  }
+
+  func finalize() -> String {
+    let bigEndian = crc32c.finalize().bigEndian
+    return withUnsafeBytes(of: bigEndian) { Data($0).base64EncodedString() }
+  }
+}
+
+/// MD5 checksum calculator.
+struct MD5Calculator: ChecksumCalculator {
+  let algorithmName = "md5"
+  private var md5 = Insecure.MD5()
+
+  init() {}
+
+  mutating func update(_ buffer: UnsafeRawBufferPointer) {
+    md5.update(bufferPointer: buffer)
+  }
+
+  func finalize() -> String {
+    Data(md5.finalize()).base64EncodedString()
+  }
+}
+
+/// A static checksum calculator that returns a user-provided value without computing.
+struct ProvidedChecksumCalculator: ChecksumCalculator {
+  let algorithmName: String
+  let value: String
+
+  init(algorithmName: String, value: String) {
+    self.algorithmName = algorithmName
+    let prefix = "\(algorithmName)="
+    if value.hasPrefix(prefix) {
+      self.value = String(value.dropFirst(prefix.count))
+    } else {
+      self.value = value
+    }
+  }
+
+  mutating func update(_ buffer: UnsafeRawBufferPointer) {
+    // No-op: value is static and already provided
+  }
+
+  func finalize() -> String {
+    value
+  }
+}
+
+extension ChecksumOptions {
+  func makeUploadCalculators(crc32cSeed: UInt32? = nil) -> [any ChecksumCalculator] {
+    var calculators = [any ChecksumCalculator]()
+    if let crc = self.crc32c {
+      switch crc {
+      case .auto:
+        calculators.append(CRC32CCalculator(seed: crc32cSeed))
+      case .value(let val):
+        calculators.append(ProvidedChecksumCalculator(algorithmName: "crc32c", value: val))
+      }
+    }
+    if let md5 = self.md5 {
+      switch md5 {
+      case .auto:
+        calculators.append(MD5Calculator())
+      case .value(let val):
+        calculators.append(ProvidedChecksumCalculator(algorithmName: "md5", value: val))
+      }
+    }
+    return calculators
+  }
+}

--- a/packages/storage/Sources/GoogleCloudStorage/ChecksummedSource.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/ChecksummedSource.swift
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Crypto
 import Foundation
-@_spi(GoogleCloudInternal) import struct GoogleCloudGax._CRC32C
 
 struct ChunkInfo: Sendable {
   let data: Data
@@ -25,8 +23,7 @@ struct ChunkInfo: Sendable {
 struct ChecksummedSource<S: UploadSource> {
   var source: S
   let options: ChecksumOptions
-  private var md5 = Insecure.MD5()
-  private var crc32c = _CRC32C()
+  private var calculators: [any ChecksumCalculator] = []
   private var nextChunk: Data? = nil
   private var isInitialized = false
   private var isFinished = false
@@ -36,6 +33,7 @@ struct ChecksummedSource<S: UploadSource> {
   init(source: S, options: ChecksumOptions) {
     self.source = source
     self.options = options
+    self.calculators = options.makeUploadCalculators()
   }
 
   init(source: S, validation: ChecksumValidation) {
@@ -48,19 +46,18 @@ struct ChecksummedSource<S: UploadSource> {
     case .md5:
       self.options = ChecksumOptions(crc32c: nil, md5: .auto)
     }
+    self.calculators = self.options.makeUploadCalculators()
   }
 
   mutating func seedCRC32C(seed: UInt32, bytesHashed: Int64) {
-    if options.crc32c == .auto {
-      self.crc32c = _CRC32C(seed: seed)
+    if let idx = calculators.firstIndex(where: { $0 is CRC32CCalculator }) {
+      calculators[idx] = CRC32CCalculator(seed: seed)
       self.bytesHashed = bytesHashed
     }
   }
 
   private mutating func updateChecksums(data: Data, startOffset: Int64) {
-    let needCRC32C = (options.crc32c == .auto)
-    let needMD5 = (options.md5 == .auto)
-    guard needCRC32C || needMD5 else { return }
+    guard !calculators.isEmpty else { return }
 
     let endOffset = startOffset + Int64(data.count)
     guard endOffset > bytesHashed else { return }
@@ -73,11 +70,8 @@ struct ChecksummedSource<S: UploadSource> {
       unhashedData = data.subdata(in: offsetInChunk..<data.count)
     }
 
-    if needCRC32C {
-      crc32c.update(unhashedData)
-    }
-    if needMD5 {
-      md5.update(data: unhashedData)
+    for i in calculators.indices {
+      calculators[i].update(unhashedData)
     }
 
     bytesHashed = endOffset
@@ -112,35 +106,8 @@ struct ChecksummedSource<S: UploadSource> {
   mutating func finalizeChecksum() -> String? {
     guard !isFinished else { return nil }
     isFinished = true
-    var parts = [String]()
-
-    if let crcOption = options.crc32c {
-      switch crcOption {
-      case .auto:
-        let bigEndian = crc32c.finalize().bigEndian
-        var bytes = [UInt8]()
-        withUnsafeBytes(of: bigEndian) {
-          bytes = Array($0)
-        }
-        parts.append("crc32c=" + Data(bytes).base64EncodedString())
-      case .value(let val):
-        let formatted = val.hasPrefix("crc32c=") ? val : "crc32c=" + val
-        parts.append(formatted)
-      }
-    }
-
-    if let md5Option = options.md5 {
-      switch md5Option {
-      case .auto:
-        let digest = md5.finalize()
-        parts.append("md5=" + Data(digest).base64EncodedString())
-      case .value(let val):
-        let formatted = val.hasPrefix("md5=") ? val : "md5=" + val
-        parts.append(formatted)
-      }
-    }
-
-    return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    guard !calculators.isEmpty else { return nil }
+    return calculators.map { "\($0.algorithmName)=\($0.finalize())" }.joined(separator: ", ")
   }
 }
 
@@ -151,10 +118,7 @@ extension ChecksummedSource where S: SeekableUploadSource {
     isFinished = false
     nextChunkOffset = offset
 
-    let needCRC32C = (options.crc32c == .auto)
-    let needMD5 = (options.md5 == .auto)
-
-    guard offset > bytesHashed && (needCRC32C || needMD5) else {
+    guard offset > bytesHashed && !calculators.isEmpty else {
       try await source.seek(to: offset)
       return
     }

--- a/packages/storage/Sources/GoogleCloudStorage/DownloadOptions.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/DownloadOptions.swift
@@ -154,6 +154,45 @@ struct HttpContentRange: Sendable, Hashable, Equatable {
 ///   }
 /// }
 /// ```
+///
+/// ### Checksum Validation
+///
+/// Validate data integrity during downloads using CRC32C or MD5 checksums:
+///
+/// ```swift
+/// // Default: Automatic CRC32C validation against server metadata
+/// let options = ReadObjectOptions()
+///
+/// // Validate against a pre-computed Base64-encoded checksum
+/// let options = ReadObjectOptions().with {
+///   $0.checksums = ChecksumOptions(crc32c: "TVUQaA==")
+/// }
+///
+/// // Validate against a 32-bit unsigned integer CRC32C checksum
+/// let options = ReadObjectOptions().with {
+///   $0.checksums = ChecksumOptions(crc32c: 0x4D551068)
+/// }
+///
+/// // Validate using MD5 instead of CRC32C
+/// let options = ReadObjectOptions().with {
+///   $0.checksums = ChecksumOptions(crc32c: nil, md5: .auto)
+/// }
+///
+/// // Validate both CRC32C and MD5
+/// let options = ReadObjectOptions().with {
+///   $0.checksums = ChecksumOptions(crc32c: .auto, md5: .auto)
+/// }
+///
+/// // Disable checksum validation
+/// let options = ReadObjectOptions().with {
+///   $0.checksums = .none
+/// }
+/// ```
+///
+/// > Note: Automatic checksum verification (`.auto`) is skipped for partial (ranged) reads
+/// > and decompressive transcoding because server metadata checksums cover the entire original
+/// > object, not partial or decompressed bytes. Pre-computed expected values (`.value(...)`)
+/// > are always verified.
 public struct ReadObjectOptions: Sendable {
   /// Object generation (`UInt64?`) to read a specific revision of an object.
   public var generation: UInt64?
@@ -170,7 +209,12 @@ public struct ReadObjectOptions: Sendable {
   /// Flag to enable automatic decompressive transcoding by GCS. Defaults to `true`.
   public var enableDecompressiveTranscoding: Bool = true
 
-  /// Checksum options for validating data integrity.
+  /// Checksum options for validating downloaded data integrity.
+  ///
+  /// Defaults to `.default`, which automatically calculates and validates CRC32C
+  /// checksums against the object's server metadata upon reaching EOF.
+  ///
+  /// If a checksum mismatch is detected, `DownloadError.checksumMismatch` is thrown.
   public var checksums: ChecksumOptions = .default
 
   /// Flag to enable transparent auto-resumption on transient network failures. Defaults to `true`.

--- a/packages/storage/Sources/GoogleCloudStorage/DownloadOptions.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/DownloadOptions.swift
@@ -242,6 +242,9 @@ public struct ReadObjectMetadata: Sendable, Hashable, Equatable {
   /// Content size of the object payload in bytes.
   public var size: UInt64 = 0
 
+  /// Stored content length of the object before decompressive transcoding (if applicable).
+  public var storedContentLength: UInt64?
+
   /// Generation revision number of the object.
   public var generation: UInt64 = 0
 
@@ -332,6 +335,9 @@ package final class ReadObjectCoordinator: @unchecked Sendable {
   private var bytesReceived: UInt64 = 0
   private var isFinished: Bool = false
   private var isCancelled: Bool = false
+  private var crc32cCalculator: CRC32CCalculator?
+  private var md5Calculator: MD5Calculator?
+  private var hasValidatedChecksums: Bool = false
 
   package init(
     bucket: String,
@@ -345,6 +351,12 @@ package final class ReadObjectCoordinator: @unchecked Sendable {
     self.options = options
     self.httpClient = httpClient
     self.retryLoop = retryLoop
+    if options.checksums.crc32c != nil {
+      self.crc32cCalculator = CRC32CCalculator()
+    }
+    if options.checksums.md5 != nil {
+      self.md5Calculator = MD5Calculator()
+    }
   }
 
   private func ensureInitialFetch() async throws -> ReadObjectMetadata {
@@ -404,8 +416,10 @@ package final class ReadObjectCoordinator: @unchecked Sendable {
           self.streamIterator = it
           if let chunk {
             bytesReceived += UInt64(chunk.readableBytes)
+            updateChecksums(with: chunk)
             return chunk
           } else {
+            try validateChecksumsAtEOF()
             isFinished = true
             return nil
           }
@@ -414,16 +428,23 @@ package final class ReadObjectCoordinator: @unchecked Sendable {
           self.bodyIterator = it
           if let chunk {
             bytesReceived += UInt64(chunk.readableBytes)
+            updateChecksums(with: chunk)
             return chunk
           } else {
+            try validateChecksumsAtEOF()
             isFinished = true
             return nil
           }
         } else {
+          try validateChecksumsAtEOF()
           isFinished = true
           return nil
         }
       } catch {
+        if error is DownloadError {
+          isFinished = true
+          throw error
+        }
         guard options.autoResume else {
           isFinished = true
           throw error
@@ -434,6 +455,72 @@ package final class ReadObjectCoordinator: @unchecked Sendable {
     }
 
     return nil
+  }
+
+  private func updateChecksums(with chunk: NIOCore.ByteBuffer) {
+    guard crc32cCalculator != nil || md5Calculator != nil else { return }
+    chunk.withUnsafeReadableBytes { buffer in
+      crc32cCalculator?.update(buffer)
+      md5Calculator?.update(buffer)
+    }
+  }
+
+  private func validateChecksumsAtEOF() throws {
+    guard !hasValidatedChecksums else { return }
+    hasValidatedChecksums = true
+
+    let currentMetadata = self.metadata ?? ReadObjectMetadata()
+    let isRangedRead = (options.range != .entire)
+    let isDecompressedTranscoding =
+      (currentMetadata.storedContentLength != nil && currentMetadata.contentEncoding == nil)
+
+    if let crcOption = options.checksums.crc32c, let calc = crc32cCalculator {
+      let actual = calc.finalize()
+      switch crcOption {
+      case .auto:
+        if !isRangedRead && !isDecompressedTranscoding, let expected = currentMetadata.crc32c {
+          if actual != expected {
+            throw DownloadError.checksumMismatch(
+              expected: expected,
+              actual: actual,
+              algorithm: calc.algorithmName
+            )
+          }
+        }
+      case .value(let expected):
+        if actual != expected {
+          throw DownloadError.checksumMismatch(
+            expected: expected,
+            actual: actual,
+            algorithm: calc.algorithmName
+          )
+        }
+      }
+    }
+
+    if let md5Option = options.checksums.md5, let calc = md5Calculator {
+      let actual = calc.finalize()
+      switch md5Option {
+      case .auto:
+        if !isRangedRead && !isDecompressedTranscoding, let expected = currentMetadata.md5Hash {
+          if actual != expected {
+            throw DownloadError.checksumMismatch(
+              expected: expected,
+              actual: actual,
+              algorithm: calc.algorithmName
+            )
+          }
+        }
+      case .value(let expected):
+        if actual != expected {
+          throw DownloadError.checksumMismatch(
+            expected: expected,
+            actual: actual,
+            algorithm: calc.algorithmName
+          )
+        }
+      }
+    }
   }
 
   private func resumeDownload(underlyingError: Error) async throws {

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Download.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Download.swift
@@ -73,6 +73,12 @@ extension StorageClient {
       metadata.size = size
     }
 
+    if let storedLengthStr = headers.first(name: "x-goog-stored-content-length"),
+      let storedLength = UInt64(storedLengthStr)
+    {
+      metadata.storedContentLength = storedLength
+    }
+
     if let genStr = headers.first(name: "x-goog-generation"),
       let gen = UInt64(genStr)
     {

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -839,35 +839,11 @@ extension StorageClient {
   fileprivate static func computeSimpleChecksum(_ data: Data, options: ChecksumOptions) throws
     -> String?
   {
-    var parts = [String]()
-
-    if let crcOption = options.crc32c {
-      switch crcOption {
-      case .auto:
-        let crc = _CRC32C.compute(data)
-        let bigEndian = crc.bigEndian
-        var bytes = [UInt8]()
-        withUnsafeBytes(of: bigEndian) {
-          bytes = Array($0)
-        }
-        parts.append("crc32c=" + Data(bytes).base64EncodedString())
-      case .value(let val):
-        let formatted = val.hasPrefix("crc32c=") ? val : "crc32c=" + val
-        parts.append(formatted)
-      }
+    var calculators = options.makeUploadCalculators()
+    guard !calculators.isEmpty else { return nil }
+    for i in calculators.indices {
+      calculators[i].update(data)
     }
-
-    if let md5Option = options.md5 {
-      switch md5Option {
-      case .auto:
-        let digest = Insecure.MD5.hash(data: data)
-        parts.append("md5=" + Data(digest).base64EncodedString())
-      case .value(let val):
-        let formatted = val.hasPrefix("md5=") ? val : "md5=" + val
-        parts.append(formatted)
-      }
-    }
-
-    return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    return calculators.map { "\($0.algorithmName)=\($0.finalize())" }.joined(separator: ", ")
   }
 }

--- a/packages/storage/Tests/ChecksumTests.swift
+++ b/packages/storage/Tests/ChecksumTests.swift
@@ -12,6 +12,7 @@
 // See the License for theing specific language governing permissions and
 // limitations under the License.
 
+import Crypto
 import Foundation
 import GoogleCloudAuth
 @_spi(GoogleCloudInternal) import GoogleCloudGax
@@ -288,5 +289,65 @@ import Testing
 
     #expect(remainingData == Data("World!".utf8))
     #expect(finalChecksum == "crc32c=TVUQaA==")
+  }
+
+  @Test func testCRC32CCalculator() {
+    var calculator = CRC32CCalculator()
+    #expect(calculator.algorithmName == "crc32c")
+
+    let data1 = Data("Hello, ".utf8)
+    let data2 = Data("World!".utf8)
+    calculator.update(data1)
+    calculator.update(data2)
+    #expect(calculator.finalize() == "TVUQaA==")
+  }
+
+  @Test func testCRC32CCalculatorSeeded() {
+    let part1 = Data("Hello, ".utf8)
+    let part2 = Data("World!".utf8)
+    let seed = _CRC32C.compute(part1)
+
+    var calc = CRC32CCalculator(seed: seed)
+    calc.update(part2)
+    #expect(calc.finalize() == "TVUQaA==")
+  }
+
+  @Test func testMD5Calculator() {
+    var calculator = MD5Calculator()
+    #expect(calculator.algorithmName == "md5")
+
+    let data1 = Data("Hello, ".utf8)
+    let data2 = Data("World!".utf8)
+    calculator.update(data1)
+    calculator.update(data2)
+    #expect(calculator.finalize() == "ZajifYh5KDgxtmS9i38K1A==")
+  }
+
+  @Test func testProvidedChecksumCalculator() {
+    var rawCalc = ProvidedChecksumCalculator(algorithmName: "crc32c", value: "TVUQaA==")
+    #expect(rawCalc.algorithmName == "crc32c")
+    rawCalc.update(Data("ignored data".utf8))
+    #expect(rawCalc.finalize() == "TVUQaA==")
+
+    // Prefixed value gets cleaned
+    let prefixedCalc = ProvidedChecksumCalculator(algorithmName: "md5", value: "md5=custom_md5==")
+    #expect(prefixedCalc.algorithmName == "md5")
+    #expect(prefixedCalc.finalize() == "custom_md5==")
+  }
+
+  @Test func testMakeUploadCalculators() {
+    let options = ChecksumOptions(crc32c: .auto, md5: .value("user_md5=="))
+    var calcs = options.makeUploadCalculators()
+    #expect(calcs.count == 2)
+    #expect(calcs[0] is CRC32CCalculator)
+    #expect(calcs[1] is ProvidedChecksumCalculator)
+
+    let testData = Data("Hello, World!".utf8)
+    for i in calcs.indices {
+      calcs[i].update(testData)
+    }
+
+    let header = calcs.map { "\($0.algorithmName)=\($0.finalize())" }.joined(separator: ", ")
+    #expect(header == "crc32c=TVUQaA==, md5=user_md5==")
   }
 }

--- a/packages/storage/Tests/DownloadChecksumTests.swift
+++ b/packages/storage/Tests/DownloadChecksumTests.swift
@@ -1,0 +1,715 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Crypto
+import Foundation
+import GoogleCloudAuth
+@_spi(GoogleCloudInternal) import GoogleCloudGax
+@_spi(GoogleCloudInternal) @testable import GoogleCloudStorage
+import Testing
+
+@Suite struct DownloadChecksumTests {
+  private func makeClient(registry: MockRegistry) throws -> StorageClient {
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+    return try StorageClient(options, mock: registry)
+  }
+
+  @Test func crc32cSuccess() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "crc-test.txt"
+    let payload = Data("Checksum verification test payload for CRC32C".utf8)
+
+    let computedCrc = _CRC32C.compute(payload)
+    let crcBase64 = withUnsafeBytes(of: computedCrc.bigEndian) { Data($0).base64EncodedString() }
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: [
+          "Content-Length": String(payload.count),
+          "x-goog-generation": "123",
+          "x-goog-hash": "crc32c=\(crcBase64)",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let result = client.readObject(from: bucket, object: objectName)
+
+    var receivedData = Data()
+    for try await chunk in result.body {
+      receivedData.append(contentsOf: chunk.readableBytesView)
+    }
+    #expect(receivedData == payload)
+  }
+
+  @Test func crc32cMismatch() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "crc-mismatch.txt"
+    let payload = Data("Checksum verification test payload for CRC32C".utf8)
+
+    let computedCrc = _CRC32C.compute(payload)
+    let actualCrcBase64 = withUnsafeBytes(of: computedCrc.bigEndian) {
+      Data($0).base64EncodedString()
+    }
+    let invalidExpectedCrc = "invalid_crc_base64"
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: [
+          "Content-Length": String(payload.count),
+          "x-goog-generation": "123",
+          "x-goog-hash": "crc32c=\(invalidExpectedCrc)",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let result = client.readObject(from: bucket, object: objectName)
+
+    do {
+      for try await _ in result.body {}
+      Issue.record("Expected DownloadError.checksumMismatch to be thrown")
+    } catch let error as DownloadError {
+      #expect(
+        error
+          == DownloadError.checksumMismatch(
+            expected: invalidExpectedCrc,
+            actual: actualCrcBase64,
+            algorithm: "crc32c"
+          )
+      )
+    }
+  }
+
+  @Test func md5Success() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "md5-test.txt"
+    let payload = Data("Checksum verification test payload for MD5".utf8)
+
+    let md5Base64 = Data(Insecure.MD5.hash(data: payload)).base64EncodedString()
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: [
+          "Content-Length": String(payload.count),
+          "x-goog-generation": "123",
+          "x-goog-hash": "md5=\(md5Base64)",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let options = ReadObjectOptions().with {
+      $0.checksums = ChecksumOptions(crc32c: nil, md5: .auto)
+    }
+    let result = client.readObject(from: bucket, object: objectName, options: options)
+
+    var receivedData = Data()
+    for try await chunk in result.body {
+      receivedData.append(contentsOf: chunk.readableBytesView)
+    }
+    #expect(receivedData == payload)
+  }
+
+  @Test func md5Mismatch() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "md5-mismatch.txt"
+    let payload = Data("Checksum verification test payload for MD5".utf8)
+
+    let actualMd5Base64 = Data(Insecure.MD5.hash(data: payload)).base64EncodedString()
+    let invalidExpectedMd5 = "invalid_md5_base64"
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: [
+          "Content-Length": String(payload.count),
+          "x-goog-generation": "123",
+          "x-goog-hash": "md5=\(invalidExpectedMd5)",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let options = ReadObjectOptions().with {
+      $0.checksums = ChecksumOptions(crc32c: nil, md5: .auto)
+    }
+    let result = client.readObject(from: bucket, object: objectName, options: options)
+
+    do {
+      for try await _ in result.body {}
+      Issue.record("Expected DownloadError.checksumMismatch to be thrown")
+    } catch let error as DownloadError {
+      #expect(
+        error
+          == DownloadError.checksumMismatch(
+            expected: invalidExpectedMd5,
+            actual: actualMd5Base64,
+            algorithm: "md5"
+          )
+      )
+    }
+  }
+
+  @Test func contentMD5Header() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "content-md5.txt"
+    let payload = Data("Testing Content-MD5 header verification".utf8)
+
+    let actualMd5Base64 = Data(Insecure.MD5.hash(data: payload)).base64EncodedString()
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: [
+          "Content-Length": String(payload.count),
+          "Content-MD5": actualMd5Base64,
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let options = ReadObjectOptions().with {
+      $0.checksums = ChecksumOptions(crc32c: nil, md5: .auto)
+    }
+    let result = client.readObject(from: bucket, object: objectName, options: options)
+
+    var receivedData = Data()
+    for try await chunk in result.body {
+      receivedData.append(contentsOf: chunk.readableBytesView)
+    }
+    #expect(receivedData == payload)
+
+    // Now test Content-MD5 mismatch
+    let mismatchUrl = registry.url("/storage/v1/b/\(bucket)/o/mismatch.txt?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: [
+          "Content-Length": String(payload.count),
+          "Content-MD5": "wrong_content_md5",
+        ]
+      ),
+      for: mismatchUrl
+    )
+    let mismatchResult = client.readObject(from: bucket, object: "mismatch.txt", options: options)
+    do {
+      for try await _ in mismatchResult.body {}
+      Issue.record("Expected DownloadError.checksumMismatch to be thrown")
+    } catch let error as DownloadError {
+      #expect(
+        error
+          == DownloadError.checksumMismatch(
+            expected: "wrong_content_md5",
+            actual: actualMd5Base64,
+            algorithm: "md5"
+          )
+      )
+    }
+  }
+
+  @Test func dualChecksums() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "both-hashes.txt"
+    let payload = Data("Dual hash verification test payload".utf8)
+
+    let computedCrc = _CRC32C.compute(payload)
+    let crcBase64 = withUnsafeBytes(of: computedCrc.bigEndian) { Data($0).base64EncodedString() }
+    let md5Base64 = Data(Insecure.MD5.hash(data: payload)).base64EncodedString()
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: [
+          "Content-Length": String(payload.count),
+          "x-goog-hash": "crc32c=\(crcBase64), md5=\(md5Base64)",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let options = ReadObjectOptions().with {
+      $0.checksums = ChecksumOptions(crc32c: .auto, md5: .auto)
+    }
+    let result = client.readObject(from: bucket, object: objectName, options: options)
+
+    var receivedData = Data()
+    for try await chunk in result.body {
+      receivedData.append(contentsOf: chunk.readableBytesView)
+    }
+    #expect(receivedData == payload)
+
+    // Test dual validation where MD5 fails
+    let md5FailUrl = registry.url("/storage/v1/b/\(bucket)/o/md5-fail.txt?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: [
+          "Content-Length": String(payload.count),
+          "x-goog-hash": "crc32c=\(crcBase64), md5=wrong_md5",
+        ]
+      ),
+      for: md5FailUrl
+    )
+    let md5FailResult = client.readObject(from: bucket, object: "md5-fail.txt", options: options)
+    do {
+      for try await _ in md5FailResult.body {}
+      Issue.record("Expected DownloadError.checksumMismatch to be thrown")
+    } catch let error as DownloadError {
+      #expect(
+        error
+          == DownloadError.checksumMismatch(
+            expected: "wrong_md5",
+            actual: md5Base64,
+            algorithm: "md5"
+          )
+      )
+    }
+  }
+
+  @Test func userProvidedCRC32C() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "user-crc.txt"
+    let payload = Data("User provided CRC32C test payload".utf8)
+
+    let computedCrc = _CRC32C.compute(payload)
+    let crcBase64 = withUnsafeBytes(of: computedCrc.bigEndian) { Data($0).base64EncodedString() }
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: ["Content-Length": String(payload.count)]
+      ),
+      for: downloadUrl
+    )
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: ["Content-Length": String(payload.count)]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let options = ReadObjectOptions().with {
+      $0.checksums = ChecksumOptions(crc32c: .value(crcBase64), md5: nil)
+    }
+    let result = client.readObject(from: bucket, object: objectName, options: options)
+
+    var receivedData = Data()
+    for try await chunk in result.body {
+      receivedData.append(contentsOf: chunk.readableBytesView)
+    }
+    #expect(receivedData == payload)
+
+    // User provided wrong value throws mismatch
+    let wrongOptions = ReadObjectOptions().with {
+      $0.checksums = ChecksumOptions(crc32c: "wrong_crc_value", md5: nil)
+    }
+    let wrongResult = client.readObject(from: bucket, object: objectName, options: wrongOptions)
+    do {
+      for try await _ in wrongResult.body {}
+      Issue.record("Expected DownloadError.checksumMismatch to be thrown")
+    } catch let error as DownloadError {
+      #expect(
+        error
+          == DownloadError.checksumMismatch(
+            expected: "wrong_crc_value",
+            actual: crcBase64,
+            algorithm: "crc32c"
+          )
+      )
+    }
+  }
+
+  @Test func userProvidedCRC32CUInt32() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "user-uint32-crc.txt"
+    let payload = Data("Hello, World!".utf8)  // CRC32C: 0x4D551068 -> "TVUQaA=="
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: ["Content-Length": String(payload.count)]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let options = ReadObjectOptions().with {
+      $0.checksums = ChecksumOptions(crc32c: 0x4D55_1068, md5: nil)
+    }
+    let result = client.readObject(from: bucket, object: objectName, options: options)
+
+    var receivedData = Data()
+    for try await chunk in result.body {
+      receivedData.append(contentsOf: chunk.readableBytesView)
+    }
+    #expect(receivedData == payload)
+  }
+
+  @Test func userProvidedMD5() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "user-md5.txt"
+    let payload = Data("User provided MD5 test payload".utf8)
+
+    let md5Base64 = Data(Insecure.MD5.hash(data: payload)).base64EncodedString()
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: ["Content-Length": String(payload.count)]
+      ),
+      for: downloadUrl
+    )
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: ["Content-Length": String(payload.count)]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let options = ReadObjectOptions().with {
+      $0.checksums = ChecksumOptions(crc32c: nil, md5: .value(md5Base64))
+    }
+    let result = client.readObject(from: bucket, object: objectName, options: options)
+
+    var receivedData = Data()
+    for try await chunk in result.body {
+      receivedData.append(contentsOf: chunk.readableBytesView)
+    }
+    #expect(receivedData == payload)
+
+    // Wrong MD5 throws mismatch
+    let wrongOptions = ReadObjectOptions().with {
+      $0.checksums = ChecksumOptions(crc32c: nil, md5: "wrong_md5_value")
+    }
+    let wrongResult = client.readObject(from: bucket, object: objectName, options: wrongOptions)
+    do {
+      for try await _ in wrongResult.body {}
+      Issue.record("Expected DownloadError.checksumMismatch to be thrown")
+    } catch let error as DownloadError {
+      #expect(
+        error
+          == DownloadError.checksumMismatch(
+            expected: "wrong_md5_value",
+            actual: md5Base64,
+            algorithm: "md5"
+          )
+      )
+    }
+  }
+
+  @Test func checksumsNone() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "none-validation.txt"
+    let payload = Data("No checksum verification payload".utf8)
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: [
+          "Content-Length": String(payload.count),
+          "x-goog-hash": "crc32c=bad_crc, md5=bad_md5",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let options = ReadObjectOptions().with {
+      $0.checksums = .none
+    }
+    let result = client.readObject(from: bucket, object: objectName, options: options)
+
+    var receivedData = Data()
+    for try await chunk in result.body {
+      receivedData.append(contentsOf: chunk.readableBytesView)
+    }
+    #expect(receivedData == payload)
+  }
+
+  @Test func rangedReadSkipsAuto() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "ranged-skip.txt"
+    let fullPayload = Data("0123456789ABCDEF0123456789ABCDEF".utf8)
+    let rangePayload = Data("0123456789".utf8)
+
+    let fullCrc = _CRC32C.compute(fullPayload)
+    let fullCrcBase64 = withUnsafeBytes(of: fullCrc.bigEndian) { Data($0).base64EncodedString() }
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 206,
+        data: rangePayload,
+        headers: [
+          "Content-Range": "bytes 0-9/\(fullPayload.count)",
+          "Content-Length": "10",
+          "x-goog-hash": "crc32c=\(fullCrcBase64)",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let options = ReadObjectOptions().with {
+      $0.range = .bounded(start: 0, end: 9)
+    }
+    let result = client.readObject(from: bucket, object: objectName, options: options)
+
+    var receivedData = Data()
+    for try await chunk in result.body {
+      receivedData.append(contentsOf: chunk.readableBytesView)
+    }
+    #expect(receivedData == rangePayload)
+  }
+
+  @Test func rangedReadWithUserCRC() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "ranged-user-crc.txt"
+    let fullPayload = Data("0123456789ABCDEF0123456789ABCDEF".utf8)
+    let rangePayload = Data("0123456789".utf8)
+
+    let rangeCrc = _CRC32C.compute(rangePayload)
+    let rangeCrcBase64 = withUnsafeBytes(of: rangeCrc.bigEndian) { Data($0).base64EncodedString() }
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 206,
+        data: rangePayload,
+        headers: [
+          "Content-Range": "bytes 0-9/\(fullPayload.count)",
+          "Content-Length": "10",
+        ]
+      ),
+      for: downloadUrl
+    )
+    registry.register(
+      response: .success(
+        statusCode: 206,
+        data: rangePayload,
+        headers: [
+          "Content-Range": "bytes 0-9/\(fullPayload.count)",
+          "Content-Length": "10",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let options = ReadObjectOptions().with {
+      $0.range = .bounded(start: 0, end: 9)
+      $0.checksums = ChecksumOptions(crc32c: .value(rangeCrcBase64), md5: nil)
+    }
+    let result = client.readObject(from: bucket, object: objectName, options: options)
+
+    var receivedData = Data()
+    for try await chunk in result.body {
+      receivedData.append(contentsOf: chunk.readableBytesView)
+    }
+    #expect(receivedData == rangePayload)
+
+    // User provided wrong CRC for range throws mismatch
+    let wrongOptions = ReadObjectOptions().with {
+      $0.range = .bounded(start: 0, end: 9)
+      $0.checksums = ChecksumOptions(crc32c: "wrong_range_crc", md5: nil)
+    }
+    let wrongResult = client.readObject(from: bucket, object: objectName, options: wrongOptions)
+    do {
+      for try await _ in wrongResult.body {}
+      Issue.record("Expected DownloadError.checksumMismatch to be thrown")
+    } catch let error as DownloadError {
+      #expect(
+        error
+          == DownloadError.checksumMismatch(
+            expected: "wrong_range_crc",
+            actual: rangeCrcBase64,
+            algorithm: "crc32c"
+          )
+      )
+    }
+  }
+
+  @Test func transcodingSkipsAuto() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "transcoded.txt"
+    let uncompressedPayload = Data("Uncompressed transcoded text from GCS".utf8)
+    let storedCompressedLength: UInt64 = 25
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: uncompressedPayload,
+        headers: [
+          "Content-Length": String(uncompressedPayload.count),
+          "x-goog-stored-content-length": String(storedCompressedLength),
+          "x-goog-hash": "crc32c=stored_compressed_crc==",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let result = client.readObject(from: bucket, object: objectName)
+
+    var receivedData = Data()
+    for try await chunk in result.body {
+      receivedData.append(contentsOf: chunk.readableBytesView)
+    }
+    #expect(receivedData == uncompressedPayload)
+  }
+
+  @Test func resumeCalculatesFullChecksum() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "resume-checksum.bin"
+    let chunk1 = Data("First half of streaming payload. ".utf8)
+    let chunk2 = Data("Second half after recovery.".utf8)
+    let fullPayload = chunk1 + chunk2
+
+    let computedCrc = _CRC32C.compute(fullPayload)
+    let crcBase64 = withUnsafeBytes(of: computedCrc.bigEndian) { Data($0).base64EncodedString() }
+
+    let initialUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    let resumeUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media&generation=999")
+
+    // Attempt 1: Yields chunk1 then fails with MockNetworkError
+    registry.register(
+      response: .stream(
+        statusCode: 200,
+        chunks: [chunk1],
+        error: MockNetworkError(),
+        headers: [
+          "Content-Length": String(fullPayload.count),
+          "x-goog-generation": "999",
+          "x-goog-hash": "crc32c=\(crcBase64)",
+        ]
+      ),
+      for: initialUrl
+    )
+
+    // Attempt 2 (Resume from byte chunk1.count): Yields chunk2
+    registry.register(
+      response: .stream(
+        statusCode: 206,
+        chunks: [chunk2],
+        headers: [
+          "Content-Range": "bytes \(chunk1.count)-\(fullPayload.count - 1)/\(fullPayload.count)",
+          "Content-Length": String(chunk2.count),
+          "x-goog-generation": "999",
+          "x-goog-hash": "crc32c=\(crcBase64)",
+        ]
+      ),
+      for: resumeUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let result = client.readObject(from: bucket, object: objectName)
+
+    var receivedData = Data()
+    for try await chunk in result.body {
+      receivedData.append(contentsOf: chunk.readableBytesView)
+    }
+    #expect(receivedData == fullPayload)
+  }
+
+  @Test func emptyPayloadChecksum() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "empty-object.txt"
+    let payload = Data()
+
+    let computedCrc = _CRC32C.compute(payload)  // 0 -> "AAAAAA=="
+    let crcBase64 = withUnsafeBytes(of: computedCrc.bigEndian) { Data($0).base64EncodedString() }
+
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: [
+          "Content-Length": "0",
+          "x-goog-generation": "1",
+          "x-goog-hash": "crc32c=\(crcBase64)",
+        ]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let result = client.readObject(from: bucket, object: objectName)
+
+    var receivedData = Data()
+    for try await chunk in result.body {
+      receivedData.append(contentsOf: chunk.readableBytesView)
+    }
+    #expect(receivedData == payload)
+  }
+}

--- a/packages/storage/Tests/DownloadTests.swift
+++ b/packages/storage/Tests/DownloadTests.swift
@@ -54,6 +54,9 @@ import Testing
     let payload = Data("Hello, Cloud Storage download!".utf8)
 
     let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    let computedCrc = _CRC32C.compute(payload)
+    let crcBase64 = withUnsafeBytes(of: computedCrc.bigEndian) { Data($0).base64EncodedString() }
+    let md5Base64 = Data(Insecure.MD5.hash(data: payload)).base64EncodedString()
 
     let headers = [
       "Content-Type": "text/plain; charset=utf-8",
@@ -61,7 +64,7 @@ import Testing
       "x-goog-generation": "17123456789",
       "x-goog-metageneration": "3",
       "ETag": "\"CPv1234\"",
-      "x-goog-hash": "crc32c=AdiAvw==, md5=N1YvABC==",
+      "x-goog-hash": "crc32c=\(crcBase64), md5=\(md5Base64)",
       "x-goog-storage-class": "STANDARD",
       "Last-Modified": "Fri, 07 Aug 2026 01:00:00 GMT",
     ]
@@ -81,8 +84,8 @@ import Testing
     #expect(metadata.generation == 17123456789)
     #expect(metadata.metageneration == 3)
     #expect(metadata.etag == "\"CPv1234\"")
-    #expect(metadata.crc32c == "AdiAvw==")
-    #expect(metadata.md5Hash == "N1YvABC==")
+    #expect(metadata.crc32c == crcBase64)
+    #expect(metadata.md5Hash == md5Base64)
     #expect(metadata.contentType == "text/plain; charset=utf-8")
     #expect(metadata.storageClass == "STANDARD")
     #expect(metadata.updated != nil)

--- a/packages/storage/Tests/IntegrationTests/StorageClientDownloadChecksumIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientDownloadChecksumIntegrationTests.swift
@@ -1,0 +1,281 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Crypto
+import Foundation
+@_spi(GoogleCloudInternal) import GoogleCloudGax
+@testable import GoogleCloudStorage
+import NIOCore
+import Testing
+
+#if IntegrationTests
+
+  @Suite(
+    .enabled(
+      if: ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil
+        && ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"] != nil))
+  struct StorageClientDownloadChecksumIntegrationTests {
+    struct FixtureState: Sendable {
+      let bucketName: String
+      let objectName: String
+      let data: Data
+      let crc32cBase64: String
+      let md5Base64: String
+    }
+
+    static let bucketName = ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_BUCKET"]!
+
+    static let sharedFixture = Task<FixtureState, any Error> {
+      let objName = "test-download-checksums-\(UUID().uuidString).txt"
+      let content =
+        "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ - Checksum verification payload for integration tests!"
+      let data = Data(content.utf8)
+
+      let storageClient = try StorageClient()
+      let uploadTask = storageClient.upload(data, to: bucketName, as: objName)
+      let obj = try await uploadTask.value
+      #expect(obj.bucket == bucketName)
+      #expect(obj.name == objName)
+
+      let computedCrc = _CRC32C.compute(data)
+      let crcBase64 = withUnsafeBytes(of: computedCrc.bigEndian) { Data($0).base64EncodedString() }
+      let md5Base64 = Data(Insecure.MD5.hash(data: data)).base64EncodedString()
+
+      return FixtureState(
+        bucketName: bucketName,
+        objectName: objName,
+        data: data,
+        crc32cBase64: crcBase64,
+        md5Base64: md5Base64
+      )
+    }
+
+    @Test func testDownloadDefaultCRC32C() async throws {
+      let fixture = try await Self.sharedFixture.value
+      let storage = try StorageClient()
+
+      let result = storage.readObject(from: fixture.bucketName, object: fixture.objectName)
+      var downloadedData = Data()
+      for try await chunk in result.body {
+        downloadedData.append(contentsOf: chunk.readableBytesView)
+      }
+      #expect(downloadedData == fixture.data)
+    }
+
+    @Test func testDownloadAutoMD5() async throws {
+      let fixture = try await Self.sharedFixture.value
+      let storage = try StorageClient()
+
+      let options = ReadObjectOptions().with {
+        $0.checksums = ChecksumOptions(crc32c: nil, md5: .auto)
+      }
+      let result = storage.readObject(
+        from: fixture.bucketName, object: fixture.objectName, options: options)
+      var downloadedData = Data()
+      for try await chunk in result.body {
+        downloadedData.append(contentsOf: chunk.readableBytesView)
+      }
+      #expect(downloadedData == fixture.data)
+    }
+
+    @Test func testDownloadDualAutoChecksums() async throws {
+      let fixture = try await Self.sharedFixture.value
+      let storage = try StorageClient()
+
+      let options = ReadObjectOptions().with {
+        $0.checksums = ChecksumOptions(crc32c: .auto, md5: .auto)
+      }
+      let result = storage.readObject(
+        from: fixture.bucketName, object: fixture.objectName, options: options)
+      var downloadedData = Data()
+      for try await chunk in result.body {
+        downloadedData.append(contentsOf: chunk.readableBytesView)
+      }
+      #expect(downloadedData == fixture.data)
+    }
+
+    @Test func testDownloadUserProvidedChecksums() async throws {
+      let fixture = try await Self.sharedFixture.value
+      let storage = try StorageClient()
+
+      // User-provided CRC32C
+      let crcOptions = ReadObjectOptions().with {
+        $0.checksums = ChecksumOptions(crc32c: .value(fixture.crc32cBase64), md5: nil)
+      }
+      let crcResult = storage.readObject(
+        from: fixture.bucketName, object: fixture.objectName, options: crcOptions)
+      var crcData = Data()
+      for try await chunk in crcResult.body {
+        crcData.append(contentsOf: chunk.readableBytesView)
+      }
+      #expect(crcData == fixture.data)
+
+      // User-provided MD5
+      let md5Options = ReadObjectOptions().with {
+        $0.checksums = ChecksumOptions(crc32c: nil, md5: .value(fixture.md5Base64))
+      }
+      let md5Result = storage.readObject(
+        from: fixture.bucketName, object: fixture.objectName, options: md5Options)
+      var md5Data = Data()
+      for try await chunk in md5Result.body {
+        md5Data.append(contentsOf: chunk.readableBytesView)
+      }
+      #expect(md5Data == fixture.data)
+
+      // User-provided dual CRC32C and MD5
+      let dualOptions = ReadObjectOptions().with {
+        $0.checksums = ChecksumOptions(
+          crc32c: .value(fixture.crc32cBase64), md5: .value(fixture.md5Base64))
+      }
+      let dualResult = storage.readObject(
+        from: fixture.bucketName, object: fixture.objectName, options: dualOptions)
+      var dualData = Data()
+      for try await chunk in dualResult.body {
+        dualData.append(contentsOf: chunk.readableBytesView)
+      }
+      #expect(dualData == fixture.data)
+    }
+
+    @Test func testDownloadDisabledChecksums() async throws {
+      let fixture = try await Self.sharedFixture.value
+      let storage = try StorageClient()
+
+      let options = ReadObjectOptions().with {
+        $0.checksums = .none
+      }
+      let result = storage.readObject(
+        from: fixture.bucketName, object: fixture.objectName, options: options)
+      var downloadedData = Data()
+      for try await chunk in result.body {
+        downloadedData.append(contentsOf: chunk.readableBytesView)
+      }
+      #expect(downloadedData == fixture.data)
+    }
+
+    @Test(arguments: [
+      (ChecksumOptions(crc32c: "AAAAAA==", md5: nil), "AAAAAA==", "crc32c"),
+      (ChecksumOptions(crc32c: 0x1234_5678, md5: nil), "EjRWeA==", "crc32c"),
+      (ChecksumOptions(crc32c: nil, md5: "AAAAAA=="), "AAAAAA==", "md5"),
+      (ChecksumOptions(crc32c: .auto, md5: "AAAAAA=="), "AAAAAA==", "md5"),
+    ])
+    func testDownloadMismatchedChecksumThrows(
+      checksums: ChecksumOptions,
+      expectedMismatch: String,
+      expectedAlgorithm: String
+    ) async throws {
+      let fixture = try await Self.sharedFixture.value
+      let storage = try StorageClient()
+
+      let options = ReadObjectOptions().with {
+        $0.checksums = checksums
+      }
+      let result = storage.readObject(
+        from: fixture.bucketName, object: fixture.objectName, options: options)
+      do {
+        for try await _ in result.body {}
+        Issue.record("Expected DownloadError.checksumMismatch for \(checksums)")
+      } catch let error as DownloadError {
+        if case .checksumMismatch(let expected, _, let algorithm) = error {
+          #expect(expected == expectedMismatch)
+          #expect(algorithm == expectedAlgorithm)
+        } else {
+          Issue.record("Expected .checksumMismatch, got \(error)")
+        }
+      }
+    }
+
+    @Test func testRangedDownloadChecksums() async throws {
+      let fixture = try await Self.sharedFixture.value
+      let storage = try StorageClient()
+
+      // 1. Ranged download with default .auto skips full-object checksum verification
+      let rangedAutoOptions = ReadObjectOptions().with {
+        $0.range = .bounded(start: 0, end: 9)
+      }
+      let rangedAutoResult = storage.readObject(
+        from: fixture.bucketName, object: fixture.objectName, options: rangedAutoOptions)
+      var rangedAutoData = Data()
+      for try await chunk in rangedAutoResult.body {
+        rangedAutoData.append(contentsOf: chunk.readableBytesView)
+      }
+      #expect(rangedAutoData == fixture.data.subdata(in: 0..<10))
+
+      // 2. Ranged download with user-provided expected range checksums
+      let rangeSlice = fixture.data.subdata(in: 0..<10)
+      let rangeCrc = _CRC32C.compute(rangeSlice)
+      let rangeCrcBase64 = withUnsafeBytes(of: rangeCrc.bigEndian) {
+        Data($0).base64EncodedString()
+      }
+      let rangeMd5Base64 = Data(Insecure.MD5.hash(data: rangeSlice)).base64EncodedString()
+
+      // 2a. User-provided range CRC32C
+      let rangedCrcOptions = ReadObjectOptions().with {
+        $0.range = .bounded(start: 0, end: 9)
+        $0.checksums = ChecksumOptions(crc32c: .value(rangeCrcBase64), md5: nil)
+      }
+      let rangedCrcResult = storage.readObject(
+        from: fixture.bucketName, object: fixture.objectName, options: rangedCrcOptions)
+      var rangedCrcData = Data()
+      for try await chunk in rangedCrcResult.body {
+        rangedCrcData.append(contentsOf: chunk.readableBytesView)
+      }
+      #expect(rangedCrcData == rangeSlice)
+
+      // 2b. User-provided range MD5
+      let rangedMd5Options = ReadObjectOptions().with {
+        $0.range = .bounded(start: 0, end: 9)
+        $0.checksums = ChecksumOptions(crc32c: nil, md5: .value(rangeMd5Base64))
+      }
+      let rangedMd5Result = storage.readObject(
+        from: fixture.bucketName, object: fixture.objectName, options: rangedMd5Options)
+      var rangedMd5Data = Data()
+      for try await chunk in rangedMd5Result.body {
+        rangedMd5Data.append(contentsOf: chunk.readableBytesView)
+      }
+      #expect(rangedMd5Data == rangeSlice)
+    }
+
+    @Test(arguments: [
+      (ChecksumOptions(crc32c: "bad_crc_range", md5: nil), "bad_crc_range", "crc32c"),
+      (ChecksumOptions(crc32c: nil, md5: "bad_md5_range"), "bad_md5_range", "md5"),
+    ])
+    func testRangedDownloadMismatchedChecksumThrows(
+      checksums: ChecksumOptions,
+      expectedMismatch: String,
+      expectedAlgorithm: String
+    ) async throws {
+      let fixture = try await Self.sharedFixture.value
+      let storage = try StorageClient()
+
+      let options = ReadObjectOptions().with {
+        $0.range = .bounded(start: 0, end: 9)
+        $0.checksums = checksums
+      }
+      let result = storage.readObject(
+        from: fixture.bucketName, object: fixture.objectName, options: options)
+      do {
+        for try await _ in result.body {}
+        Issue.record("Expected DownloadError.checksumMismatch on invalid range checksum")
+      } catch let error as DownloadError {
+        if case .checksumMismatch(let expected, _, let algorithm) = error {
+          #expect(expected == expectedMismatch)
+          #expect(algorithm == expectedAlgorithm)
+        } else {
+          Issue.record("Expected .checksumMismatch, got \(error)")
+        }
+      }
+    }
+  }
+
+#endif


### PR DESCRIPTION
Fixes #467

Note: we also refactor the logic for collecting checksum values so it can be shared between upload and download workflows.