### PR TITLE
feat(gax): add routing parameter matcher and segment encoder

### DIFF
--- a/packages/gax/Sources/GoogleCloudGaxGRPC/RoutingMatcher.swift
+++ b/packages/gax/Sources/GoogleCloudGaxGRPC/RoutingMatcher.swift
@@ -1,0 +1,126 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+@_spi(GoogleCloudInternal) import GoogleCloudGax
+
+/// Represents a segment in a routing parameter path template per AIP-4222.
+@_spi(GoogleCloudInternal)
+public enum _RoutingSegment: Sendable, Equatable {
+  /// A literal string, matches its exact prefix value.
+  case literal(String)
+  /// Matches any value satisfying `[^/]+` (up to the next `/` or end of string).
+  case singleWildcard
+  /// Matches any value, including empty strings.
+  case multiWildcard
+  /// Matches any value satisfying `([:/].*)?` or empty string.
+  case trailingMultiWildcard
+
+  func matchLength(in haystack: Substring) -> Int? {
+    switch self {
+    case .literal(let lit):
+      return haystack.hasPrefix(lit) ? lit.count : nil
+    case .singleWildcard:
+      if haystack.isEmpty || haystack.hasPrefix("/") {
+        return nil
+      }
+      if let slashIndex = haystack.firstIndex(of: "/") {
+        return haystack.distance(from: haystack.startIndex, to: slashIndex)
+      }
+      return haystack.count
+    case .multiWildcard:
+      return haystack.count
+    case .trailingMultiWildcard:
+      if haystack.isEmpty {
+        return 0
+      }
+      if haystack.hasPrefix("/") || haystack.hasPrefix(":") {
+        return haystack.count
+      }
+      return nil
+    }
+  }
+}
+
+/// Helper for extracting and formatting AIP-4222 gRPC routing metadata parameters.
+@_spi(GoogleCloudInternal)
+public enum _RoutingMatcher {
+  /// The RFC 6570 Section 1.5 unreserved character set: `ALPHA / DIGIT / - / . / _ / ~`.
+  private static let unreservedCharacterSet = CharacterSet(
+    charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~"
+  )
+
+  /// Percent-encodes a string according to RFC 6570 Section 3.2.2.
+  public static func encode(_ value: String) -> String {
+    value.addingPercentEncoding(withAllowedCharacters: unreservedCharacterSet) ?? value
+  }
+
+  /// Formats a single key and value into a percent-encoded `key=value` string.
+  public static func format(key: String, value: String) -> String {
+    "\(encode(key))=\(encode(value))"
+  }
+
+  /// Formats a list of key-value pairs into an array of percent-encoded `key=value` strings.
+  public static func format(_ matches: [(key: String, value: String?)]) -> [String] {
+    matches.compactMap { key, value in
+      guard let value, !value.isEmpty else { return nil }
+      return format(key: key, value: value)
+    }
+  }
+
+  /// Extracts a routing parameter value from `haystack` using decomposed template segments.
+  ///
+  /// - Parameters:
+  ///   - haystack: The input string to match against.
+  ///   - prefix: Initial template segments that must match, not included in the result.
+  ///   - matching: Template segments that must match, included in the result.
+  ///   - suffix: Trailing template segments that must match, not included in the result.
+  /// - Returns: The extracted segment string if matched, or `nil`.
+  public static func value(
+    _ haystack: String?,
+    prefix: [_RoutingSegment] = [],
+    matching: [_RoutingSegment],
+    suffix: [_RoutingSegment] = []
+  ) -> String? {
+    guard let haystack, !haystack.isEmpty else { return nil }
+
+    var remains = Substring(haystack)
+    var startOffset = 0
+    var endOffset = 0
+
+    for needle in prefix {
+      guard let count = needle.matchLength(in: remains) else { return nil }
+      startOffset += count
+      endOffset += count
+      remains = remains.dropFirst(count)
+    }
+
+    for needle in matching {
+      guard let count = needle.matchLength(in: remains) else { return nil }
+      endOffset += count
+      remains = remains.dropFirst(count)
+    }
+
+    for needle in suffix {
+      guard let count = needle.matchLength(in: remains) else { return nil }
+      remains = remains.dropFirst(count)
+    }
+
+    guard remains.isEmpty, startOffset < endOffset else { return nil }
+
+    let start = haystack.index(haystack.startIndex, offsetBy: startOffset)
+    let end = haystack.index(haystack.startIndex, offsetBy: endOffset)
+    return String(haystack[start..<end])
+  }
+}

--- a/packages/gax/Tests/RoutingMatcherTests.swift
+++ b/packages/gax/Tests/RoutingMatcherTests.swift
@@ -26,7 +26,9 @@ import Testing
 
     // Slashes and other reserved/special characters must be encoded
     #expect(_RoutingMatcher.encode("foo/bar") == "foo%2Fbar")
-    #expect(_RoutingMatcher.encode("projects/_/buckets/my-bucket") == "projects%2F_%2Fbuckets%2Fmy-bucket")
+    #expect(
+      _RoutingMatcher.encode("projects/_/buckets/my-bucket") == "projects%2F_%2Fbuckets%2Fmy-bucket"
+    )
     #expect(_RoutingMatcher.encode("foo=bar&baz=qux") == "foo%3Dbar%26baz%3Dqux")
     #expect(_RoutingMatcher.encode("hello world") == "hello%20world")
   }
@@ -49,10 +51,11 @@ import Testing
       ("source_bucket", "projects/_/buckets/s"),
       ("blank", ""),
     ])
-    #expect(params == [
-      "bucket=projects%2F_%2Fbuckets%2Fd",
-      "source_bucket=projects%2F_%2Fbuckets%2Fs",
-    ])
+    #expect(
+      params == [
+        "bucket=projects%2F_%2Fbuckets%2Fd",
+        "source_bucket=projects%2F_%2Fbuckets%2Fs",
+      ])
   }
 
   @Test func matchEntireMultiWildcard() {
@@ -164,14 +167,16 @@ import Testing
     let reqName: String? = "invalid-name"
     let reqParent: String? = "projects/p/buckets/b"
 
-    let extracted = _RoutingMatcher.value(
-      reqName,
-      prefix: [.literal("projects/"), .singleWildcard, .literal("/locations/")],
-      matching: [.singleWildcard]
-    ) ?? _RoutingMatcher.value(
-      reqParent,
-      matching: [.multiWildcard]
-    )
+    let extracted =
+      _RoutingMatcher.value(
+        reqName,
+        prefix: [.literal("projects/"), .singleWildcard, .literal("/locations/")],
+        matching: [.singleWildcard]
+      )
+      ?? _RoutingMatcher.value(
+        reqParent,
+        matching: [.multiWildcard]
+      )
 
     #expect(extracted == "projects/p/buckets/b")
   }

--- a/packages/gax/Tests/RoutingMatcherTests.swift
+++ b/packages/gax/Tests/RoutingMatcherTests.swift
@@ -1,0 +1,178 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+@_spi(GoogleCloudInternal) import GoogleCloudGaxGRPC
+import Testing
+
+@Suite struct RoutingMatcherTests {
+  @Test func rfc6570PercentEncoding() {
+    // RFC 6570 Section 1.5 unreserved: ALPHA / DIGIT / - / . / _ / ~
+    #expect(_RoutingMatcher.encode("abcdefghijklmnopqrstuvwxyz") == "abcdefghijklmnopqrstuvwxyz")
+    #expect(_RoutingMatcher.encode("ABCDEFGHIJKLMNOPQRSTUVWXYZ") == "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+    #expect(_RoutingMatcher.encode("0123456789") == "0123456789")
+    #expect(_RoutingMatcher.encode("-._~") == "-._~")
+
+    // Slashes and other reserved/special characters must be encoded
+    #expect(_RoutingMatcher.encode("foo/bar") == "foo%2Fbar")
+    #expect(_RoutingMatcher.encode("projects/_/buckets/my-bucket") == "projects%2F_%2Fbuckets%2Fmy-bucket")
+    #expect(_RoutingMatcher.encode("foo=bar&baz=qux") == "foo%3Dbar%26baz%3Dqux")
+    #expect(_RoutingMatcher.encode("hello world") == "hello%20world")
+  }
+
+  @Test func formatKeyValue() {
+    #expect(
+      _RoutingMatcher.format(key: "bucket", value: "projects/_/buckets/my-bucket")
+        == "bucket=projects%2F_%2Fbuckets%2Fmy-bucket"
+    )
+    #expect(
+      _RoutingMatcher.format(key: "table/name", value: "a/b/c")
+        == "table%2Fname=a%2Fb%2Fc"
+    )
+  }
+
+  @Test func formatList() {
+    let params = _RoutingMatcher.format([
+      ("bucket", "projects/_/buckets/d"),
+      ("empty", nil),
+      ("source_bucket", "projects/_/buckets/s"),
+      ("blank", ""),
+    ])
+    #expect(params == [
+      "bucket=projects%2F_%2Fbuckets%2Fd",
+      "source_bucket=projects%2F_%2Fbuckets%2Fs",
+    ])
+  }
+
+  @Test func matchEntireMultiWildcard() {
+    let match = _RoutingMatcher.value(
+      "projects/my-project/buckets/my-bucket",
+      matching: [.multiWildcard]
+    )
+    #expect(match == "projects/my-project/buckets/my-bucket")
+  }
+
+  @Test func matchPrefixAndSingleWildcard() {
+    let match = _RoutingMatcher.value(
+      "projects/my-project/locations/us-central1",
+      prefix: [.literal("projects/"), .singleWildcard, .literal("/locations/")],
+      matching: [.singleWildcard]
+    )
+    #expect(match == "us-central1")
+  }
+
+  @Test func matchGcsBucketWithTrailingWildcard() {
+    // Pattern: {bucket=projects/*/buckets/*}/** on "projects/p/buckets/b/folders/f"
+    let match1 = _RoutingMatcher.value(
+      "projects/my-proj/buckets/test-bucket/folders/my-folder",
+      matching: [
+        .literal("projects/"),
+        .singleWildcard,
+        .literal("/buckets/"),
+        .singleWildcard,
+      ],
+      suffix: [.trailingMultiWildcard]
+    )
+    #expect(match1 == "projects/my-proj/buckets/test-bucket")
+
+    // Without trailing path segments
+    let match2 = _RoutingMatcher.value(
+      "projects/_/buckets/test-bucket",
+      matching: [
+        .literal("projects/"),
+        .singleWildcard,
+        .literal("/buckets/"),
+        .singleWildcard,
+      ],
+      suffix: [.trailingMultiWildcard]
+    )
+    #expect(match2 == "projects/_/buckets/test-bucket")
+
+    // With storageLayout suffix
+    let match3 = _RoutingMatcher.value(
+      "projects/_/buckets/test-bucket/storageLayout",
+      matching: [
+        .literal("projects/"),
+        .singleWildcard,
+        .literal("/buckets/"),
+        .singleWildcard,
+      ],
+      suffix: [.trailingMultiWildcard]
+    )
+    #expect(match3 == "projects/_/buckets/test-bucket")
+  }
+
+  @Test func matchWithPrefixAndSuffix() {
+    // projects/p/locations/l/instances/i/tables/t
+    let match = _RoutingMatcher.value(
+      "projects/p/locations/l/instances/i/tables/t",
+      prefix: [
+        .literal("projects/"),
+        .singleWildcard,
+        .literal("/locations/"),
+        .singleWildcard,
+        .literal("/"),
+      ],
+      matching: [
+        .literal("instances/"),
+        .singleWildcard,
+      ],
+      suffix: [
+        .literal("/tables"),
+        .trailingMultiWildcard,
+      ]
+    )
+    #expect(match == "instances/i")
+  }
+
+  @Test func matchMismatchCases() {
+    #expect(_RoutingMatcher.value(nil, matching: [.multiWildcard]) == nil)
+    #expect(_RoutingMatcher.value("", matching: [.multiWildcard]) == nil)
+
+    // Prefix mismatch
+    #expect(
+      _RoutingMatcher.value(
+        "organizations/123/locations/us",
+        prefix: [.literal("projects/"), .singleWildcard, .literal("/locations/")],
+        matching: [.singleWildcard]
+      ) == nil
+    )
+
+    // Suffix mismatch
+    #expect(
+      _RoutingMatcher.value(
+        "projects/p/locations/us/extra",
+        prefix: [.literal("projects/"), .singleWildcard, .literal("/locations/")],
+        matching: [.singleWildcard],
+        suffix: [.literal("/zones/z")]
+      ) == nil
+    )
+  }
+
+  @Test func fallbackChaining() {
+    let reqName: String? = "invalid-name"
+    let reqParent: String? = "projects/p/buckets/b"
+
+    let extracted = _RoutingMatcher.value(
+      reqName,
+      prefix: [.literal("projects/"), .singleWildcard, .literal("/locations/")],
+      matching: [.singleWildcard]
+    ) ?? _RoutingMatcher.value(
+      reqParent,
+      matching: [.multiWildcard]
+    )
+
+    #expect(extracted == "projects/p/buckets/b")
+  }
+}


### PR DESCRIPTION
add runtime routing parameter extraction and formatting support for gRPC transports in `GoogleCloudGaxGRPC

for https://github.com/googleapis/google-cloud-swift/issues/479 