### PR TITLE
fix(auth)!: better errors when ADC is not configured

### DIFF
--- a/packages/auth/Sources/GoogleCloudAuth/Credentials.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/Credentials.swift
@@ -25,46 +25,6 @@ package let defaultUniverseDomain = "googleapis.com"
 /// Formatted as an array of key-value tuples to natively support duplicate header names.
 public typealias AuthHeaders = [(String, String)]
 
-/// Represents any error occurring during credentials resolution or initialization.
-public enum CredentialsError: Error, Sendable, Hashable {
-  /// Indicates that the requested operation or credential type is not supported by the current backend.
-  case notSupported(String)
-
-  /// Indicates a failure while parsing or decoding configuration data (e.g., malformed JSON key).
-  case parseError(String)
-
-  /// Application Default Credentials (ADC) could not resolve a valid configuration.
-  ///
-  /// ## Troubleshooting
-  ///
-  /// Could not fetch an auth token to authenticate with Google Cloud. The most common reason
-  /// for this problem is that you are not running in a Google Cloud environment and you have
-  /// not configured local credentials for development and testing.
-  ///
-  /// To setup local credentials, run `gcloud auth application-default login`. More information
-  /// on how to authenticate client libraries can be found at
-  /// https://cloud.google.com/docs/authentication/client-libraries
-  case missingEnvironmentConfiguration(String)
-}
-
-extension CredentialsError: LocalizedError {
-  public var errorDescription: String? {
-    switch self {
-    case .notSupported(let detail):
-      return "Operation not supported: \(detail)"
-    case .parseError(let detail):
-      return "Configuration parse error: \(detail)"
-    case .missingEnvironmentConfiguration(let context):
-      return """
-        Could not fetch an auth token to authenticate with Google Cloud. The most common reason for this problem is that you are not running in a Google Cloud environment and you have not configured local credentials for development and testing.
-        To setup local credentials, run `gcloud auth application-default login`. More information on how to authenticate client libraries can be found at https://cloud.google.com/docs/authentication/client-libraries
-
-        Context: \(context)
-        """
-    }
-  }
-}
-
 /// Represents the access specifier for a service account based token,
 /// specifying either OAuth 2.0 scopes or a JWT audience.
 ///

--- a/packages/auth/Sources/GoogleCloudAuth/CredentialsError.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/CredentialsError.swift
@@ -1,0 +1,120 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Represents any error occurring during credentials resolution or initialization.
+public enum CredentialsError: Error, Sendable {
+  /// Indicates that the requested operation or credential type is not supported by the current backend.
+  case notSupported(String)
+
+  /// Indicates a failure while parsing or decoding configuration data (e.g., malformed JSON key).
+  case parseError(String)
+
+  /// Application Default Credentials (ADC) cannot retrieve an access token.
+  ///
+  /// ## Troubleshooting
+  ///
+  /// The credentials have been configured to retrieve access tokens from a metadata server but the
+  /// token could not be retrieved. Sometimes the configuration is implicit: Application Default
+  /// Credentials default to using a metadata service if no other source is found.
+  ///
+  /// In most Google Cloud environments (GCE, GKE, Cloud Run, etc.) the metadata service is always
+  /// available and provides access tokens that, in effect, service as authentication credentials.
+  ///
+  /// There are basically four cases to consider:
+  /// - `adc == true`, `env == nil`: the credentials were configured to use a default-initialized
+  ///   ``CredentialsConfiguration``. The metadata server is just the fallback when no other
+  ///   credentials are found. The `GCE_METADATA_HOST` environment is not set, so the library uses the
+  ///   default metadata server endpoint (`http://metadata.google.internal`). The most common reason
+  ///   for this problem is that the application is **not** running in a Google Cloud environment and
+  ///   you have not configured local credentials for development and testing.
+  /// - `adc == false`, `env == nil`: the credentials were configured to use the metadata server
+  ///   explicitly. The GCE_METADATA_HOST environment is not set, so the library uses the default
+  ///   metadata server endpoint (`http://metadata.google.internal`). The most common reason for this
+  ///   problem is that the application is intended to run in a Google Cloud environment and you
+  ///   attempted to run the application elsewhere. Rarely, your administrator has disabled the
+  ///   metadata server. In this case consult with your system administrator about the recommended way
+  ///   for applications to authenticate to Google Cloud.
+  /// - `adc == true`, `env != nil`: the credentials were configured to use a default-initialized
+  ///   ``CredentialsConfiguration``The metadata server is just the fallback when no other credentials
+  ///   are found. The `GCE_METADATA_HOST` environment is set, the client library will try to use its
+  ///   value as the metadata server endpoint. Most likely, you intended to run a test using a fake
+  ///   metadata server and the fake is not running.
+  /// - `adc == false`, `env != nil`: the credentials were configured to use the metadata server
+  ///   explicitly. The `GCE_METADATA_HOST` environment is set, the client library will try to use its
+  ///   value as the metadata server endpoint. Most likely, you intended to run a test using a fake
+  ///   metadata server and the fake is not running.
+  ///
+  /// To setup local credentials, run `gcloud auth application-default login`. More information
+  /// on how to authenticate client libraries can be found at
+  /// https://cloud.google.com/docs/authentication/client-libraries
+  ///
+  case cannotFetchToken(adc: Bool, env: String?, source: any Error)
+}
+
+extension CredentialsError: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    switch self {
+    case .notSupported(let detail):
+      return "Operation not supported: \(detail)"
+    case .parseError(let detail):
+      return "Configuration parse error: \(detail)"
+    case .cannotFetchToken(let adc, let env, let error):
+      switch (adc, env) {
+      case (true, nil):
+        return
+          """
+          The credentials were configured to use `.adc()`, the default. The ADC (Application Default
+          Credentials) discovery algorith has fallen back on the metadata server, which indicates it
+          could not find any other credentials.
+          The GCE_METADATA_HOST environment variable is not set, therefore the library uses the
+          default metadata server endpoint (\(MDSAccessTokenProvider.defaultEndpoint)).
+          The most common reason for this problem is that the application is **not** running in a Google
+          Cloud environment and you have not configured local credentials for development and testing.
+          Underlying error: \(error)
+          """
+      case (false, nil):
+        return
+          """
+          The credentials were configured to use `.mds()` that is,
+          explicitly requested the metadata server.
+          The GCE_METADATA_HOST environment variable is not set, therefore the library uses the
+          default metadata server endpoint (\(MDSAccessTokenProvider.defaultEndpoint)).
+          Verify the environment where the application is running has a metadata server.
+          Underlying error: \(error)
+          """
+      case (true, let env):
+        return
+          """
+          The credentials were configured to use `.adc()`, the default. The ADC (Application Default
+          Credentials) discovery algorith has fallen back on the metadata server, which indicates it
+          could not find any other credentials.
+          The GCE_METADATA_HOST environment variable is set to '\(env ?? "")', overriding the default.
+          Verify the metadata service is running at that endpoint.
+          Underlying error: \(error)
+          """
+      case (false, let env):
+        return
+          """
+          The credentials were configured to use `.mds()` that is, explicitly requested the
+          metadata server.
+          The GCE_METADATA_HOST environment variable is set to '\(env ?? "")', overriding the default.
+          Verify the metadata service is running at that endpoint.
+          Underlying error: \(error)
+          """
+      }
+    }
+  }
+}

--- a/packages/auth/Sources/GoogleCloudAuth/CredentialsError.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/CredentialsError.swift
@@ -77,8 +77,8 @@ extension CredentialsError: CustomDebugStringConvertible {
         return
           """
           The credentials were configured to use `.adc()`, the default. The ADC (Application Default
-          Credentials) discovery algorith has fallen back on the metadata server, which indicates it
-          could not find any other credentials.
+          Credentials) discovery algorithm has fallen back on the metadata server, which indicates
+          it could not find any other credentials.
           The GCE_METADATA_HOST environment variable is not set, therefore the library uses the
           default metadata server endpoint (\(MDSAccessTokenProvider.defaultEndpoint)).
           The most common reason for this problem is that the application is **not** running in a Google
@@ -99,8 +99,8 @@ extension CredentialsError: CustomDebugStringConvertible {
         return
           """
           The credentials were configured to use `.adc()`, the default. The ADC (Application Default
-          Credentials) discovery algorith has fallen back on the metadata server, which indicates it
-          could not find any other credentials.
+          Credentials) discovery algorithm has fallen back on the metadata server, which indicates
+          it could not find any other credentials.
           The GCE_METADATA_HOST environment variable is set to '\(env ?? "")', overriding the default.
           Verify the metadata service is running at that endpoint.
           Underlying error: \(error)

--- a/packages/auth/Sources/GoogleCloudAuth/Providers/MDSAccessTokenProvider.swift
+++ b/packages/auth/Sources/GoogleCloudAuth/Providers/MDSAccessTokenProvider.swift
@@ -26,6 +26,8 @@ struct MDSAccessTokenProvider: TokenProvider, Sendable {
   let retryConfiguration: RetryConfiguration?
   let environment: [String: String]
 
+  static let defaultEndpoint = "http://metadata.google.internal"
+
   init(
     endpoint: URL? = nil,
     quotaProjectID: String? = nil,
@@ -51,15 +53,6 @@ struct MDSAccessTokenProvider: TokenProvider, Sendable {
     return true
   }
 
-  private func missingConfigurationError(targetURL: URL, underlyingError: AuthHTTPError)
-    -> CredentialsError
-  {
-    let envKeys = self.environment.keys.filter { $0.contains("GOOGLE") || $0.contains("GCE") }
-    return .missingEnvironmentConfiguration(
-      "MDS environment probe failed for target URL: \(targetURL). GCE_METADATA_HOST environment variable not found. Found environment keys: \(envKeys). Underlying error: \(underlyingError)"
-    )
-  }
-
   func fetchToken() async throws -> Token {
     let hostEnv = self.environment["GCE_METADATA_HOST"]
 
@@ -70,7 +63,7 @@ struct MDSAccessTokenProvider: TokenProvider, Sendable {
       let hostString = hostEnv.hasPrefix("http") ? hostEnv : "http://\(hostEnv)"
       baseEndpoint = URL(string: hostString)!
     } else {
-      baseEndpoint = URL(string: "http://metadata.google.internal")!
+      baseEndpoint = URL(string: Self.defaultEndpoint)!
     }
 
     var urlComponents = URLComponents(url: baseEndpoint, resolvingAgainstBaseURL: false)!
@@ -110,18 +103,8 @@ struct MDSAccessTokenProvider: TokenProvider, Sendable {
           operation: fetchOperation
         )
       }
-    } catch let error as AuthHTTPError {
-      if self.fromADC && hostEnv == nil {
-        if case .transportError = error {
-          throw self.missingConfigurationError(targetURL: url, underlyingError: error)
-        }
-        if case .unsuccessfulResponse(let response) = error, response.status == .notFound {
-          throw self.missingConfigurationError(targetURL: url, underlyingError: error)
-        }
-      }
-      throw error
     } catch {
-      throw error
+      throw CredentialsError.cannotFetchToken(adc: self.fromADC, env: hostEnv, source: error)
     }
   }
 }

--- a/packages/auth/Tests/ADCTests.swift
+++ b/packages/auth/Tests/ADCTests.swift
@@ -14,10 +14,7 @@
 
 import Foundation
 import Testing
-
 @testable import GoogleCloudAuth
-
-// MARK: - Suite: ADCTest
 
 @Suite struct ADCTest {
   @Test func resolvesToMDSCredentials() async throws {

--- a/packages/auth/Tests/CredentialsErrorTest.swift
+++ b/packages/auth/Tests/CredentialsErrorTest.swift
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+import GoogleCloudAuth
+
+@Suite struct CredentialsErrorTest {
+  @Test func notSupported() {
+    let got = CredentialsError.notSupported("-- details here --")
+    #expect(
+      got.debugDescription.contains("-- details here --"),
+      "\(got):\n\(got.debugDescription)")
+  }
+
+  @Test func parseErrorLocalized() {
+    let got = CredentialsError.parseError("-- details here --")
+    #expect(
+      got.debugDescription.contains("-- details here --"),
+      "\(got):\n\(got.debugDescription)")
+  }
+
+  @Test func cannotFetchTokenDetails() {
+    let source = CredentialsError.notSupported("--inner--")
+    let got = CredentialsError.cannotFetchToken(adc: true, env: nil, source: source)
+    #expect(
+      got.debugDescription.contains("\(source)"),
+      "\(got):\n\(got.debugDescription)")
+  }
+
+  @Test(arguments: [
+    (true, String?.none, "to use `.adc()`"),
+    (true, String?.none, "The GCE_METADATA_HOST environment variable is not set"),
+    (false, String?.none, "to use `.mds()`"),
+    (false, String?.none, "The GCE_METADATA_HOST environment variable is not set"),
+    (true, "--env-value--", "GCE_METADATA_HOST environment variable is set to '--env-value--'"),
+    (false, "--env-value--", "GCE_METADATA_HOST environment variable is set to '--env-value--'"),
+  ]) func cannotFetchToken(adc: Bool, env: String?, want: String) {
+    let source = CredentialsError.notSupported("--inner--")
+    let got = CredentialsError.cannotFetchToken(adc: adc, env: env, source: source)
+    #expect(
+      got.debugDescription.contains(want),
+      "expected `\(want)` in the localized message, got:\n\(got.debugDescription)")
+  }
+}

--- a/packages/auth/Tests/CredentialsTests.swift
+++ b/packages/auth/Tests/CredentialsTests.swift
@@ -41,6 +41,32 @@ import Testing
     )
   }
 
+  @Test func adcNotFoundError() async throws {
+    let fileManager = FileManager.default
+    let tempDirectoryURL = fileManager.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try fileManager.createDirectory(
+      at: tempDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+    defer {
+      try? fileManager.removeItem(at: tempDirectoryURL)
+    }
+    // Run with an environment that will fail.
+    let credentials = try Credentials(
+      configuration: try .adc(environment: [
+        "GCE_METADATA_HOST": "https://not-valid.internal.:1",
+        "HOME": tempDirectoryURL.absoluteString,
+        "__TEST_SIMULATE_ADC": "true",
+      ]))
+
+    let error = await #expect(throws: CredentialsError.self) {
+      try await credentials.headers()
+    }
+    guard case .cannotFetchToken = error else {
+      Issue.record("unexpected error type \(error)")
+      return
+    }
+  }
+
   @Test func resolveProviderForUserCredentials() async throws {
     let mockJSON = """
       {

--- a/packages/auth/Tests/MDSCredentialsTests.swift
+++ b/packages/auth/Tests/MDSCredentialsTests.swift
@@ -149,18 +149,11 @@ import Testing
     let provider = MDSCredentials(client: client, fromADC: true, environment: [:])
     let error = await #expect(throws: CredentialsError.self) { _ = try await provider.headers() }
 
-    if let error = error {
-      #expect(
-        error.localizedDescription.contains("application-default"),
-        "Localized description lacks application-default troubleshooting context: \(error.localizedDescription)"
-      )
-
-      if case let .missingEnvironmentConfiguration(payload) = error {
-        #expect(
-          payload.contains("GCE_METADATA_HOST"),
-          "Error payload lacks specific environment diagnostic info: \(payload)"
-        )
-      }
+    if case let .cannotFetchToken(adc, env, _) = error {
+      #expect(adc == true, "Error details: \(error)")
+      #expect(env == nil, "Error details: \(error)")
+    } else {
+      Issue.record("Unexpected error type: \(error)")
     }
   }
 
@@ -173,8 +166,15 @@ import Testing
     ])
     let client = AuthHTTPClient(mock: mock)
     let provider = MDSCredentials(
-      client: client, fromADC: true, environment: ["GCE_METADATA_HOST": "127.0.0.1:8080"])
-    let error = await #expect(throws: AuthHTTPError.self) { _ = try await provider.headers() }
+      client: client, fromADC: true, environment: ["GCE_METADATA_HOST": "127.0.0.1:1"])
+    let credentialsError = await #expect(throws: CredentialsError.self) {
+      _ = try await provider.headers()
+    }
+    let error = #expect(throws: AuthHTTPError.self) {
+      if case let .cannotFetchToken(_, _, source) = credentialsError {
+        throw source
+      }
+    }
     if case let .transportError(urlError) = error {
       #expect(
         urlError.code == .cannotConnectToHost, "Expected cannotConnectToHost, got \(urlError.code)")
@@ -268,9 +268,14 @@ import Testing
     let client = AuthHTTPClient(mock: mock)
     let provider = MDSCredentials(retryConfiguration: retryConfig, client: client, environment: [:])
 
-    await #expect(throws: AuthHTTPError.self) {
+    let error = await #expect(throws: CredentialsError.self) {
       _ = try await provider.headers()
     }
+    guard case let .cannotFetchToken(_, _, source) = error else {
+      Issue.record("expected a .cannotFetchToken error, got=\(error)")
+      return
+    }
+    #expect(source is AuthHTTPError, "expected AuthHTTPError as the source, got \(source)")
     let count = attempts.getCount()
     #expect(count == 1, "Expected no retries on permanent HTTP 404 error, got \(count) calls")
   }


### PR DESCRIPTION
Always use `CredentialsError.cannotFetchToken()` when the MDS credentials provider cannot fetch the token, regardless of the error cause.

Use `Foundation.CustomDebugStringConvertible` so a descriptive error appears on the CLI when `CredentialsError` is raised.

Change the `.cannotFetchToken` case to be less stringly-typed. Carry the information about the error in consumable types and convert them to a string where we need them to.

Refactor `CredentialsError` to its own file and give it its own tests.

Fixes #218 