### PR TITLE
ci: skip integration tests in unit test builds

### DIFF
--- a/ci/gcb/minimum-swift.yaml
+++ b/ci/gcb/minimum-swift.yaml
@@ -23,7 +23,7 @@ options:
   logging: CLOUD_LOGGING_ONLY
   env:
     - GOOGLE_CLOUD_SWIFT_TEST_RUNNING_ON_GCB=1
-    - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
+    - PROJECT_ID=${PROJECT_ID}
     - GCB_TRIGGER_NAME=${TRIGGER_NAME}
   workerPool: 'projects/${PROJECT_ID}/locations/${_POOL_REGION}/workerPools/${_POOL_ID}'
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'

--- a/ci/gcb/scripted.yaml
+++ b/ci/gcb/scripted.yaml
@@ -23,7 +23,7 @@ options:
   logging: CLOUD_LOGGING_ONLY
   env:
     - GOOGLE_CLOUD_SWIFT_TEST_RUNNING_ON_GCB=1
-    - GOOGLE_CLOUD_PROJECT=${PROJECT_ID}
+    - PROJECT_ID=${PROJECT_ID}
     - GCB_TRIGGER_NAME=${TRIGGER_NAME}
   workerPool: 'projects/${PROJECT_ID}/locations/${_POOL_REGION}/workerPools/${_POOL_ID}'
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'

--- a/ci/gcb/scripts/integration-tests.sh
+++ b/ci/gcb/scripts/integration-tests.sh
@@ -27,10 +27,11 @@ flags=(
     --scratch-path "/workspace/.build-cache"
     --build-path   "/workspace/.build"
 )
-if [[ -z "${GOOGLE_CLOUD_PROJECT:-}" ]]; then
-    echo "✗ missing GOOGLE_CLOUD_PROJECT environment variable"
+if [[ -z "${PROJECT_ID:-}" ]]; then
+    echo "✗ missing PROJECT_ID environment variable"
     exit 1
 fi
+export GOOGLE_CLOUD_PROJECT="${PROJECT_ID}"
 export GOOGLE_CLOUD_SWIFT_TEST_SERVICE_ACCOUNT=swift-sdk-test@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com
 export GOOGLE_CLOUD_SWIFT_TEST_BUCKET=${GOOGLE_CLOUD_PROJECT}-test-bucket
 


### PR DESCRIPTION
I was warned, and still managed to enable integration tests during the unit test builds.