### PR TITLE
cleanup(gax)!: protect `_RetryLoop` with `@_spi()`

### DIFF
--- a/packages/gax/Sources/GoogleCloudGax/RetryLoop.swift
+++ b/packages/gax/Sources/GoogleCloudGax/RetryLoop.swift
@@ -22,7 +22,7 @@ import Foundation
 ///
 /// In between calls the function waits the amount of time prescribed by the backoff policy, using
 /// `sleep` to implement any sleep.
-public struct _RetryLoop: Sendable {
+@_spi(GoogleCloudInternal) public struct _RetryLoop: Sendable {
   let retryPolicy: any RetryPolicy
   let backoffPolicy: any BackoffPolicy
   let retryThrottler: any RetryThrottler

--- a/packages/gax/Tests/RetryLoopTests.swift
+++ b/packages/gax/Tests/RetryLoopTests.swift
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import Foundation
-import GoogleCloudGax
 import GoogleRpc
 import Synchronization
 import Testing
+@_spi(GoogleCloudInternal) import GoogleCloudGax
 
 @Suite struct RetryLoopTest {
   func permanent() -> RequestError {


### PR DESCRIPTION
Belt and suspenders. This is an internal-only API, we want to use the `@_spi()` attribute to prevent misuse.

Fixes #501 and then fixes #13 