### PR TITLE
test: new endurance test

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -122,6 +122,17 @@ let package = Package(
           name: "GoogleCloudSecurityPublicCAV1", package: "google-cloud-security-publicca-v1"),
       ],
     ),
+    .executableTarget(
+      name: "Endurance",
+      dependencies: [
+        .product(name: "GoogleCloudSecretManagerV1", package: "google-cloud-secretmanager-v1"),
+        .product(name: "GoogleCloudGax", package: "gax"),
+        .product(name: "GoogleCloudWkt", package: "wkt"),
+        .product(name: "GoogleCloudTestHelpers", package: "test-helpers"),
+      ],
+      path: "Tests/Endurance",
+      exclude: ["README.md", "endurance-test.service"]
+    ),
   ]
 )
 

--- a/Tests/Endurance/Logging.swift
+++ b/Tests/Endurance/Logging.swift
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+struct StructuredLog: Codable, Sendable {
+  let severity: String
+  let labels: [String: String]
+  let message: String
+}
+
+func reportError(_ error: any Error, task: String) {
+  let log = StructuredLog(
+    severity: "error",
+    labels: [
+      "application": "endurance-test",
+      "version": "0.1.0",
+      "task": task,
+    ],
+    message: "\(error)"
+  )
+  if let data = try? JSONEncoder().encode(log),
+    let jsonString = String(data: data, encoding: .utf8)
+  {
+    FileHandle.standardError.write(Data((jsonString + "\n").utf8))
+  } else {
+    FileHandle.standardError.write(Data("{\"severity\":\"error\",\"message\":\"\(error)\"}\n".utf8))
+  }
+}
+
+func reportInfo(_ message: String, task: String) {
+  let log = StructuredLog(
+    severity: "info",
+    labels: [
+      "application": "endurance-test",
+      "version": "0.1.0",
+      "task": task,
+    ],
+    message: message
+  )
+  if let data = try? JSONEncoder().encode(log),
+    let jsonString = String(data: data, encoding: .utf8)
+  {
+    FileHandle.standardOutput.write(Data((jsonString + "\n").utf8))
+  } else {
+    print("{\"severity\":\"info\",\"message\":\"\(message)\"}")
+  }
+}

--- a/Tests/Endurance/Metrics.swift
+++ b/Tests/Endurance/Metrics.swift
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// A thread-safe metrics tracker for aggregating request counts across concurrent workers.
+actor MetricsTracker {
+  private var totalSuccessCount: UInt64 = 0
+  private var totalErrorCount: UInt64 = 0
+  private var totalUpdateCount: UInt64 = 0
+
+  func record(
+    successes: UInt64,
+    errors: UInt64,
+    updates: UInt64
+  ) -> (totalSuccess: UInt64, totalError: UInt64, totalUpdate: UInt64) {
+    totalSuccessCount += successes
+    totalErrorCount += errors
+    totalUpdateCount += updates
+    return (totalSuccessCount, totalErrorCount, totalUpdateCount)
+  }
+}

--- a/Tests/Endurance/README.md
+++ b/Tests/Endurance/README.md
@@ -1,0 +1,107 @@
+# Google Cloud client libraries for Swift: endurance test
+
+This directory contains a test to verify the client libraries work well in
+long-running applications. Our unit and integration tests are (and should be)
+short-lived. These tests may miss bugs that only manifest themselves when the
+application runs for a long time. Examples of such bugs include:
+
+- Failure to refresh access tokens in the authentication library.
+- Transient errors that appear rarely and are not handled correctly.
+- Race conditions that only appear rarely.
+- Resource leaks, including memory, file descriptors, or any other resource.
+
+While Swift's memory safety and structured concurrency make it hard to
+introduce some of the problems described above, it is not impossible to do so.
+While running a test for a long time does not guarantee that such bugs will be
+found, it makes it less likely that such bugs do exist. In the worst case, such
+a test provides scaffolding to reproduce any bugs reported by our customers.
+
+## Basic Deployment
+
+For a one-time run, we can use GCE to run the program and manually configure the
+resources and permissions to run the program. If we wanted to run this program
+continuously, then we should consider a more advanced deployment, such as GKE.
+
+## Pre-requisites
+
+You will need a project with billing enabled. The Secret Manager and Compute
+Engine APIs should be enabled too. You will need a GCE VM instance, and the
+default GCE service account will need to have the secret manager admin role.
+
+Capture the project id:
+
+```shell
+export PROJECT_ID=$(gcloud config get project)
+```
+
+Make sure the service account has the necessary privileges:
+
+```shell
+PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format='value(projectNumber)')
+ACCOUNT=${PROJECT_NUMBER}-compute@developer.gserviceaccount.com
+gcloud projects add-iam-policy-binding ${PROJECT_ID} --role=roles/secretmanager.viewer --member=serviceAccount:${ACCOUNT}
+gcloud projects add-iam-policy-binding ${PROJECT_ID} --role=roles/secretmanager.secretAccessor --member=serviceAccount:${ACCOUNT}
+gcloud projects add-iam-policy-binding ${PROJECT_ID} --role=roles/secretmanager.secretVersionManager --member=serviceAccount:${ACCOUNT}
+```
+
+Create the testing resources:
+
+```shell
+for i in $(seq 0 19); do
+    id=$(printf "secret-%03d" $i)
+    gcloud secrets create --labels=endurance-test=true ${id}
+done
+```
+
+## Deployment
+
+On a GCE instance, install the Swift development tools (e.g. via swiftly or official Swift packages), git, and build tools:
+
+```shell
+sudo apt update && sudo apt install -y git curl binutils libcurl4-openssl-dev libssl-dev
+curl -s https://swiftlang.github.io/swiftly/swiftly-install.sh | bash
+source ~/.local/share/swiftly/env.sh
+swiftly install latest
+```
+
+Clone the code and build/run the test:
+
+```shell
+git clone https://github.com/googleapis/google-cloud-swift.git
+cd google-cloud-swift
+swift run -c release Endurance
+```
+
+That should print some progress metrics every 10 seconds or so. If it fails to
+start or cannot successfully update and access the secrets, check the
+permissions and project configuration.
+
+Once it is working, run it in the background with the logs going to Cloud Logging.
+First, copy the binary to `/usr/local/bin`:
+
+```shell
+sudo cp .build/release/Endurance /usr/local/bin/endurance-test
+```
+
+Create the systemd user service unit:
+
+```shell
+mkdir -p ~/.config/systemd/user
+sed "s/@PROJECT@/$PROJECT_ID/" Tests/Endurance/endurance-test.service >~/.config/systemd/user/endurance-test.service
+```
+
+Start the program as a background service:
+
+```shell
+systemctl --user daemon-reload
+systemctl --user enable --now endurance-test.service
+systemctl --user status endurance-test.service
+```
+
+## Future Work
+
+It would be nice to report metrics, such as successful request counts and
+request latency to Cloud Monitoring.
+
+If we wanted to deploy and run this continuously, it would be nice to use GKE
+and Cloud Build to automatically deploy new versions.

--- a/Tests/Endurance/README.md
+++ b/Tests/Endurance/README.md
@@ -58,10 +58,14 @@ done
 On a GCE instance, install the Swift development tools (e.g. via swiftly or official Swift packages), git, and build tools:
 
 ```shell
-sudo apt update && sudo apt install -y git curl binutils libcurl4-openssl-dev libssl-dev
-curl -s https://swiftlang.github.io/swiftly/swiftly-install.sh | bash
-source ~/.local/share/swiftly/env.sh
+sudo apt update && sudo apt install -y git curl binutils libcurl4-openssl-dev libssl-dev gpg build-essential
+curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz && \
+tar zxf swiftly-$(uname -m).tar.gz && \
+./swiftly init --quiet-shell-followup && \
+. "${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh" && \
+hash -r
 swiftly install latest
+sudo apt-get -y install libicu-dev libedit-dev libsqlite3-dev libncurses-dev libpython3-dev libxml2-dev pkg-config uuid-dev libstdc++-12-dev
 ```
 
 Clone the code and build/run the test:
@@ -87,15 +91,15 @@ Create the systemd user service unit:
 
 ```shell
 mkdir -p ~/.config/systemd/user
-sed "s/@PROJECT@/$PROJECT_ID/" Tests/Endurance/endurance-test.service >~/.config/systemd/user/endurance-test.service
+sudo sed "s/@PROJECT@/$PROJECT_ID/" Tests/Endurance/endurance-test.service >/etc/systemd/system/swift-endurance.service
 ```
 
 Start the program as a background service:
 
 ```shell
-systemctl --user daemon-reload
-systemctl --user enable --now endurance-test.service
-systemctl --user status endurance-test.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now endurance-test.service
+sudo systemctl status endurance-test.service
 ```
 
 ## Future Work
@@ -105,3 +109,7 @@ request latency to Cloud Monitoring.
 
 If we wanted to deploy and run this continuously, it would be nice to use GKE
 and Cloud Build to automatically deploy new versions.
+
+It may be easier to deploy this by building a docker image (there is a Swift
+plugin to do this locally), and then deploy the image to an instance
+configured with the Container-Optimized OS image.

--- a/Tests/Endurance/README.md
+++ b/Tests/Endurance/README.md
@@ -53,9 +53,12 @@ for i in $(seq 0 19); do
 done
 ```
 
+If the resources already exist these commands will fail, you can ignore those errors.
+
 ## Deployment
 
-On a GCE instance, install the Swift development tools (e.g. via swiftly or official Swift packages), git, and build tools:
+On a single GCE instance, install the Swift development tools (e.g. via swiftly
+or official Swift packages), git, and build tools:
 
 ```shell
 sudo apt update && sudo apt install -y git curl binutils libcurl4-openssl-dev libssl-dev gpg build-essential
@@ -102,6 +105,10 @@ sudo systemctl enable --now endurance-test.service
 sudo systemctl status endurance-test.service
 ```
 
+The benchmark is tuned to use all the API quota in a single project. If you run
+more than one copy of the test you will see a much higher failure rate than
+expected.
+
 ## Future Work
 
 It would be nice to report metrics, such as successful request counts and
@@ -113,3 +120,10 @@ and Cloud Build to automatically deploy new versions.
 It may be easier to deploy this by building a docker image (there is a Swift
 plugin to do this locally), and then deploy the image to an instance
 configured with the Container-Optimized OS image.
+
+Alternatively, we could configure configure the VM using Terraform and use a
+`metadata_startup_script` to do all the work.
+
+However, this benchmark is executed rarely, once every few of years, if that.
+Before investing on a lot of automation consider whether there is a return on
+it.

--- a/Tests/Endurance/endurance-test.service
+++ b/Tests/Endurance/endurance-test.service
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=Google Cloud client libraries for Swift Endurance Test
+
+[Service]
+Type=simple
+StandardOutput=journal
+Environment="PROJECT_ID=@PROJECT@"
+ExecStart=/usr/local/bin/endurance-test
+
+[Install]
+WantedBy=default.target

--- a/Tests/Endurance/endurance-test.service
+++ b/Tests/Endurance/endurance-test.service
@@ -18,7 +18,7 @@ Description=Google Cloud client libraries for Swift Endurance Test
 [Service]
 Type=simple
 StandardOutput=journal
-Environment="PROJECT_ID=@PROJECT@"
+Environment="GOOGLE_CLOUD_PROJECT=@PROJECT@"
 ExecStart=/usr/local/bin/endurance-test
 
 [Install]

--- a/Tests/Endurance/main.swift
+++ b/Tests/Endurance/main.swift
@@ -1,0 +1,215 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import GoogleCloudGax
+import GoogleCloudSecretManagerV1
+
+private let tooManyErrors: UInt64 = 100
+
+// Fixed payload string used across endurance test runs.
+private let payloadData = Data("the quick brown fox jumps over the lazy dog".utf8)
+
+// Hardcoded CRC32C checksum for `payloadData`.
+// This value (0x3c18f4d6) can be verified using:
+//   echo -n "the quick brown fox jumps over the lazy dog" > /tmp/payload.txt
+//   gcloud storage hash --skip-md5 /tmp/payload.txt
+// and converting the CRC32C base64 output to hex or integer.
+private let payloadCrc32c: Int64 = 0x3c18f4d6
+
+enum EnduranceError: Error, CustomStringConvertible {
+  case missingProjectId
+  case noEnduranceSecretsFound(projectId: String)
+
+  var description: String {
+    switch self {
+    case .missingProjectId:
+      return "PROJECT_ID or GOOGLE_CLOUD_PROJECT environment variable is not set"
+    case .noEnduranceSecretsFound(let projectId):
+      return "no secrets with the `endurance-test` label found in \(projectId)"
+    }
+  }
+}
+
+do {
+  try await startWorkers()
+} catch {
+  reportError(error, task: "main")
+}
+
+/// Starts concurrent worker tasks for all endurance secrets found in the project.
+private func startWorkers() async throws {
+  let value = ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"]
+  guard let projectId = value, !projectId.isEmpty else {
+    throw EnduranceError.missingProjectId
+  }
+
+  let clientOptions = ClientOptions().with {
+    $0.retryPolicy = BaseRetryPolicy()
+      .withTimeLimit(.seconds(15))
+      .withAttemptLimit(5)
+  }
+  let discoveryClient = try SecretManagerServiceClient(clientOptions)
+
+  let enduranceSecrets = try await getEnduranceSecrets(
+    client: discoveryClient, projectId: projectId)
+  let totalWorkers = enduranceSecrets.count
+  precondition(totalWorkers > 0, "totalWorkers must not be 0")
+
+  let metrics = MetricsTracker()
+
+  try await withThrowingTaskGroup(of: Void.self) { group in
+    for (taskId, secret) in enduranceSecrets.enumerated() {
+      group.addTask {
+        let taskName = "worker[\(secret)]"
+        do {
+          let client = try SecretManagerServiceClient(clientOptions)
+          try await worker(
+            client: client,
+            secret: secret,
+            taskId: taskId,
+            totalWorkers: totalWorkers,
+            metrics: metrics
+          )
+        } catch {
+          reportError(error, task: taskName)
+          throw error
+        }
+      }
+    }
+    try await group.waitForAll()
+  }
+}
+
+/// Continuously perform RPCs to a given secret.
+private func worker(
+  client: SecretManagerServiceClient,
+  secret: String,
+  taskId: Int,
+  totalWorkers: Int,
+  metrics: MetricsTracker
+) async throws {
+  // First create a secret version, to ensure the loop will succeed.
+  var version = try await updateSecret(client: client, secret: secret)
+
+  // We want to create a new version every minute on average across all workers.
+  // That will keep this test well below the quota:
+  //   https://cloud.google.com/secret-manager/quotas
+  let addVersionPeriod = Duration.seconds(60.0 * Double(totalWorkers))
+  let reportPeriod = Duration.seconds(10)
+
+  var lastAddVersion = ContinuousClock.now
+  var lastReport = ContinuousClock.now
+  var errorCount: UInt64 = 0
+  var successCount: UInt64 = 0
+  var updateCount: UInt64 = 0
+
+  while true {
+    let now = ContinuousClock.now
+    if now >= lastAddVersion + addVersionPeriod {
+      version = try await updateSecret(client: client, secret: secret)
+      lastAddVersion = ContinuousClock.now
+      updateCount += 1
+    }
+
+    if now >= lastReport + reportPeriod {
+      let totals = await metrics.record(
+        successes: successCount,
+        errors: errorCount,
+        updates: updateCount
+      )
+      if taskId == 0 {
+        reportInfo(
+          "success_count=\(totals.totalSuccess), error_count=\(totals.totalError), version_count=\(totals.totalUpdate), current_success_count=\(successCount), current_error_count=\(errorCount), total_workers=\(totalWorkers)",
+          task: "task[0]"
+        )
+      }
+      lastReport = ContinuousClock.now
+      errorCount = 0
+      successCount = 0
+      updateCount = 0
+    }
+
+    // We want to average about 80,000 requests per minute total across all workers.
+    // That will keep the test well below the quota:
+    //   https://cloud.google.com/secret-manager/quotas
+    let waitDuration = Duration.seconds((60.0 * Double(totalWorkers)) / 80_000.0)
+    let nextTargetTime = ContinuousClock.now + waitDuration
+
+    let accessRequest = AccessSecretVersionRequest().with {
+      $0.name = version.name
+    }
+    let requestOptions = RequestOptions().with {
+      $0.attemptTimeout = .seconds(1)
+    }
+
+    do {
+      _ = try await client.accessSecretVersion(request: accessRequest, options: requestOptions)
+      successCount += 1
+    } catch {
+      errorCount += 1
+      if errorCount > tooManyErrors && successCount == 0 {
+        throw error
+      }
+    }
+
+    if ContinuousClock.now < nextTargetTime {
+      try await Task.sleep(until: nextTargetTime, clock: .continuous)
+    }
+  }
+}
+
+/// Cleans up old versions and creates a new secret version with a payload.
+private func updateSecret(
+  client: SecretManagerServiceClient,
+  secret: String
+) async throws -> SecretVersion {
+  // To keep things tidy, remove any existing versions.
+  let items = try client.listSecretVersions(byItem: .init().with { $0.parent = secret })
+  for try await version in items {
+    if version.state == .destroyed {
+      continue
+    }
+    _ = try await client.destroySecretVersion(request: .init().with { $0.name = version.name })
+  }
+
+  let version = try await client.addSecretVersion(
+    request: .init().with {
+      $0.parent = secret
+      $0.payload = SecretPayload().with {
+        $0.data = payloadData
+        $0.dataCrc32C = payloadCrc32c
+      }
+    })
+  return version
+}
+
+/// Retrieves all secret resource names labeled with `endurance-test`.
+private func getEnduranceSecrets(
+  client: SecretManagerServiceClient,
+  projectId: String
+) async throws -> [String] {
+  var secrets: [String] = []
+  let items = try client.listSecrets(
+    byItem: .init().with { $0.parent = "projects/\(projectId)" })
+  for try await secret in items {
+    if secret.labels["endurance-test"] != nil {
+      secrets.append(secret.name)
+    }
+  }
+  if secrets.isEmpty {
+    throw EnduranceError.noEnduranceSecretsFound(projectId: projectId)
+  }
+  return secrets
+}

--- a/Tests/Endurance/main.swift
+++ b/Tests/Endurance/main.swift
@@ -35,7 +35,7 @@ enum EnduranceError: Error, CustomStringConvertible {
   var description: String {
     switch self {
     case .missingProjectId:
-      return "PROJECT_ID or GOOGLE_CLOUD_PROJECT environment variable is not set"
+      return "GOOGLE_CLOUD_PROJECT environment variable is not set"
     case .noEnduranceSecretsFound(let projectId):
       return "no secrets with the `endurance-test` label found in \(projectId)"
     }


### PR DESCRIPTION
Add a manual test to verify things work on long-running applications. As the README explains, running the same program for a long time may uncover bugs such as access token not being refreshed, bad defaults for the retry policies, or slow memory leaks, or crashes under rare scenarios. The test is not guaranteed to find these things, but when it does find them we have real problems.

Towards #16 

LLM disclosure: I used Jetski to translate the [Rust version](https://github.com/googleapis/google-cloud-rust/tree/main/tests/endurance) of this test. And then I read the code and tweaked a couple of things.