### PR TITLE
cleanup(gax): introduce `_QueryParameterEncoder`

### DIFF
--- a/Tests/QueryParameter/QueryParameterTests.swift
+++ b/Tests/QueryParameter/QueryParameterTests.swift
@@ -35,7 +35,7 @@ struct WellKnown: Encodable {
     maskMany: [mask]
   )
 
-  let encoder = QueryParameterEncoder()
+  let encoder = _QueryParameterEncoder()
   let items = try encoder.encode(value, prefix: "fieldName")
   let sortedItems = items.sorted { $0.name < $1.name }
 
@@ -57,7 +57,7 @@ struct WellKnown: Encodable {
     maskMany: []
   )
 
-  let encoder = QueryParameterEncoder()
+  let encoder = _QueryParameterEncoder()
   let items = try encoder.encode(value, prefix: "fieldName")
   #expect(items == [URLQueryItem(name: "fieldName.duration", value: "123.450s")])
 }
@@ -71,7 +71,7 @@ struct WellKnown: Encodable {
     maskMany: []
   )
 
-  let encoder = QueryParameterEncoder()
+  let encoder = _QueryParameterEncoder()
   let items = try encoder.encode(value, prefix: "fieldName")
   #expect(items == [URLQueryItem(name: "fieldName.mask", value: "userId")])
 }
@@ -86,7 +86,7 @@ struct WellKnown: Encodable {
     }
   }
 
-  let encoder = QueryParameterEncoder()
+  let encoder = _QueryParameterEncoder()
   let items = try encoder.encode(request, prefix: "fieldName")
   let sortedItems = items.sorted { $0.name < $1.name }
 
@@ -105,7 +105,7 @@ struct WellKnown: Encodable {
     $0.externalAccountKey = nil
   }
 
-  let encoder = QueryParameterEncoder()
+  let encoder = _QueryParameterEncoder()
   let items = try encoder.encode(request, prefix: "fieldName")
   #expect(
     items == [URLQueryItem(name: "fieldName.parent", value: "projects/my-project/locations/global")]
@@ -113,7 +113,7 @@ struct WellKnown: Encodable {
 }
 
 @Test func testPrefixSerialization() throws {
-  let encoder = QueryParameterEncoder()
+  let encoder = _QueryParameterEncoder()
   let duration = try GoogleCloudWkt.Duration(seconds: 123, nanos: 450_000_000)
 
   let items = try encoder.encode(duration, prefix: "myPrefix")

--- a/packages/gax/Sources/GoogleCloudGax/QueryParameter.swift
+++ b/packages/gax/Sources/GoogleCloudGax/QueryParameter.swift
@@ -22,7 +22,7 @@ import Foundation
 ///     <https://github.com/googleapis/googleapis/blob/16b4737e7b870914e0c384b87f0e50ed388aa225/google/api/http.proto#L87-L118>
 ///
 /// This type implements the rules for any encodable type, including well-known types.
-@_spi(GoogleCloudInternal) public class QueryParameterEncoder {
+@_spi(GoogleCloudInternal) public class _QueryParameterEncoder {
   public init() {}
 
   /// Encodes `value` as an array of query parameters with `prefix` as the base name.
@@ -39,6 +39,17 @@ import Foundation
   ///     of each field in the struct.
   ///
   /// - Throws: an error if the value cannot be serialized, though this should be rare.
+  public func encode<T: Encodable>(_ value: T, prefix: String) throws -> [URLQueryItem] {
+    let encoder = InternalEncoder(prefix: prefix)
+    try value.encode(to: encoder)
+    return encoder.queryItems
+  }
+}
+
+// TODO(https://github.com/googleapis/google-cloud-swift/issues/13) - remove once the generator stops using it
+@_spi(GoogleCloudInternal) public class QueryParameterEncoder {
+  public init() {}
+
   public func encode<T: Encodable>(_ value: T, prefix: String) throws -> [URLQueryItem] {
     let encoder = InternalEncoder(prefix: prefix)
     try value.encode(to: encoder)

--- a/packages/gax/Tests/HTTPClientV2Tests.swift
+++ b/packages/gax/Tests/HTTPClientV2Tests.swift
@@ -290,7 +290,7 @@ import NIOHTTP1
     var query = [
       URLQueryItem(name: "$alt", value: "json;enum-encoding=int")
     ]
-    let encoder = GoogleCloudGax.QueryParameterEncoder()
+    let encoder = GoogleCloudGax._QueryParameterEncoder()
     query.append(contentsOf: try encoder.encode("test-only-thing-id", prefix: "thingId"))
     var req = try await client.newRequest(path: path, query: query)
     req.setMethod(.POST)

--- a/packages/gax/Tests/QueryParameterEncoderTests.swift
+++ b/packages/gax/Tests/QueryParameterEncoderTests.swift
@@ -18,7 +18,7 @@ import Testing
 
 @Suite struct QueryParameterEncoderTests {
   @Test func encodeSimpleTypes() throws {
-    let encoder = QueryParameterEncoder()
+    let encoder = _QueryParameterEncoder()
 
     let stringItems = try encoder.encode("hello", prefix: "field")
     #expect(stringItems == [URLQueryItem(name: "field", value: "hello")])
@@ -41,7 +41,7 @@ import Testing
   }
 
   @Test func encodeRecursiveTypes() throws {
-    let encoder = QueryParameterEncoder()
+    let encoder = _QueryParameterEncoder()
     let user = User(name: "Bob", address: Address(city: "Seattle"), roles: ["admin", "editor"])
 
     let items = try encoder.encode(user, prefix: "test")


### PR DESCRIPTION
I want to rename `QueryParameterEncoder` to `_QueryParameterEncoder`, I will do this over two PRs because the generator needs changes to stop using the previous anem.

In this first one I copy the type (no biggie, it is like 10 lines of code). That makes it possible to change the tests.

In a second PR I will update the generator with a version that uses the new name. I can remove the old name at that point.

Towards https://github.com/googleapis/google-cloud-swift/issues/497 
