### PR TITLE
cleanup!: more internal types are `@_spi()`

### DIFF
--- a/Tests/Discovery/DiscoveryBytes.swift
+++ b/Tests/Discovery/DiscoveryBytes.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 // Verify the generated code can deserialize `bytes` as url-safe base64 encoded strings.
 //

--- a/Tests/ProtoJSON/FieldsBool.swift
+++ b/Tests/ProtoJSON/FieldsBool.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct BoolFields {
   typealias T = MessageWithBool

--- a/Tests/ProtoJSON/FieldsBoolValue.swift
+++ b/Tests/ProtoJSON/FieldsBoolValue.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsBoolValue {
   typealias T = MessageWithBoolValue

--- a/Tests/ProtoJSON/FieldsBytes.swift
+++ b/Tests/ProtoJSON/FieldsBytes.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct BytesFields {
   typealias T = MessageWithBytes

--- a/Tests/ProtoJSON/FieldsBytesValue.swift
+++ b/Tests/ProtoJSON/FieldsBytesValue.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsBytesValue {
   typealias T = MessageWithBytesValue

--- a/Tests/ProtoJSON/FieldsDouble.swift
+++ b/Tests/ProtoJSON/FieldsDouble.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct DoubleFields {
   typealias T = MessageWithF64

--- a/Tests/ProtoJSON/FieldsDoubleValue.swift
+++ b/Tests/ProtoJSON/FieldsDoubleValue.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsDoubleValue {
   typealias T = MessageWithDoubleValue

--- a/Tests/ProtoJSON/FieldsEnum.swift
+++ b/Tests/ProtoJSON/FieldsEnum.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsEnum {
   typealias T = MessageWithEnum

--- a/Tests/ProtoJSON/FieldsFieldMask.swift
+++ b/Tests/ProtoJSON/FieldsFieldMask.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsFieldMask {
   typealias T = MessageWithFieldMask

--- a/Tests/ProtoJSON/FieldsFloat.swift
+++ b/Tests/ProtoJSON/FieldsFloat.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FloatFields {
   typealias T = MessageWithF32

--- a/Tests/ProtoJSON/FieldsFloatValue.swift
+++ b/Tests/ProtoJSON/FieldsFloatValue.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsFloatValue {
   typealias T = MessageWithFloatValue

--- a/Tests/ProtoJSON/FieldsInt32.swift
+++ b/Tests/ProtoJSON/FieldsInt32.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct Int32Fields {
   typealias T = MessageWithI32

--- a/Tests/ProtoJSON/FieldsInt32Value.swift
+++ b/Tests/ProtoJSON/FieldsInt32Value.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsInt32Value {
   typealias T = MessageWithInt32Value

--- a/Tests/ProtoJSON/FieldsInt64.swift
+++ b/Tests/ProtoJSON/FieldsInt64.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct Int64Fields {
   typealias T = MessageWithI64

--- a/Tests/ProtoJSON/FieldsInt64Value.swift
+++ b/Tests/ProtoJSON/FieldsInt64Value.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsInt64Value {
   typealias T = MessageWithInt64Value

--- a/Tests/ProtoJSON/FieldsListValue.swift
+++ b/Tests/ProtoJSON/FieldsListValue.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsListValue {
   typealias T = MessageWithListValue

--- a/Tests/ProtoJSON/FieldsNullValue.swift
+++ b/Tests/ProtoJSON/FieldsNullValue.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsNullValue {
   typealias T = MessageWithNullValue

--- a/Tests/ProtoJSON/FieldsRecursion.swift
+++ b/Tests/ProtoJSON/FieldsRecursion.swift
@@ -14,8 +14,7 @@
 
 import Foundation
 import Testing
-
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsRecursion {
   @Test(

--- a/Tests/ProtoJSON/FieldsString.swift
+++ b/Tests/ProtoJSON/FieldsString.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct StringFields {
   typealias T = MessageWithString

--- a/Tests/ProtoJSON/FieldsStringValue.swift
+++ b/Tests/ProtoJSON/FieldsStringValue.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsStringValue {
   typealias T = MessageWithStringValue

--- a/Tests/ProtoJSON/FieldsStruct.swift
+++ b/Tests/ProtoJSON/FieldsStruct.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsStruct {
   typealias T = MessageWithStruct

--- a/Tests/ProtoJSON/FieldsUInt32.swift
+++ b/Tests/ProtoJSON/FieldsUInt32.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct UInt32Fields {
   typealias T = MessageWithU32

--- a/Tests/ProtoJSON/FieldsUInt32Value.swift
+++ b/Tests/ProtoJSON/FieldsUInt32Value.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsUInt32Value {
   typealias T = MessageWithUInt32Value

--- a/Tests/ProtoJSON/FieldsUInt64.swift
+++ b/Tests/ProtoJSON/FieldsUInt64.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct UInt64Fields {
   typealias T = MessageWithU64

--- a/Tests/ProtoJSON/FieldsUInt64Value.swift
+++ b/Tests/ProtoJSON/FieldsUInt64Value.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsUInt64Value {
   typealias T = MessageWithUInt64Value

--- a/Tests/ProtoJSON/FieldsValue.swift
+++ b/Tests/ProtoJSON/FieldsValue.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct FieldsValue {
   typealias T = MessageWithValue

--- a/Tests/ProtoJSON/OneOfsTests.swift
+++ b/Tests/ProtoJSON/OneOfsTests.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct OneOfsTests {
   @Test(

--- a/Tests/QueryParameter/QueryParameterTests.swift
+++ b/Tests/QueryParameter/QueryParameterTests.swift
@@ -14,9 +14,9 @@
 
 import Foundation
 import Testing
-import GoogleCloudGax
 import GoogleCloudWkt
 import GoogleCloudSecurityPublicCAV1
+@_spi(GoogleCloudInternal) import GoogleCloudGax
 
 struct WellKnown: Encodable {
   let duration: GoogleCloudWkt.Duration?

--- a/packages/gax/Package.swift
+++ b/packages/gax/Package.swift
@@ -69,7 +69,6 @@ let package = Package(
         .product(name: "GoogleRpc", package: "google-rpc"),
       ],
       path: "Tests",
-      exclude: ["IntegrationTests"]
     ),
   ]
 )

--- a/packages/gax/Sources/GoogleCloudGax/ErrorWrapper.swift
+++ b/packages/gax/Sources/GoogleCloudGax/ErrorWrapper.swift
@@ -17,7 +17,7 @@ import struct AsyncHTTPClient.HTTPClientResponse
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 import GoogleRpc
 
 /// The services send errors using this structure.

--- a/packages/gax/Sources/GoogleCloudGax/HTTPClientResponse.swift
+++ b/packages/gax/Sources/GoogleCloudGax/HTTPClientResponse.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import Foundation
-import class GoogleCloudWkt._ProtoJSONDecoder
+@_spi(GoogleCloudInternal) import class GoogleCloudWkt._ProtoJSONDecoder
 import struct AsyncHTTPClient.HTTPClientResponse
 import struct NIOHTTP1.HTTPHeaders
 import enum NIOHTTP1.HTTPResponseStatus

--- a/packages/gax/Sources/GoogleCloudGax/LongRunningOperations.swift
+++ b/packages/gax/Sources/GoogleCloudGax/LongRunningOperations.swift
@@ -33,6 +33,9 @@ public protocol PollableOperation<ResponseType> {
 ///
 /// This class implements a generic polling loop with a backoff policy to avoid overloading the
 /// server with status requests.
+///
+/// The class cannot be marked as `@_spi()` because it is the returned type
+/// for public methods.
 public final class _PollableOperationImpl<ResponseType>: PollableOperation {
   /// Represents the current state of the long-running operation.
   public struct State {

--- a/packages/gax/Sources/GoogleCloudGax/QueryParameter.swift
+++ b/packages/gax/Sources/GoogleCloudGax/QueryParameter.swift
@@ -22,7 +22,7 @@ import Foundation
 ///     <https://github.com/googleapis/googleapis/blob/16b4737e7b870914e0c384b87f0e50ed388aa225/google/api/http.proto#L87-L118>
 ///
 /// This type implements the rules for any encodable type, including well-known types.
-public class QueryParameterEncoder {
+@_spi(GoogleCloudInternal) public class QueryParameterEncoder {
   public init() {}
 
   /// Encodes `value` as an array of query parameters with `prefix` as the base name.

--- a/packages/gax/Tests/QueryParameterEncoderTests.swift
+++ b/packages/gax/Tests/QueryParameterEncoderTests.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-@testable import GoogleCloudGax
+@_spi(GoogleCloudInternal) @testable import GoogleCloudGax
 
 @Suite struct QueryParameterEncoderTests {
   @Test func encodeSimpleTypes() throws {

--- a/packages/gax/Tests/StatusDetailTests.swift
+++ b/packages/gax/Tests/StatusDetailTests.swift
@@ -14,9 +14,9 @@
 
 import Foundation
 import Testing
-@testable import GoogleCloudGax
 import GoogleCloudWkt
 import GoogleRpc
+@testable import GoogleCloudGax
 
 @Suite struct StatusDetailTests {
   @Test func badRequest() throws {
@@ -138,17 +138,7 @@ import GoogleRpc
   }
 
   @Test func other() throws {
-    struct BadRetryInfo: Codable, GoogleCloudWkt._AnyPackable {
-      static var _anyTypeUrl: String { return "type.googleapis.com/google.rpc.BadRetryInfo" }
-      var retryDelay: String = "invalid"
-      func _pack() throws -> GoogleCloudWkt.Struct {
-        return try GoogleCloudWkt._slowAnySerialize(message: self)
-      }
-      init() {}
-      init(fromAny any: GoogleCloudWkt.`Any`) throws { fatalError() }
-    }
-
-    let input = BadRetryInfo()
+    let input = GoogleCloudWkt.Api()  // A valid message, but unexpected in status details.
     let asAny = try GoogleCloudWkt.`Any`(fromMessage: input)
     let detail = StatusDetail(from: asAny)
     guard case let .other(got) = detail else {

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -17,7 +17,7 @@ import Foundation
   import FoundationNetworking
 #endif
 import GoogleCloudGax
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 @_spi(GoogleCloudInternal) import struct GoogleCloudGax._CRC32C
 import Crypto
 @_spi(GoogleCloudInternal) import GoogleCloudGax

--- a/packages/storage/Tests/ObjectV1ResponseTests.swift
+++ b/packages/storage/Tests/ObjectV1ResponseTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import Foundation
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 @testable import GoogleCloudStorage
 import Testing
 

--- a/packages/storage/Tests/StorageObjectTests.swift
+++ b/packages/storage/Tests/StorageObjectTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import Foundation
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 @testable import GoogleCloudStorage
 import Testing
 

--- a/packages/storage/Tests/UploadMetadataTests.swift
+++ b/packages/storage/Tests/UploadMetadataTests.swift
@@ -15,7 +15,7 @@
 import Foundation
 import GoogleCloudAuth
 @_spi(GoogleCloudInternal) import GoogleCloudGax
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 @_spi(GoogleCloudInternal) @testable import GoogleCloudStorage
 import Testing
 

--- a/packages/wkt/Sources/GoogleCloudWkt/AnyPackable.swift
+++ b/packages/wkt/Sources/GoogleCloudWkt/AnyPackable.swift
@@ -15,6 +15,12 @@
 import Foundation
 
 /// A type conforming to the `_AnyPackable` protocol can be packed into and unpacked from ``Any``.
+///
+/// This protocol is an implementation detail of the Google Cloud client libraries for Swift.
+/// Do not use it directly.
+///
+/// For `google-cloud-swift` developers: while it would be desirable to make this type `@_spi()` we
+/// cannot because then normal types like ``Api`` cannot use it.
 public protocol _AnyPackable {
   static var _anyTypeUrl: String { get }
   init(fromAny any: `Any`) throws
@@ -22,6 +28,7 @@ public protocol _AnyPackable {
 }
 
 // Deserializes a message of type `M` from an `Any`.
+@_spi(GoogleCloudInternal)
 public func _slowAnyDeserialize<M: Decodable & _AnyPackable>(
   _ type: M.Type, from: `Any`
 ) throws -> M {
@@ -36,6 +43,7 @@ public func _slowAnyDeserialize<M: Decodable & _AnyPackable>(
 }
 
 // Serializes a message of type `M` into an `Any`.
+@_spi(GoogleCloudInternal)
 public func _slowAnySerialize<M: Encodable>(message: M) throws -> Struct {
   let encoder = JSONEncoder()
   encoder.outputFormatting = [.withoutEscapingSlashes]

--- a/packages/wkt/Sources/GoogleCloudWkt/DiscoveryBase64.swift
+++ b/packages/wkt/Sources/GoogleCloudWkt/DiscoveryBase64.swift
@@ -22,7 +22,7 @@ private import ExtrasBase64
 ///   <https://datatracker.ietf.org/doc/html/rfc4648#section-5>
 ///
 /// We use an external dependency because, on macOS < 26, Swift does not support url-safe encoding.
-public enum _DiscoveryBase64 {
+@_spi(GoogleCloudInternal) public enum _DiscoveryBase64 {
   /// Encodes `input` into a base64url string.
   public static func encode(_ input: Data) -> String {
     return String(

--- a/packages/wkt/Sources/GoogleCloudWkt/ProtoJSONDecoder.swift
+++ b/packages/wkt/Sources/GoogleCloudWkt/ProtoJSONDecoder.swift
@@ -30,7 +30,7 @@ import Foundation
 /// Unfortunately the system types conforming to the `Decoder` protocol are not public, they cannot be named to implement
 /// any wrapper types. The approach is to use an `Interceptor<T>` type that implements `Decodable` and wraps the `any Decoder`
 /// it receives.
-public class _ProtoJSONDecoder {
+@_spi(GoogleCloudInternal) public class _ProtoJSONDecoder {
   public init() {}
 
   public func decode<T>(_ type: T.Type, from: Data) throws -> T where T: Decodable {

--- a/packages/wkt/Tests/Any/BasicMessage.swift
+++ b/packages/wkt/Tests/Any/BasicMessage.swift
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import Foundation
-import GoogleCloudWkt
 import Testing
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 extension AnyTests {
   struct BasicMessage: Codable, Equatable, Sendable {

--- a/packages/wkt/Tests/DiscoveryBase64Tests.swift
+++ b/packages/wkt/Tests/DiscoveryBase64Tests.swift
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import Foundation
-import GoogleCloudWkt
 import Testing
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct Base64Tests {
   @Test(arguments: [

--- a/packages/wkt/Tests/ProtoJSONDecoder.swift
+++ b/packages/wkt/Tests/ProtoJSONDecoder.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 @Suite struct ProtoJSONDecoderTest {
   @Test func decodeMissingMapNested() throws {

--- a/packages/wkt/Tests/ProtoJSONDecoder/MapPrimitives.swift
+++ b/packages/wkt/Tests/ProtoJSONDecoder/MapPrimitives.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 extension ProtoJSONDecoderTest {
   // Only test the types that appear in sidekick messages

--- a/packages/wkt/Tests/ProtoJSONDecoder/OptionalPrimitives.swift
+++ b/packages/wkt/Tests/ProtoJSONDecoder/OptionalPrimitives.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 extension ProtoJSONDecoderTest {
   // Only test the types that appear in sidekick messages

--- a/packages/wkt/Tests/ProtoJSONDecoder/RepeatedPrimitives.swift
+++ b/packages/wkt/Tests/ProtoJSONDecoder/RepeatedPrimitives.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 extension ProtoJSONDecoderTest {
   // Only test the types that appear in sidekick messages

--- a/packages/wkt/Tests/ProtoJSONDecoder/RequiredPrimitives.swift
+++ b/packages/wkt/Tests/ProtoJSONDecoder/RequiredPrimitives.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Testing
-import GoogleCloudWkt
+@_spi(GoogleCloudInternal) import GoogleCloudWkt
 
 extension ProtoJSONDecoderTest {
   // Only test the types that appear in sidekick messages


### PR DESCRIPTION
Mark several types as `@_spi()`, document why some protocols cannot be, and fix the tests add the necessary attributes in their imports.

Towards #13 