### PR TITLE
cleanup(gax)!: remove `QueryParameterEncoder`

### DIFF
--- a/packages/gax/Sources/GoogleCloudGax/QueryParameter.swift
+++ b/packages/gax/Sources/GoogleCloudGax/QueryParameter.swift
@@ -46,17 +46,6 @@ import Foundation
   }
 }
 
-// TODO(https://github.com/googleapis/google-cloud-swift/issues/13) - remove once the generator stops using it
-@_spi(GoogleCloudInternal) public class QueryParameterEncoder {
-  public init() {}
-
-  public func encode<T: Encodable>(_ value: T, prefix: String) throws -> [URLQueryItem] {
-    let encoder = InternalEncoder(prefix: prefix)
-    try value.encode(to: encoder)
-    return encoder.queryItems
-  }
-}
-
 private struct StringKey: CodingKey {
   var stringValue: String
   var intValue: Int? { nil }


### PR DESCRIPTION
This type was only intended for internal use, but lacked the `_` prefix and the `@_spi` attribute. Now that nothing uses it, we can remove it.

Fixes #497 