### PR TITLE
test: storage add `w1r3` benchmark

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8e1a366dde2df7f8378a9f11a371ebcf11d279e49eec83cbc8872ea43a35ceae",
+  "originHash" : "46bbc9a2606019f408b0b349e9b2cb7cfafdd9ee1776c94e0eacc155c2a653bd",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -35,6 +35,15 @@
       "state" : {
         "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
         "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -54,6 +54,7 @@ let package = Package(
     .package(path: "./packages/storage"),
     .package(path: "./guide"),
     .package(url: "https://github.com/apple/swift-log", from: "1.12.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
     // Only used for development.
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
   ] + generatedDependencies,
@@ -121,6 +122,18 @@ let package = Package(
         .product(
           name: "GoogleCloudSecurityPublicCAV1", package: "google-cloud-security-publicca-v1"),
       ],
+    ),
+    .executableTarget(
+      name: "StorageW1R3",
+      dependencies: [
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "GoogleCloudStorage", package: "storage"),
+        .product(name: "GoogleCloudAuth", package: "auth"),
+        .product(name: "GoogleCloudGax", package: "gax"),
+        .product(name: "Logging", package: "swift-log"),
+      ],
+      path: "Tests/StorageW1R3",
+      exclude: ["README.md"]
     ),
   ]
 )

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -67,7 +67,6 @@ public struct BenchmarkRunner: Sendable {
 
     // Print CSV header to stdout
     print(Sample.header)
-    fflush(stdout)
 
     // Start background periodic counter reporting to stderr
     let monitorTask = Task {
@@ -287,15 +286,30 @@ public struct BenchmarkRunner: Sendable {
 
   private static func emitSample(_ sample: Sample) {
     print(sample.toRow())
-    fflush(stdout)
   }
 
   private static func generateRandomBuffer(size: Int) -> Data {
     guard size > 0 else { return Data() }
+    var generator = SystemRandomNumberGenerator()
     var data = Data(count: size)
     data.withUnsafeMutableBytes { ptr in
       guard let baseAddress = ptr.baseAddress else { return }
-      arc4random_buf(baseAddress, ptr.count)
+      var remaining = ptr.count
+      var current = baseAddress.assumingMemoryBound(to: UInt64.self)
+      while remaining >= 8 {
+        current.pointee = generator.next()
+        current = current.advanced(by: 1)
+        remaining -= 8
+      }
+      if remaining > 0 {
+        var bytePtr = UnsafeMutableRawPointer(current).assumingMemoryBound(to: UInt8.self)
+        var val = generator.next()
+        for _ in 0..<remaining {
+          bytePtr.pointee = UInt8(truncatingIfNeeded: val)
+          val >>= 8
+          bytePtr = bytePtr.advanced(by: 1)
+        }
+      }
     }
     return data
   }

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -1,0 +1,306 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import GoogleCloudAuth
+import GoogleCloudGax
+import GoogleCloudStorage
+
+public struct BenchmarkRunner: Sendable {
+  public let bucketName: String
+  public let minObjectSize: Int
+  public let maxObjectSize: Int
+  public let taskCount: Int
+  public let iterations: Int
+  public let minDeleteBatch: Int
+  public let maxDeleteBatch: Int
+  public let rampupPeriod: Duration
+  public let readCount: Int
+  public let noDelete: Bool
+
+  public init(
+    bucketName: String,
+    minObjectSize: Int,
+    maxObjectSize: Int,
+    taskCount: Int,
+    iterations: Int,
+    minDeleteBatch: Int,
+    maxDeleteBatch: Int,
+    rampupPeriod: Duration,
+    readCount: Int,
+    noDelete: Bool
+  ) {
+    self.bucketName = bucketName
+    self.minObjectSize = minObjectSize
+    self.maxObjectSize = maxObjectSize
+    self.taskCount = taskCount
+    self.iterations = iterations
+    self.minDeleteBatch = minDeleteBatch
+    self.maxDeleteBatch = maxDeleteBatch
+    self.rampupPeriod = rampupPeriod
+    self.readCount = readCount
+    self.noDelete = noDelete
+  }
+
+  public func execute() async throws {
+    logToStderr(
+      "Starting W1R3 benchmark with bucket: \(bucketName), tasks: \(taskCount), iterations: \(iterations)"
+    )
+
+    let counters = BenchmarkCounters()
+
+    logToStderr("Generating random payload buffer (\(maxObjectSize) bytes)...")
+    let randomBuffer = Self.generateRandomBuffer(size: maxObjectSize)
+    logToStderr("Random payload buffer ready.")
+
+    // Print CSV header to stdout
+    print(Sample.header)
+    fflush(stdout)
+
+    // Start background periodic counter reporting to stderr
+    let monitorTask = Task {
+      while !Task.isCancelled {
+        try? await Task.sleep(for: .seconds(5))
+        if Task.isCancelled { break }
+        let summary = await counters.formattedDescription()
+        logToStderr(summary)
+      }
+    }
+    defer {
+      monitorTask.cancel()
+    }
+
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      for taskIndex in 0..<taskCount {
+        group.addTask {
+          await self.runWorker(
+            taskIndex: taskIndex,
+            counters: counters,
+            buffer: randomBuffer
+          )
+        }
+      }
+      try await group.waitForAll()
+    }
+
+    let finalSummary = await counters.formattedDescription()
+    logToStderr("DONE. Final \(finalSummary)")
+  }
+
+  private func runWorker(
+    taskIndex: Int,
+    counters: BenchmarkCounters,
+    buffer: Data
+  ) async {
+    let clock = ContinuousClock()
+    // Apply rampup delay
+    if taskIndex > 0 {
+      let delay = rampupPeriod * Double(taskIndex)
+      try? await Task.sleep(for: delay)
+    }
+
+    let storageClient: StorageClient
+    let controlClient: StorageControlClient
+    do {
+      storageClient = try StorageClient()
+      controlClient = try StorageControlClient()
+    } catch {
+      logToStderr("Failed to initialize Storage clients for task \(taskIndex): \(error)")
+      return
+    }
+
+    let taskStartInstant = clock.now
+    var deletes = [String]()
+    var batchSize =
+      minDeleteBatch == maxDeleteBatch
+      ? minDeleteBatch
+      : Int.random(in: minDeleteBatch...maxDeleteBatch)
+
+    for iteration in 0..<iterations {
+      let size =
+        minObjectSize == maxObjectSize
+        ? minObjectSize
+        : Int.random(in: minObjectSize...maxObjectSize)
+      let objectName = Self.randomObjectName()
+      let isResumable = Bool.random()
+      let uploadOp: Operation = isResumable ? .resumable : .singleShot
+
+      let uploadBuilder = SampleBuilder(
+        task: taskIndex,
+        taskStartInstant: taskStartInstant,
+        iteration: iteration,
+        op: uploadOp,
+        targetSize: size,
+        object: objectName
+      )
+
+      let uploadSlice = size > 0 ? buffer.prefix(size) : Data()
+
+      var uploadedObject: GoogleCloudStorage.Object? = nil
+      do {
+        let object = try await StorageOperations.upload(
+          client: storageClient,
+          controlClient: controlClient,
+          bucketName: bucketName,
+          objectName: objectName,
+          data: uploadSlice,
+          isResumable: isResumable
+        )
+        uploadedObject = object
+        let sample = uploadBuilder.success()
+        Self.emitSample(sample)
+        await counters.incrementWrite()
+        await counters.incrementSample()
+      } catch {
+        let details = await counters.errorDetails(error: error)
+        let sample = uploadBuilder.error(details: details)
+        Self.emitSample(sample)
+        await counters.incrementWrite()
+        await counters.incrementWriteError()
+        await counters.incrementSample()
+        continue
+      }
+
+      // Download / Read loop
+      for readIndex in 0..<readCount {
+        let readOp = Operation.read(readIndex)
+        let readBuilder = SampleBuilder(
+          task: taskIndex,
+          taskStartInstant: taskStartInstant,
+          iteration: iteration,
+          op: readOp,
+          targetSize: size,
+          object: objectName
+        )
+
+        let (transferSize, readError) = await StorageOperations.download(
+          client: storageClient,
+          bucketName: bucketName,
+          objectName: objectName,
+          generation: uploadedObject?.generation
+        )
+
+        if let error = readError {
+          let details = await counters.errorDetails(error: error)
+          if transferSize > 0 {
+            let sample = readBuilder.interrupted(transferSize: transferSize, details: details)
+            Self.emitSample(sample)
+          } else {
+            let sample = readBuilder.error(details: details)
+            Self.emitSample(sample)
+          }
+          await counters.incrementRead()
+          await counters.incrementReadError()
+          await counters.incrementSample()
+        } else {
+          let sample = readBuilder.success(transferSize: transferSize)
+          Self.emitSample(sample)
+          await counters.incrementRead()
+          await counters.incrementSample()
+        }
+      }
+
+      // Deletion queueing
+      if !noDelete {
+        deletes.append(objectName)
+        if deletes.count >= batchSize {
+          let currentBatch = deletes
+          deletes.removeAll(keepingCapacity: true)
+          batchSize =
+            minDeleteBatch == maxDeleteBatch
+            ? minDeleteBatch
+            : Int.random(in: minDeleteBatch...maxDeleteBatch)
+
+          let deleteBuilder = SampleBuilder(
+            task: taskIndex,
+            taskStartInstant: taskStartInstant,
+            iteration: iteration,
+            op: .delete,
+            targetSize: currentBatch.count,
+            object: objectName
+          )
+
+          do {
+            try await StorageOperations.batchDelete(
+              bucketName: bucketName,
+              objects: currentBatch
+            )
+            let sample = deleteBuilder.success()
+            Self.emitSample(sample)
+            await counters.incrementDelete()
+            await counters.incrementSample()
+          } catch {
+            let details = await counters.errorDetails(error: error)
+            let sample = deleteBuilder.error(details: details)
+            Self.emitSample(sample)
+            await counters.incrementDelete()
+            await counters.incrementDeleteError()
+            await counters.incrementSample()
+          }
+        }
+      }
+    }
+
+    // Flush remaining deletes
+    if !noDelete && !deletes.isEmpty {
+      let finalBatch = deletes
+      let deleteBuilder = SampleBuilder(
+        task: taskIndex,
+        taskStartInstant: taskStartInstant,
+        iteration: iterations,
+        op: .delete,
+        targetSize: finalBatch.count,
+        object: "N/A"
+      )
+
+      do {
+        try await StorageOperations.batchDelete(
+          bucketName: bucketName,
+          objects: finalBatch
+        )
+        let sample = deleteBuilder.success()
+        Self.emitSample(sample)
+        await counters.incrementDelete()
+        await counters.incrementSample()
+      } catch {
+        let details = await counters.errorDetails(error: error)
+        let sample = deleteBuilder.error(details: details)
+        Self.emitSample(sample)
+        await counters.incrementDelete()
+        await counters.incrementDeleteError()
+        await counters.incrementSample()
+      }
+    }
+  }
+
+  private static func emitSample(_ sample: Sample) {
+    print(sample.toRow())
+    fflush(stdout)
+  }
+
+  private static func generateRandomBuffer(size: Int) -> Data {
+    guard size > 0 else { return Data() }
+    var data = Data(count: size)
+    data.withUnsafeMutableBytes { ptr in
+      guard let baseAddress = ptr.baseAddress else { return }
+      arc4random_buf(baseAddress, ptr.count)
+    }
+    return data
+  }
+
+  private static func randomObjectName() -> String {
+    let charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    return String((0..<32).map { _ in charset.randomElement()! })
+  }
+}

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -290,28 +290,8 @@ public struct BenchmarkRunner: Sendable {
 
   private static func generateRandomBuffer(size: Int) -> Data {
     guard size > 0 else { return Data() }
-    var generator = SystemRandomNumberGenerator()
-    var data = Data(count: size)
-    data.withUnsafeMutableBytes { ptr in
-      guard let baseAddress = ptr.baseAddress else { return }
-      var remaining = ptr.count
-      var current = baseAddress.assumingMemoryBound(to: UInt64.self)
-      while remaining >= 8 {
-        current.pointee = generator.next()
-        current = current.advanced(by: 1)
-        remaining -= 8
-      }
-      if remaining > 0 {
-        var bytePtr = UnsafeMutableRawPointer(current).assumingMemoryBound(to: UInt8.self)
-        var val = generator.next()
-        for _ in 0..<remaining {
-          bytePtr.pointee = UInt8(truncatingIfNeeded: val)
-          val >>= 8
-          bytePtr = bytePtr.advanced(by: 1)
-        }
-      }
-    }
-    return data
+    let bytes = (0..<size).map { _ in UInt8.random(in: .min ... .max) }
+    return Data(bytes)
   }
 
   private static func randomObjectName() -> String {

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -17,6 +17,7 @@ import GoogleCloudAuth
 import GoogleCloudGax
 import GoogleCloudStorage
 
+/// Orchestrates the execution of the W1R3 benchmark across concurrent worker tasks.
 public struct BenchmarkRunner: Sendable {
   public let bucketName: String
   public let minObjectSize: Int

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -290,7 +290,17 @@ public struct BenchmarkRunner: Sendable {
 
   private static func generateRandomBuffer(size: Int) -> Data {
     guard size > 0 else { return Data() }
-    let bytes = (0..<size).map { _ in UInt8.random(in: .min ... .max) }
+    var bytes = [UInt8](repeating: 0, count: size)
+    var offset = 0
+    while offset < size {
+      var val = UInt64.random(in: .min ... .max)
+      let count = min(8, size - offset)
+      for i in 0..<count {
+        bytes[offset + i] = UInt8(truncatingIfNeeded: val)
+        val >>= 8
+      }
+      offset += count
+    }
     return Data(bytes)
   }
 

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -133,108 +133,56 @@ public struct BenchmarkRunner: Sendable {
       if minDeleteBatch == maxDeleteBatch { return minDeleteBatch }
       return Int.random(in: minDeleteBatch...maxDeleteBatch)
     }
+    let pickObjectSize = { () -> Int in
+      if minObjectSize == maxObjectSize { return minObjectSize }
+      return Int.random(in: minObjectSize...maxObjectSize)
+    }
     var batchSize = pickBatchSize()
 
     for iteration in 0..<iterations {
-      let size =
-        minObjectSize == maxObjectSize
-        ? minObjectSize
-        : Int.random(in: minObjectSize...maxObjectSize)
+      let size = pickObjectSize()
       let objectName = Self.randomObjectName()
       let isResumable = Bool.random()
-      let uploadOp: Operation = isResumable ? .resumable : .singleShot
-
-      let uploadBuilder = SampleBuilder(
-        task: taskIndex,
-        taskStartInstant: taskStartInstant,
-        iteration: iteration,
-        op: uploadOp,
-        targetSize: size,
-        object: objectName
-      )
-
       let uploadSlice = size > 0 ? buffer.prefix(size) : Data()
+      let iterationId = IterationId(
+        task: taskIndex, taskStartInstant: taskStartInstant, iteration: iteration)
 
-      var uploadedObject: GoogleCloudStorage.Object? = nil
-      do {
-        let object = try await StorageOperations.upload(
-          client: storageClient,
+      guard
+        let uploadedObject = await self.sampleUpload(
+          iterationId: iterationId,
+          counters: counters,
+          storageClient: storageClient,
           controlClient: controlClient,
           bucketName: bucketName,
           objectName: objectName,
           data: uploadSlice,
-          isResumable: isResumable
-        )
-        uploadedObject = object
-        let sample = uploadBuilder.success()
-        self.emitSample(sample)
-        await counters.incrementWrite()
-        await counters.incrementSample()
-      } catch {
-        let details = await counters.errorDetails(error: error)
-        let sample = uploadBuilder.error(details: details)
-        self.emitSample(sample)
-        await counters.incrementWrite()
-        await counters.incrementWriteError()
-        await counters.incrementSample()
+          isResumable: isResumable)
+      else {
         continue
       }
 
-      // Download / Read loop
       for readIndex in 0..<readCount {
-        let readOp = Operation.read(readIndex)
-        let readBuilder = SampleBuilder(
-          task: taskIndex,
-          taskStartInstant: taskStartInstant,
-          iteration: iteration,
-          op: readOp,
-          targetSize: size,
-          object: objectName
-        )
-
-        let (transferSize, readError) = await StorageOperations.download(
+        await self.sampleDownload(
+          iterationId: iterationId,
+          counters: counters,
+          readIndex: readIndex,
           client: storageClient,
-          bucketName: bucketName,
-          objectName: objectName,
-          generation: uploadedObject?.generation
-        )
-
-        if let error = readError {
-          let details = await counters.errorDetails(error: error)
-          if transferSize > 0 {
-            let sample = readBuilder.interrupted(transferSize: transferSize, details: details)
-            self.emitSample(sample)
-          } else {
-            let sample = readBuilder.error(details: details)
-            self.emitSample(sample)
-          }
-          await counters.incrementRead()
-          await counters.incrementReadError()
-          await counters.incrementSample()
-        } else {
-          let sample = readBuilder.success(transferSize: transferSize)
-          self.emitSample(sample)
-          await counters.incrementRead()
-          await counters.incrementSample()
-        }
+          object: uploadedObject,
+          size: size)
       }
 
       if !delete {
         continue
       }
-      if let object = uploadedObject {
-        deletes.append(object)
-      }
+      deletes.append(uploadedObject)
       if deletes.count >= batchSize {
         batchSize = pickBatchSize()
         let currentBatch = deletes
         deletes.removeAll(keepingCapacity: true)
 
         await self.deleteBatch(
-          taskIndex: taskIndex,
+          iterationId: iterationId,
           counters: counters,
-          taskStartInstant: taskStartInstant,
-          iteration: iterations,
           credentials: credentials,
           batch: currentBatch
         )
@@ -244,21 +192,99 @@ public struct BenchmarkRunner: Sendable {
     // Flush remaining deletes
     if delete {
       await self.deleteBatch(
-        taskIndex: taskIndex,
+        iterationId: IterationId(
+          task: taskIndex, taskStartInstant: taskStartInstant, iteration: iterations),
         counters: counters,
-        taskStartInstant: taskStartInstant,
-        iteration: iterations,
         credentials: credentials,
         batch: deletes
       )
     }
   }
 
-  private func deleteBatch(
-    taskIndex: Int,
+  private func sampleUpload(
+    iterationId: IterationId,
     counters: BenchmarkCounters,
-    taskStartInstant: ContinuousClock.Instant,
-    iteration: Int,
+    storageClient: StorageClient,
+    controlClient: StorageControlClient,
+    bucketName: String,
+    objectName: String,
+    data: Data,
+    isResumable: Bool
+  ) async -> GoogleCloudStorage.Object? {
+    let uploadOp: Operation = isResumable ? .resumable : .singleShot
+
+    let uploadBuilder = SampleBuilder(
+      iterationId: iterationId,
+      op: uploadOp,
+      targetSize: data.count,
+      object: objectName
+    )
+    do {
+      let object = try await StorageOperations.upload(
+        client: storageClient,
+        controlClient: controlClient,
+        bucketName: bucketName,
+        objectName: objectName,
+        data: data,
+        isResumable: isResumable
+      )
+      let sample = uploadBuilder.success()
+      self.emitSample(sample)
+      await counters.incrementWrite()
+      await counters.incrementSample()
+      return object
+    } catch {
+      let details = await counters.errorDetails(error: error)
+      let sample = uploadBuilder.error(details: details)
+      self.emitSample(sample)
+      await counters.incrementWrite()
+      await counters.incrementWriteError()
+      await counters.incrementSample()
+    }
+    return nil
+  }
+
+  private func sampleDownload(
+    iterationId: IterationId,
+    counters: BenchmarkCounters,
+    readIndex: Int,
+    client: StorageClient,
+    object: GoogleCloudStorage.Object,
+    size: Int,
+  ) async {
+    let readOp = Operation.read(readIndex)
+    let readBuilder = SampleBuilder(
+      iterationId: iterationId,
+      op: readOp,
+      targetSize: size,
+      object: object.name
+    )
+
+    let (transferSize, readError) = await StorageOperations.download(client: client, object: object)
+
+    if let error = readError {
+      let details = await counters.errorDetails(error: error)
+      if transferSize > 0 {
+        let sample = readBuilder.interrupted(transferSize: transferSize, details: details)
+        self.emitSample(sample)
+      } else {
+        let sample = readBuilder.error(details: details)
+        self.emitSample(sample)
+      }
+      await counters.incrementRead()
+      await counters.incrementReadError()
+      await counters.incrementSample()
+    } else {
+      let sample = readBuilder.success(transferSize: transferSize)
+      self.emitSample(sample)
+      await counters.incrementRead()
+      await counters.incrementSample()
+    }
+  }
+
+  private func deleteBatch(
+    iterationId: IterationId,
+    counters: BenchmarkCounters,
     credentials: GoogleCloudAuth.Credentials,
     batch: [GoogleCloudStorage.Object],
   ) async {
@@ -266,9 +292,7 @@ public struct BenchmarkRunner: Sendable {
       return
     }
     let deleteBuilder = SampleBuilder(
-      task: taskIndex,
-      taskStartInstant: taskStartInstant,
-      iteration: iteration,
+      iterationId: iterationId,
       op: .delete,
       targetSize: batch.count,
       object: batch[0].name,

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -110,11 +110,13 @@ public struct BenchmarkRunner: Sendable {
       try? await Task.sleep(for: delay)
     }
 
+    let credentials: Credentials
     let storageClient: StorageClient
     let controlClient: StorageControlClient
     do {
-      storageClient = try StorageClient()
-      controlClient = try StorageControlClient()
+      credentials = try Credentials()
+      storageClient = try StorageClient(StorageClientOptions().with { $0.client = .init().with { $0.credentials = credentials }})
+      controlClient = try StorageControlClient(ClientOptions().with { $0.credentials = credentials })
     } catch {
       logToStderr("Failed to initialize Storage clients for task \(taskIndex): \(error)")
       return
@@ -233,6 +235,7 @@ public struct BenchmarkRunner: Sendable {
 
           do {
             try await StorageOperations.batchDelete(
+              credentials: credentials,
               bucketName: bucketName,
               objects: currentBatch
             )
@@ -266,6 +269,7 @@ public struct BenchmarkRunner: Sendable {
 
       do {
         try await StorageOperations.batchDelete(
+          credentials: credentials,
           bucketName: bucketName,
           objects: finalBatch
         )
@@ -285,7 +289,9 @@ public struct BenchmarkRunner: Sendable {
   }
 
   private static func emitSample(_ sample: Sample) {
-    print(sample.toRow())
+    if sample.result != .ok {
+      print(sample.toRow())
+    }
   }
 
   private static func generateRandomBuffer(size: Int) -> Data {

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -107,10 +107,10 @@ extension StorageW1R3 {
       }
     }
 
-    // Flush remaining deletes
     if self.noDelete {
       return
     }
+    // Flush remaining deletes
     await self.deleteBatch(
       iterationId: IterationId(
         task: taskIndex, taskStartInstant: taskStartInstant, iteration: iterations),

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -28,7 +28,8 @@ public struct BenchmarkRunner: Sendable {
   public let maxDeleteBatch: Int
   public let rampupPeriod: Duration
   public let readCount: Int
-  public let noDelete: Bool
+  public let delete: Bool
+  public let skipOkSamples: Bool
 
   public init(
     bucketName: String,
@@ -40,7 +41,8 @@ public struct BenchmarkRunner: Sendable {
     maxDeleteBatch: Int,
     rampupPeriod: Duration,
     readCount: Int,
-    noDelete: Bool
+    delete: Bool,
+    skipOkSamples: Bool,
   ) {
     self.bucketName = bucketName
     self.minObjectSize = minObjectSize
@@ -51,12 +53,13 @@ public struct BenchmarkRunner: Sendable {
     self.maxDeleteBatch = maxDeleteBatch
     self.rampupPeriod = rampupPeriod
     self.readCount = readCount
-    self.noDelete = noDelete
+    self.delete = delete
+    self.skipOkSamples = skipOkSamples
   }
 
   public func execute() async throws {
     logToStderr(
-      "Starting W1R3 benchmark with bucket: \(bucketName), tasks: \(taskCount), iterations: \(iterations)"
+      "# Starting W1R3 benchmark with bucket: \(bucketName), tasks: \(taskCount), iterations: \(iterations)"
     )
 
     let counters = BenchmarkCounters()
@@ -65,10 +68,10 @@ public struct BenchmarkRunner: Sendable {
     let randomBuffer = Self.generateRandomBuffer(size: maxObjectSize)
     logToStderr("Random payload buffer ready.")
 
-    // Print CSV header to stdout
+    // Print CSV header to stdout.
     print(Sample.header)
 
-    // Start background periodic counter reporting to stderr
+    // Start a background task to periodically report the counters to stderr.
     let monitorTask = Task {
       while !Task.isCancelled {
         try? await Task.sleep(for: .seconds(5))
@@ -125,7 +128,7 @@ public struct BenchmarkRunner: Sendable {
     }
 
     let taskStartInstant = clock.now
-    var deletes = [String]()
+    var deletes = [GoogleCloudStorage.Object]()
     var batchSize =
       minDeleteBatch == maxDeleteBatch
       ? minDeleteBatch
@@ -163,13 +166,13 @@ public struct BenchmarkRunner: Sendable {
         )
         uploadedObject = object
         let sample = uploadBuilder.success()
-        Self.emitSample(sample)
+        self.emitSample(sample)
         await counters.incrementWrite()
         await counters.incrementSample()
       } catch {
         let details = await counters.errorDetails(error: error)
         let sample = uploadBuilder.error(details: details)
-        Self.emitSample(sample)
+        self.emitSample(sample)
         await counters.incrementWrite()
         await counters.incrementWriteError()
         await counters.incrementSample()
@@ -199,101 +202,104 @@ public struct BenchmarkRunner: Sendable {
           let details = await counters.errorDetails(error: error)
           if transferSize > 0 {
             let sample = readBuilder.interrupted(transferSize: transferSize, details: details)
-            Self.emitSample(sample)
+            self.emitSample(sample)
           } else {
             let sample = readBuilder.error(details: details)
-            Self.emitSample(sample)
+            self.emitSample(sample)
           }
           await counters.incrementRead()
           await counters.incrementReadError()
           await counters.incrementSample()
         } else {
           let sample = readBuilder.success(transferSize: transferSize)
-          Self.emitSample(sample)
+          self.emitSample(sample)
           await counters.incrementRead()
           await counters.incrementSample()
         }
       }
 
-      // Deletion queueing
-      if !noDelete {
-        deletes.append(objectName)
-        if deletes.count >= batchSize {
-          let currentBatch = deletes
-          deletes.removeAll(keepingCapacity: true)
-          batchSize =
-            minDeleteBatch == maxDeleteBatch
-            ? minDeleteBatch
-            : Int.random(in: minDeleteBatch...maxDeleteBatch)
+      if !delete {
+        continue
+      }
+      if let object = uploadedObject {
+        deletes.append(object)
+      }
+      if deletes.count >= batchSize {
+        // Pick the next batch size and delete the current batch.
+        batchSize =
+          minDeleteBatch == maxDeleteBatch
+          ? minDeleteBatch
+          : Int.random(in: minDeleteBatch...maxDeleteBatch)
+        let currentBatch = deletes
+        deletes.removeAll(keepingCapacity: true)
 
-          let deleteBuilder = SampleBuilder(
-            task: taskIndex,
-            taskStartInstant: taskStartInstant,
-            iteration: iteration,
-            op: .delete,
-            targetSize: currentBatch.count,
-            object: objectName
-          )
-
-          do {
-            try await StorageOperations.batchDelete(
-              credentials: credentials,
-              bucketName: bucketName,
-              objects: currentBatch
-            )
-            let sample = deleteBuilder.success()
-            Self.emitSample(sample)
-            await counters.incrementDelete()
-            await counters.incrementSample()
-          } catch {
-            let details = await counters.errorDetails(error: error)
-            let sample = deleteBuilder.error(details: details)
-            Self.emitSample(sample)
-            await counters.incrementDelete()
-            await counters.incrementDeleteError()
-            await counters.incrementSample()
-          }
-        }
+        await self.deleteBatch(
+          taskIndex: taskIndex,
+          counters: counters,
+          taskStartInstant: taskStartInstant,
+          iteration: iterations,
+          credentials: credentials,
+          batch: currentBatch
+        )
       }
     }
 
     // Flush remaining deletes
-    if !noDelete && !deletes.isEmpty {
-      let finalBatch = deletes
-      let deleteBuilder = SampleBuilder(
-        task: taskIndex,
+    if delete {
+      await self.deleteBatch(
+        taskIndex: taskIndex,
+        counters: counters,
         taskStartInstant: taskStartInstant,
         iteration: iterations,
-        op: .delete,
-        targetSize: finalBatch.count,
-        object: "N/A"
+        credentials: credentials,
+        batch: deletes
       )
-
-      do {
-        try await StorageOperations.batchDelete(
-          credentials: credentials,
-          bucketName: bucketName,
-          objects: finalBatch
-        )
-        let sample = deleteBuilder.success()
-        Self.emitSample(sample)
-        await counters.incrementDelete()
-        await counters.incrementSample()
-      } catch {
-        let details = await counters.errorDetails(error: error)
-        let sample = deleteBuilder.error(details: details)
-        Self.emitSample(sample)
-        await counters.incrementDelete()
-        await counters.incrementDeleteError()
-        await counters.incrementSample()
-      }
     }
   }
 
-  private static func emitSample(_ sample: Sample) {
-    if sample.result != .ok {
-      print(sample.toRow())
+  private func deleteBatch(
+    taskIndex: Int,
+    counters: BenchmarkCounters,
+    taskStartInstant: ContinuousClock.Instant,
+    iteration: Int,
+    credentials: GoogleCloudAuth.Credentials,
+    batch: [GoogleCloudStorage.Object],
+  ) async {
+    if batch.isEmpty {
+      return
     }
+    let deleteBuilder = SampleBuilder(
+      task: taskIndex,
+      taskStartInstant: taskStartInstant,
+      iteration: iteration,
+      op: .delete,
+      targetSize: batch.count,
+      object: batch[0].name,
+    )
+
+    do {
+      try await StorageOperations.batchDelete(
+        credentials: credentials, batch: batch
+      )
+      let sample = deleteBuilder.success()
+      self.emitSample(sample)
+      await counters.incrementDelete()
+      await counters.incrementSample()
+    } catch {
+      let details = await counters.errorDetails(error: error)
+      let sample = deleteBuilder.error(details: details)
+      self.emitSample(sample)
+      await counters.incrementDelete()
+      await counters.incrementDeleteError()
+      await counters.incrementSample()
+    }
+  }
+
+  private func emitSample(_ sample: Sample) {
+    if self.skipOkSamples && sample.result == .ok {
+      return
+    }
+    print(sample.toRow())
   }
 
   private static func generateRandomBuffer(size: Int) -> Data {

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -129,10 +129,11 @@ public struct BenchmarkRunner: Sendable {
 
     let taskStartInstant = clock.now
     var deletes = [GoogleCloudStorage.Object]()
-    var batchSize =
-      minDeleteBatch == maxDeleteBatch
-      ? minDeleteBatch
-      : Int.random(in: minDeleteBatch...maxDeleteBatch)
+    let pickBatchSize = { () -> Int in
+      if minDeleteBatch == maxDeleteBatch { return minDeleteBatch }
+      return Int.random(in: minDeleteBatch...maxDeleteBatch)
+    }
+    var batchSize = pickBatchSize()
 
     for iteration in 0..<iterations {
       let size =
@@ -225,11 +226,7 @@ public struct BenchmarkRunner: Sendable {
         deletes.append(object)
       }
       if deletes.count >= batchSize {
-        // Pick the next batch size and delete the current batch.
-        batchSize =
-          minDeleteBatch == maxDeleteBatch
-          ? minDeleteBatch
-          : Int.random(in: minDeleteBatch...maxDeleteBatch)
+        batchSize = pickBatchSize()
         let currentBatch = deletes
         deletes.removeAll(keepingCapacity: true)
 

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -18,90 +18,8 @@ import GoogleCloudGax
 import GoogleCloudStorage
 
 /// Orchestrates the execution of the W1R3 benchmark across concurrent worker tasks.
-public struct BenchmarkRunner: Sendable {
-  public let bucketName: String
-  public let minObjectSize: Int
-  public let maxObjectSize: Int
-  public let taskCount: Int
-  public let iterations: Int
-  public let minDeleteBatch: Int
-  public let maxDeleteBatch: Int
-  public let rampupPeriod: Duration
-  public let readCount: Int
-  public let delete: Bool
-  public let skipOkSamples: Bool
-
-  public init(
-    bucketName: String,
-    minObjectSize: Int,
-    maxObjectSize: Int,
-    taskCount: Int,
-    iterations: Int,
-    minDeleteBatch: Int,
-    maxDeleteBatch: Int,
-    rampupPeriod: Duration,
-    readCount: Int,
-    delete: Bool,
-    skipOkSamples: Bool,
-  ) {
-    self.bucketName = bucketName
-    self.minObjectSize = minObjectSize
-    self.maxObjectSize = maxObjectSize
-    self.taskCount = taskCount
-    self.iterations = iterations
-    self.minDeleteBatch = minDeleteBatch
-    self.maxDeleteBatch = maxDeleteBatch
-    self.rampupPeriod = rampupPeriod
-    self.readCount = readCount
-    self.delete = delete
-    self.skipOkSamples = skipOkSamples
-  }
-
-  public func execute() async throws {
-    logToStderr(
-      "# Starting W1R3 benchmark with bucket: \(bucketName), tasks: \(taskCount), iterations: \(iterations)"
-    )
-
-    let counters = BenchmarkCounters()
-
-    logToStderr("Generating random payload buffer (\(maxObjectSize) bytes)...")
-    let randomBuffer = Self.generateRandomBuffer(size: maxObjectSize)
-    logToStderr("Random payload buffer ready.")
-
-    // Print CSV header to stdout.
-    print(Sample.header)
-
-    // Start a background task to periodically report the counters to stderr.
-    let monitorTask = Task {
-      while !Task.isCancelled {
-        try? await Task.sleep(for: .seconds(5))
-        if Task.isCancelled { break }
-        let summary = await counters.formattedDescription()
-        logToStderr(summary)
-      }
-    }
-    defer {
-      monitorTask.cancel()
-    }
-
-    try await withThrowingTaskGroup(of: Void.self) { group in
-      for taskIndex in 0..<taskCount {
-        group.addTask {
-          await self.runWorker(
-            taskIndex: taskIndex,
-            counters: counters,
-            buffer: randomBuffer
-          )
-        }
-      }
-      try await group.waitForAll()
-    }
-
-    let finalSummary = await counters.formattedDescription()
-    logToStderr("DONE. Final \(finalSummary)")
-  }
-
-  private func runWorker(
+extension StorageW1R3 {
+  func runWorker(
     taskIndex: Int,
     counters: BenchmarkCounters,
     buffer: Data
@@ -171,7 +89,7 @@ public struct BenchmarkRunner: Sendable {
           size: size)
       }
 
-      if !delete {
+      if !self.noDelete {
         continue
       }
       deletes.append(uploadedObject)
@@ -190,7 +108,7 @@ public struct BenchmarkRunner: Sendable {
     }
 
     // Flush remaining deletes
-    if delete {
+    if !self.noDelete {
       await self.deleteBatch(
         iterationId: IterationId(
           task: taskIndex, taskStartInstant: taskStartInstant, iteration: iterations),
@@ -323,7 +241,8 @@ public struct BenchmarkRunner: Sendable {
     print(sample.toRow())
   }
 
-  private static func generateRandomBuffer(size: Int) -> Data {
+  func generateRandomBuffer() -> Data {
+    let size = self.maxObjectSize
     guard size > 0 else { return Data() }
     // There is a lot going on here. Sometimes the benchmark is used with really large buffers,
     // 256MiB and 2GiB are not uncommon. To efficiently initialized the buffer with random data

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -89,7 +89,7 @@ extension StorageW1R3 {
           size: size)
       }
 
-      if !self.noDelete {
+      if self.noDelete {
         continue
       }
       deletes.append(uploadedObject)
@@ -108,15 +108,16 @@ extension StorageW1R3 {
     }
 
     // Flush remaining deletes
-    if !self.noDelete {
-      await self.deleteBatch(
-        iterationId: IterationId(
-          task: taskIndex, taskStartInstant: taskStartInstant, iteration: iterations),
-        counters: counters,
-        credentials: credentials,
-        batch: deletes
-      )
+    if self.noDelete {
+      return
     }
+    await self.deleteBatch(
+      iterationId: IterationId(
+        task: taskIndex, taskStartInstant: taskStartInstant, iteration: iterations),
+      counters: counters,
+      credentials: credentials,
+      batch: deletes
+    )
   }
 
   private func sampleUpload(

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -115,8 +115,10 @@ public struct BenchmarkRunner: Sendable {
     let controlClient: StorageControlClient
     do {
       credentials = try Credentials()
-      storageClient = try StorageClient(StorageClientOptions().with { $0.client = .init().with { $0.credentials = credentials }})
-      controlClient = try StorageControlClient(ClientOptions().with { $0.credentials = credentials })
+      storageClient = try StorageClient(
+        StorageClientOptions().with { $0.client = .init().with { $0.credentials = credentials } })
+      controlClient = try StorageControlClient(
+        ClientOptions().with { $0.credentials = credentials })
     } catch {
       logToStderr("Failed to initialize Storage clients for task \(taskIndex): \(error)")
       return
@@ -296,16 +298,23 @@ public struct BenchmarkRunner: Sendable {
 
   private static func generateRandomBuffer(size: Int) -> Data {
     guard size > 0 else { return Data() }
-    var bytes = [UInt8](repeating: 0, count: size)
-    var offset = 0
-    while offset < size {
-      var val = UInt64.random(in: .min ... .max)
-      let count = min(8, size - offset)
-      for i in 0..<count {
-        bytes[offset + i] = UInt8(truncatingIfNeeded: val)
-        val >>= 8
+    // There is a lot going on here. Sometimes the benchmark is used with really large buffers,
+    // 256MiB and 2GiB are not uncommon. To efficiently initialized the buffer with random data
+    // we create an array of the desired size.
+    let bytes = [UInt8](unsafeUninitializedCapacity: size) { buffer, initializedCount in
+      var offset = 0
+      while offset < size {
+        // Fetch a full word at a time. We could use UInt8.random to make the code simpler, but
+        // that discards 7 bytes of (expensively computed) random data.
+        var val = UInt64.random(in: .min ... .max)
+        let count = min(8, size - offset)
+        for i in 0..<count {
+          buffer[offset + i] = UInt8(truncatingIfNeeded: val)
+          val >>= 8
+        }
+        offset += count
       }
-      offset += count
+      initializedCount = size
     }
     return Data(bytes)
   }

--- a/Tests/StorageW1R3/Counters.swift
+++ b/Tests/StorageW1R3/Counters.swift
@@ -18,7 +18,7 @@ import Foundation
 ///
 /// An `actor` offers more than good enough performance in this case. We could have used
 /// low-level atomics, but (a) the benchmark is heavily network I/O-bound, and (b) counter
-/// increments occur only upon operation/batch completion. In these circumstances `actor` 
+/// increments occur only upon operation/batch completion. In these circumstances `actor`
 /// dispatch overhead should be negligible.
 public actor BenchmarkCounters {
   public private(set) var sampleCount: UInt64 = 0

--- a/Tests/StorageW1R3/Counters.swift
+++ b/Tests/StorageW1R3/Counters.swift
@@ -1,0 +1,93 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Aggregates performance counters across concurrent benchmark tasks.
+///
+/// An `actor` offers more than good enough performance in this case. We could have used
+/// low-level atomics, but (a) the benchmark is heavily network I/O-bound, and (b) counter
+/// increments occur only upon operation/batch completion. In these circumstances `actor` 
+/// dispatch overhead should be negligible.
+public actor BenchmarkCounters {
+  public private(set) var sampleCount: UInt64 = 0
+  public private(set) var deleteCount: UInt64 = 0
+  public private(set) var readCount: UInt64 = 0
+  public private(set) var writeCount: UInt64 = 0
+  public private(set) var deleteError: UInt64 = 0
+  public private(set) var readError: UInt64 = 0
+  public private(set) var writeError: UInt64 = 0
+
+  public init() {}
+
+  public func incrementSample() {
+    sampleCount &+= 1
+  }
+
+  public func incrementDelete() {
+    deleteCount &+= 1
+  }
+
+  public func incrementRead() {
+    readCount &+= 1
+  }
+
+  public func incrementWrite() {
+    writeCount &+= 1
+  }
+
+  public func incrementDeleteError() {
+    deleteError &+= 1
+  }
+
+  public func incrementReadError() {
+    readError &+= 1
+  }
+
+  public func incrementWriteError() {
+    writeError &+= 1
+  }
+
+  public func snapshot() -> [(key: String, value: UInt64)] {
+    [
+      ("DELETE_COUNT", deleteCount),
+      ("DELETE_ERROR", deleteError),
+      ("READ_COUNT", readCount),
+      ("READ_ERROR", readError),
+      ("SAMPLE_COUNT", sampleCount),
+      ("WRITE_COUNT", writeCount),
+      ("WRITE_ERROR", writeError),
+    ]
+  }
+
+  public func formattedDescription() -> String {
+    let pairs = snapshot().map { "\"\($0.key)\": \($0.value)" }.joined(separator: ", ")
+    return "Counters = [\(pairs)]"
+  }
+
+  public func errorDetails(error: (any Error)?) -> String {
+    var details = snapshot().map { "\($0.key)=\($0.value)" }
+    if let error = error {
+      details.append("error=\(error)")
+    }
+    return details.joined(separator: ";").replacingOccurrences(of: ",", with: ";")
+  }
+}
+
+public func logToStderr(_ message: String) {
+  let line = message.hasSuffix("\n") ? message : message + "\n"
+  if let data = line.data(using: .utf8) {
+    FileHandle.standardError.write(data)
+  }
+}

--- a/Tests/StorageW1R3/DurationParser.swift
+++ b/Tests/StorageW1R3/DurationParser.swift
@@ -15,55 +15,7 @@
 import ArgumentParser
 import Foundation
 
-enum SizeParser {
-  /// Parses size strings such as "128KiB", "1MiB", "10MB", "1024", "0" into bytes.
-  static func parse(_ input: String) throws -> Int {
-    let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else {
-      throw ValidationError("Size cannot be empty")
-    }
-
-    if let direct = Int(trimmed) {
-      guard direct >= 0 else {
-        throw ValidationError("Size cannot be negative: \(input)")
-      }
-      return direct
-    }
-
-    let units: [(suffix: String, multiplier: Int)] = [
-      ("tib", 1024 * 1024 * 1024 * 1024),
-      ("tb", 1000 * 1000 * 1000 * 1000),
-      ("gib", 1024 * 1024 * 1024),
-      ("gb", 1000 * 1000 * 1000),
-      ("g", 1024 * 1024 * 1024),
-      ("mib", 1024 * 1024),
-      ("mb", 1000 * 1000),
-      ("m", 1024 * 1024),
-      ("kib", 1024),
-      ("kb", 1000),
-      ("k", 1024),
-      ("b", 1),
-    ]
-
-    let lower = trimmed.lowercased()
-    for unit in units {
-      if lower.hasSuffix(unit.suffix) {
-        let numericPart = String(trimmed.dropLast(unit.suffix.count))
-          .trimmingCharacters(in: .whitespaces)
-        if let value = Double(numericPart) {
-          guard value >= 0 else {
-            throw ValidationError("Size cannot be negative: \(input)")
-          }
-          return Int(value * Double(unit.multiplier))
-        }
-      }
-    }
-
-    throw ValidationError(
-      "Invalid size format: '\(input)'. Expected values like '128KiB', '1MiB', '10MB', etc.")
-  }
-}
-
+/// Helper to parse human-readable duration strings (e.g. "500ms", "30s", "5m", "1h") into `Duration`.
 enum DurationParser {
   /// Parses duration strings such as "500ms", "30s", "5m", "1h" into `Duration`.
   static func parse(_ input: String) throws -> Duration {

--- a/Tests/StorageW1R3/ExperimentResult.swift
+++ b/Tests/StorageW1R3/ExperimentResult.swift
@@ -1,0 +1,26 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// The outcome status of an individual benchmark operation sample.
+public enum ExperimentResult: String, Sendable {
+  case ok = "OK"
+  case err = "ERR"
+  case int = "INT"
+
+  public var name: String {
+    rawValue
+  }
+}

--- a/Tests/StorageW1R3/IterationId.swift
+++ b/Tests/StorageW1R3/IterationId.swift
@@ -1,0 +1,25 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Identifies a particular iteration of the benchmark.
+public struct IterationId {
+  /// The task running the iteration.
+  public let task: Int
+  /// When did the task start.
+  public let taskStartInstant: ContinuousClock.Instant
+  /// The iteration within that task.
+  public let iteration: Int
+}

--- a/Tests/StorageW1R3/Operation.swift
+++ b/Tests/StorageW1R3/Operation.swift
@@ -1,0 +1,32 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// The type of storage operation performed during a benchmark step.
+public enum Operation: Sendable {
+  case resumable
+  case singleShot
+  case read(Int)
+  case delete
+
+  public var name: String {
+    switch self {
+    case .resumable: return "RESUMABLE"
+    case .singleShot: return "SINGLE_SHOT"
+    case .read(let index): return "READ[\(index)]"
+    case .delete: return "DELETE"
+    }
+  }
+}

--- a/Tests/StorageW1R3/Parsers.swift
+++ b/Tests/StorageW1R3/Parsers.swift
@@ -1,0 +1,107 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArgumentParser
+import Foundation
+
+enum SizeParser {
+  /// Parses size strings such as "128KiB", "1MiB", "10MB", "1024", "0" into bytes.
+  static func parse(_ input: String) throws -> Int {
+    let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      throw ValidationError("Size cannot be empty")
+    }
+
+    if let direct = Int(trimmed) {
+      guard direct >= 0 else {
+        throw ValidationError("Size cannot be negative: \(input)")
+      }
+      return direct
+    }
+
+    let units: [(suffix: String, multiplier: Int)] = [
+      ("tib", 1024 * 1024 * 1024 * 1024),
+      ("tb", 1000 * 1000 * 1000 * 1000),
+      ("gib", 1024 * 1024 * 1024),
+      ("gb", 1000 * 1000 * 1000),
+      ("g", 1024 * 1024 * 1024),
+      ("mib", 1024 * 1024),
+      ("mb", 1000 * 1000),
+      ("m", 1024 * 1024),
+      ("kib", 1024),
+      ("kb", 1000),
+      ("k", 1024),
+      ("b", 1),
+    ]
+
+    let lower = trimmed.lowercased()
+    for unit in units {
+      if lower.hasSuffix(unit.suffix) {
+        let numericPart = String(trimmed.dropLast(unit.suffix.count))
+          .trimmingCharacters(in: .whitespaces)
+        if let value = Double(numericPart) {
+          guard value >= 0 else {
+            throw ValidationError("Size cannot be negative: \(input)")
+          }
+          return Int(value * Double(unit.multiplier))
+        }
+      }
+    }
+
+    throw ValidationError(
+      "Invalid size format: '\(input)'. Expected values like '128KiB', '1MiB', '10MB', etc.")
+  }
+}
+
+enum DurationParser {
+  /// Parses duration strings such as "500ms", "30s", "5m", "1h" into `Duration`.
+  static func parse(_ input: String) throws -> Duration {
+    let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      throw ValidationError("Duration cannot be empty")
+    }
+
+    let lower = trimmed.lowercased()
+    if lower.hasSuffix("ms") {
+      let numStr = String(trimmed.dropLast(2)).trimmingCharacters(in: .whitespaces)
+      guard let ms = Double(numStr), ms >= 0 else {
+        throw ValidationError("Invalid millisecond duration: \(input)")
+      }
+      return .milliseconds(ms)
+    } else if lower.hasSuffix("s") {
+      let numStr = String(trimmed.dropLast(1)).trimmingCharacters(in: .whitespaces)
+      guard let s = Double(numStr), s >= 0 else {
+        throw ValidationError("Invalid second duration: \(input)")
+      }
+      return .seconds(s)
+    } else if lower.hasSuffix("m") {
+      let numStr = String(trimmed.dropLast(1)).trimmingCharacters(in: .whitespaces)
+      guard let m = Double(numStr), m >= 0 else {
+        throw ValidationError("Invalid minute duration: \(input)")
+      }
+      return .seconds(m * 60)
+    } else if lower.hasSuffix("h") {
+      let numStr = String(trimmed.dropLast(1)).trimmingCharacters(in: .whitespaces)
+      guard let h = Double(numStr), h >= 0 else {
+        throw ValidationError("Invalid hour duration: \(input)")
+      }
+      return .seconds(h * 3600)
+    } else if let s = Double(trimmed), s >= 0 {
+      return .seconds(s)
+    }
+
+    throw ValidationError(
+      "Invalid duration format: '\(input)'. Expected values like '500ms', '30s', '5m', etc.")
+  }
+}

--- a/Tests/StorageW1R3/README.md
+++ b/Tests/StorageW1R3/README.md
@@ -1,0 +1,65 @@
+# W1R3 Benchmark
+
+Benchmarks the Cloud Storage Swift client library. The benchmark uploads an object and
+reads it 3 times (or `--read-count` times), reporting the single-stream upload and download bandwidth.
+
+## Pre-requisites
+
+Obtain a GCE instance. You should try to use a [Compute-optimized] instance
+(e.g. the `c2d-*` family), with a large network bandwidth allocation. See the
+[Network Bandwidth] guide.
+
+## Bucket
+
+Use a bucket in the same region as your VM. If you need to create a bucket,
+these instructions may help:
+
+- Create a configuration file to automatically delete objects after one day
+
+  ```shell
+  echo '{ "lifecycle": { "rule": [ { "action": {"type": "Delete"}, "condition": {"age": 1} } ] } }' > lf.json
+  ```
+
+- Create the bucket. Replace the `${REGION}` and `${BUCKET_NAME}` placeholders
+  as needed:
+
+  ```shell
+  gcloud storage buckets create \
+    --enable-hierarchical-namespace --uniform-bucket-level-access \
+    --soft-delete-duration=0s --lifecycle-file=lf.json \
+    --location=${REGION}  gs://${BUCKET_NAME}
+  ```
+
+## Running
+
+Start the program and use different files for `stdout` vs. `stderr`:
+
+```shell
+TS=$(date +%s); swift run -c release StorageW1R3 \
+    --bucket-name ${BUCKET_NAME} --max-object-size 128KiB --task-count 4 \
+    >bm-${TS}.txt 2>bm-${TS}.log </dev/null &
+```
+
+Wait for the program to finish.
+
+## Upload results to BigQuery
+
+You can upload the results to BigQuery for analysis using your favorite
+statistical packages.
+
+If you have not done so already, make a dataset:
+
+```shell
+bq mk dataset ${GOOGLE_CLOUD_PROJECT}:w1r3
+```
+
+Then upload the results of the experiment:
+
+```shell
+bq load --source_format CSV --skip_leading_rows 1 \
+    ${GOOGLE_CLOUD_PROJECT}:w1r3.swift001 bm-${TS}.txt \
+    Task:int64,Iteration:int64,IterationStart:int64,Operation,Size:int64,TransferSize:int64,ElapsedMicroseconds:int64,Object,Result,Details
+```
+
+[compute-optimized]: https://cloud.google.com/compute/docs/compute-optimized-machines
+[network bandwidth]: https://cloud.google.com/compute/docs/network-bandwidth

--- a/Tests/StorageW1R3/Sample.swift
+++ b/Tests/StorageW1R3/Sample.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 
+/// The type of storage operation performed during a benchmark step.
 public enum Operation: Sendable {
   case resumable
   case singleShot
@@ -30,6 +31,7 @@ public enum Operation: Sendable {
   }
 }
 
+/// The outcome status of an individual benchmark operation sample.
 public enum ExperimentResult: String, Sendable {
   case ok = "OK"
   case err = "ERR"
@@ -40,6 +42,7 @@ public enum ExperimentResult: String, Sendable {
   }
 }
 
+/// A recorded measurement sample representing the result and timing of a single operation.
 public struct Sample: Sendable {
   public static let header =
     "Task,Iteration,IterationStart,Operation,Size,TransferSize,ElapsedMicroseconds,Object,Result,Details"
@@ -60,6 +63,7 @@ public struct Sample: Sendable {
   }
 }
 
+/// Helper to measure operation duration and build `Sample` instances with relative timestamps.
 public struct SampleBuilder: Sendable {
   public let task: Int
   public let relativeStartMicros: Int64

--- a/Tests/StorageW1R3/Sample.swift
+++ b/Tests/StorageW1R3/Sample.swift
@@ -1,0 +1,145 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+public enum Operation: Sendable {
+  case resumable
+  case singleShot
+  case read(Int)
+  case delete
+
+  public var name: String {
+    switch self {
+    case .resumable: return "RESUMABLE"
+    case .singleShot: return "SINGLE_SHOT"
+    case .read(let index): return "READ[\(index)]"
+    case .delete: return "DELETE"
+    }
+  }
+}
+
+public enum ExperimentResult: String, Sendable {
+  case ok = "OK"
+  case err = "ERR"
+  case int = "INT"
+
+  public var name: String {
+    rawValue
+  }
+}
+
+public struct Sample: Sendable {
+  public static let header =
+    "Task,Iteration,IterationStart,Operation,Size,TransferSize,ElapsedMicroseconds,Object,Result,Details"
+
+  public let task: Int
+  public let iteration: Int
+  public let iterationStartMicros: Int64
+  public let operation: Operation
+  public let size: Int
+  public let transferSize: Int
+  public let elapsedMicros: Int64
+  public let object: String
+  public let result: ExperimentResult
+  public let details: String
+
+  public func toRow() -> String {
+    "\(task),\(iteration),\(iterationStartMicros),\(operation.name),\(size),\(transferSize),\(elapsedMicros),\(object),\(result.name),\(details)"
+  }
+}
+
+public struct SampleBuilder: Sendable {
+  public let task: Int
+  public let relativeStartMicros: Int64
+  public let iteration: Int
+  public let clock: ContinuousClock
+  public let startInstant: ContinuousClock.Instant
+  public let op: Operation
+  public let targetSize: Int
+  public let object: String
+
+  public init(
+    task: Int,
+    taskStartInstant: ContinuousClock.Instant,
+    iteration: Int,
+    op: Operation,
+    targetSize: Int,
+    object: String
+  ) {
+    self.task = task
+    self.clock = ContinuousClock()
+    let now = clock.now
+    let relDuration = taskStartInstant.duration(to: now)
+    self.relativeStartMicros =
+      relDuration.components.seconds * 1_000_000 + relDuration.components.attoseconds
+      / 1_000_000_000_000
+    self.iteration = iteration
+    self.startInstant = now
+    self.op = op
+    self.targetSize = targetSize
+    self.object = object
+  }
+
+  private var elapsedMicroseconds: Int64 {
+    let duration = startInstant.duration(to: clock.now)
+    return duration.components.seconds * 1_000_000 + duration.components.attoseconds
+      / 1_000_000_000_000
+  }
+
+  public func success(transferSize: Int? = nil) -> Sample {
+    Sample(
+      task: task,
+      iteration: iteration,
+      iterationStartMicros: relativeStartMicros,
+      operation: op,
+      size: targetSize,
+      transferSize: transferSize ?? targetSize,
+      elapsedMicros: elapsedMicroseconds,
+      object: object,
+      result: .ok,
+      details: ""
+    )
+  }
+
+  public func error(details: String = "") -> Sample {
+    Sample(
+      task: task,
+      iteration: iteration,
+      iterationStartMicros: relativeStartMicros,
+      operation: op,
+      size: targetSize,
+      transferSize: 0,
+      elapsedMicros: elapsedMicroseconds,
+      object: object,
+      result: .err,
+      details: details.replacingOccurrences(of: ",", with: ";")
+    )
+  }
+
+  public func interrupted(transferSize: Int, details: String = "") -> Sample {
+    Sample(
+      task: task,
+      iteration: iteration,
+      iterationStartMicros: relativeStartMicros,
+      operation: op,
+      size: targetSize,
+      transferSize: transferSize,
+      elapsedMicros: elapsedMicroseconds,
+      object: object,
+      result: .int,
+      details: details.replacingOccurrences(of: ",", with: ";")
+    )
+  }
+}

--- a/Tests/StorageW1R3/Sample.swift
+++ b/Tests/StorageW1R3/Sample.swift
@@ -14,34 +14,6 @@
 
 import Foundation
 
-/// The type of storage operation performed during a benchmark step.
-public enum Operation: Sendable {
-  case resumable
-  case singleShot
-  case read(Int)
-  case delete
-
-  public var name: String {
-    switch self {
-    case .resumable: return "RESUMABLE"
-    case .singleShot: return "SINGLE_SHOT"
-    case .read(let index): return "READ[\(index)]"
-    case .delete: return "DELETE"
-    }
-  }
-}
-
-/// The outcome status of an individual benchmark operation sample.
-public enum ExperimentResult: String, Sendable {
-  case ok = "OK"
-  case err = "ERR"
-  case int = "INT"
-
-  public var name: String {
-    rawValue
-  }
-}
-
 /// A recorded measurement sample representing the result and timing of a single operation.
 public struct Sample: Sendable {
   public static let header =
@@ -60,90 +32,5 @@ public struct Sample: Sendable {
 
   public func toRow() -> String {
     "\(task),\(iteration),\(iterationStartMicros),\(operation.name),\(size),\(transferSize),\(elapsedMicros),\(object),\(result.name),\(details)"
-  }
-}
-
-/// Helper to measure operation duration and build `Sample` instances with relative timestamps.
-public struct SampleBuilder: Sendable {
-  public let task: Int
-  public let relativeStartMicros: Int64
-  public let iteration: Int
-  public let clock: ContinuousClock
-  public let startInstant: ContinuousClock.Instant
-  public let op: Operation
-  public let targetSize: Int
-  public let object: String
-
-  public init(
-    task: Int,
-    taskStartInstant: ContinuousClock.Instant,
-    iteration: Int,
-    op: Operation,
-    targetSize: Int,
-    object: String
-  ) {
-    self.task = task
-    self.clock = ContinuousClock()
-    let now = clock.now
-    let relDuration = taskStartInstant.duration(to: now)
-    self.relativeStartMicros =
-      relDuration.components.seconds * 1_000_000 + relDuration.components.attoseconds
-      / 1_000_000_000_000
-    self.iteration = iteration
-    self.startInstant = now
-    self.op = op
-    self.targetSize = targetSize
-    self.object = object
-  }
-
-  private var elapsedMicroseconds: Int64 {
-    let duration = startInstant.duration(to: clock.now)
-    return duration.components.seconds * 1_000_000 + duration.components.attoseconds
-      / 1_000_000_000_000
-  }
-
-  public func success(transferSize: Int? = nil) -> Sample {
-    Sample(
-      task: task,
-      iteration: iteration,
-      iterationStartMicros: relativeStartMicros,
-      operation: op,
-      size: targetSize,
-      transferSize: transferSize ?? targetSize,
-      elapsedMicros: elapsedMicroseconds,
-      object: object,
-      result: .ok,
-      details: ""
-    )
-  }
-
-  public func error(details: String = "") -> Sample {
-    Sample(
-      task: task,
-      iteration: iteration,
-      iterationStartMicros: relativeStartMicros,
-      operation: op,
-      size: targetSize,
-      transferSize: 0,
-      elapsedMicros: elapsedMicroseconds,
-      object: object,
-      result: .err,
-      details: details.replacingOccurrences(of: ",", with: ";")
-    )
-  }
-
-  public func interrupted(transferSize: Int, details: String = "") -> Sample {
-    Sample(
-      task: task,
-      iteration: iteration,
-      iterationStartMicros: relativeStartMicros,
-      operation: op,
-      size: targetSize,
-      transferSize: transferSize,
-      elapsedMicros: elapsedMicroseconds,
-      object: object,
-      result: .int,
-      details: details.replacingOccurrences(of: ",", with: ";")
-    )
   }
 }

--- a/Tests/StorageW1R3/SampleBuilder.swift
+++ b/Tests/StorageW1R3/SampleBuilder.swift
@@ -1,0 +1,100 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Helper to measure operation duration and build `Sample` instances with relative timestamps.
+public struct SampleBuilder: Sendable {
+  public let task: Int
+  public let relativeStartMicros: Int64
+  public let iteration: Int
+  public let clock: ContinuousClock
+  public let startInstant: ContinuousClock.Instant
+  public let op: Operation
+  public let targetSize: Int
+  public let object: String
+
+  public init(
+    task: Int,
+    taskStartInstant: ContinuousClock.Instant,
+    iteration: Int,
+    op: Operation,
+    targetSize: Int,
+    object: String
+  ) {
+    self.task = task
+    self.clock = ContinuousClock()
+    let now = clock.now
+    let relDuration = taskStartInstant.duration(to: now)
+    self.relativeStartMicros =
+      relDuration.components.seconds * 1_000_000 + relDuration.components.attoseconds
+      / 1_000_000_000_000
+    self.iteration = iteration
+    self.startInstant = now
+    self.op = op
+    self.targetSize = targetSize
+    self.object = object
+  }
+
+  private var elapsedMicroseconds: Int64 {
+    let duration = startInstant.duration(to: clock.now)
+    return duration.components.seconds * 1_000_000 + duration.components.attoseconds
+      / 1_000_000_000_000
+  }
+
+  public func success(transferSize: Int? = nil) -> Sample {
+    Sample(
+      task: task,
+      iteration: iteration,
+      iterationStartMicros: relativeStartMicros,
+      operation: op,
+      size: targetSize,
+      transferSize: transferSize ?? targetSize,
+      elapsedMicros: elapsedMicroseconds,
+      object: object,
+      result: .ok,
+      details: ""
+    )
+  }
+
+  public func error(details: String = "") -> Sample {
+    Sample(
+      task: task,
+      iteration: iteration,
+      iterationStartMicros: relativeStartMicros,
+      operation: op,
+      size: targetSize,
+      transferSize: 0,
+      elapsedMicros: elapsedMicroseconds,
+      object: object,
+      result: .err,
+      details: details.replacingOccurrences(of: ",", with: ";")
+    )
+  }
+
+  public func interrupted(transferSize: Int, details: String = "") -> Sample {
+    Sample(
+      task: task,
+      iteration: iteration,
+      iterationStartMicros: relativeStartMicros,
+      operation: op,
+      size: targetSize,
+      transferSize: transferSize,
+      elapsedMicros: elapsedMicroseconds,
+      object: object,
+      result: .int,
+      details: details.replacingOccurrences(of: ",", with: ";")
+    )
+  }
+}

--- a/Tests/StorageW1R3/SampleBuilder.swift
+++ b/Tests/StorageW1R3/SampleBuilder.swift
@@ -26,21 +26,19 @@ public struct SampleBuilder: Sendable {
   public let object: String
 
   public init(
-    task: Int,
-    taskStartInstant: ContinuousClock.Instant,
-    iteration: Int,
+    iterationId: IterationId,
     op: Operation,
     targetSize: Int,
     object: String
   ) {
-    self.task = task
+    self.task = iterationId.task
     self.clock = ContinuousClock()
     let now = clock.now
-    let relDuration = taskStartInstant.duration(to: now)
+    let relDuration = iterationId.taskStartInstant.duration(to: now)
     self.relativeStartMicros =
       relDuration.components.seconds * 1_000_000 + relDuration.components.attoseconds
       / 1_000_000_000_000
-    self.iteration = iteration
+    self.iteration = iterationId.iteration
     self.startInstant = now
     self.op = op
     self.targetSize = targetSize

--- a/Tests/StorageW1R3/SizeParser.swift
+++ b/Tests/StorageW1R3/SizeParser.swift
@@ -1,0 +1,66 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArgumentParser
+import Foundation
+
+/// Helper to parse human-readable size strings (e.g. "128KiB", "1MiB", "10MB", "0") into byte counts.
+enum SizeParser {
+  /// Parses size strings such as "128KiB", "1MiB", "10MB", "1024", "0" into bytes.
+  static func parse(_ input: String) throws -> Int {
+    let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      throw ValidationError("Size cannot be empty")
+    }
+
+    if let direct = Int(trimmed) {
+      guard direct >= 0 else {
+        throw ValidationError("Size cannot be negative: \(input)")
+      }
+      return direct
+    }
+
+    let units: [(suffix: String, multiplier: Int)] = [
+      ("tib", 1024 * 1024 * 1024 * 1024),
+      ("tb", 1000 * 1000 * 1000 * 1000),
+      ("gib", 1024 * 1024 * 1024),
+      ("gb", 1000 * 1000 * 1000),
+      ("g", 1024 * 1024 * 1024),
+      ("mib", 1024 * 1024),
+      ("mb", 1000 * 1000),
+      ("m", 1024 * 1024),
+      ("kib", 1024),
+      ("kb", 1000),
+      ("k", 1024),
+      ("b", 1),
+    ]
+
+    let lower = trimmed.lowercased()
+    for unit in units {
+      if lower.hasSuffix(unit.suffix) {
+        let numericPart = String(trimmed.dropLast(unit.suffix.count))
+          .trimmingCharacters(in: .whitespaces)
+        if let value = Double(numericPart) {
+          guard value >= 0 else {
+            throw ValidationError("Size cannot be negative: \(input)")
+          }
+          return Int(value * Double(unit.multiplier))
+        }
+      }
+    }
+
+    throw ValidationError(
+      "Invalid size format: '\(input)'. Expected values like '128KiB', '1MiB', '10MB', etc.")
+  }
+}

--- a/Tests/StorageW1R3/StorageOperations.swift
+++ b/Tests/StorageW1R3/StorageOperations.swift
@@ -1,0 +1,117 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import GoogleCloudGax
+import GoogleCloudStorage
+
+enum StorageOperations {
+  /// Uploads data to Google Cloud Storage.
+  static func upload(
+    client: StorageClient,
+    controlClient: StorageControlClient,
+    bucketName: String,
+    objectName: String,
+    data: Data,
+    isResumable: Bool
+  ) async throws -> GoogleCloudStorage.Object {
+    let options = UploadOptions().with {
+      $0.preconditions = StoragePreconditions().with {
+        $0.ifGenerationMatch = 0
+      }
+      // If resumable, chunk size is set to 8MB; if simple, threshold handles it
+      if isResumable {
+        $0.chunkSize = 8 * 1024 * 1024
+      }
+    }
+
+    let task = client.upload(data, to: bucketName, as: objectName, options: options)
+    do {
+      return try await task.value
+    } catch {
+      // If precondition failed (412), check if object already exists
+      if let reqError = error as? RequestError,
+        case .http(let details) = reqError,
+        details.http_status_code == 412
+      {
+        logToStderr("Precondition failed for \(objectName), fetching object details")
+        let getReq = GetObjectRequest().with {
+          $0.bucket = "projects/_/buckets/\(bucketName)"
+          $0.object = objectName
+        }
+        return try await controlClient.getObject(request: getReq, options: .init())
+      }
+      throw error
+    }
+  }
+
+  /// Downloads (reads) an object from Cloud Storage, returning total bytes transferred.
+  static func download(
+    client: StorageClient,
+    bucketName: String,
+    objectName: String,
+    generation: Int64?
+  ) async -> (transferSize: Int, error: (any Error)?) {
+    var options = ReadObjectOptions()
+    if let gen = generation, gen > 0 {
+      options.generation = UInt64(gen)
+    }
+
+    let readTask = client.readObject(from: bucketName, object: objectName, options: options)
+    var transferSize = 0
+    do {
+      for try await chunk in readTask.body {
+        transferSize += chunk.readableBytes
+      }
+      return (transferSize, nil)
+    } catch {
+      return (transferSize, error)
+    }
+  }
+
+  /// Deletes a batch of objects in parallel using StorageControlClient.
+  static func batchDelete(
+    bucketName: String,
+    objects: [String]
+  ) async throws {
+    guard !objects.isEmpty else { return }
+
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      for objectName in objects {
+        group.addTask {
+          let client = try StorageControlClient()
+          let deleteReq = DeleteObjectRequest().with {
+            $0.bucket = "projects/_/buckets/\(bucketName)"
+            $0.object = objectName
+          }
+          do {
+            try await client.deleteObject(request: deleteReq, options: .init())
+          } catch {
+            // Ignore 404 / NOT_FOUND as it may be due to retry
+            if let reqError = error as? RequestError {
+              if case .http(let details) = reqError, details.http_status_code == 404 {
+                return
+              }
+              if case .service(let details) = reqError, details.code == .notFound {
+                return
+              }
+            }
+            throw error
+          }
+        }
+      }
+      try await group.waitForAll()
+    }
+  }
+}

--- a/Tests/StorageW1R3/StorageOperations.swift
+++ b/Tests/StorageW1R3/StorageOperations.swift
@@ -92,7 +92,8 @@ enum StorageOperations {
     try await withThrowingTaskGroup(of: Void.self) { group in
       for objectName in objects {
         group.addTask {
-          let client = try StorageControlClient(ClientOptions().with { $0.credentials = credentials })
+          let client = try StorageControlClient(
+            ClientOptions().with { $0.credentials = credentials })
           let deleteReq = DeleteObjectRequest().with {
             $0.bucket = "projects/_/buckets/\(bucketName)"
             $0.object = objectName

--- a/Tests/StorageW1R3/StorageOperations.swift
+++ b/Tests/StorageW1R3/StorageOperations.swift
@@ -51,7 +51,10 @@ enum StorageOperations {
           $0.bucket = "projects/_/buckets/\(bucketName)"
           $0.object = objectName
         }
-        return try await controlClient.getObject(request: getReq, options: .init())
+        var object = try await controlClient.getObject(request: getReq, options: .init())
+        // TODO(https://github.com/googleapis/google-cloud-swift/issues/517) - cleanup this code
+        object.bucket.replace("projects/_/buckets/", with: "")
+        return object
       }
       throw error
     }
@@ -59,17 +62,14 @@ enum StorageOperations {
 
   /// Downloads (reads) an object from Cloud Storage, returning total bytes transferred.
   static func download(
-    client: StorageClient,
-    bucketName: String,
-    objectName: String,
-    generation: Int64?
+    client: StorageClient, object: GoogleCloudStorage.Object
   ) async -> (transferSize: Int, error: (any Error)?) {
     var options = ReadObjectOptions()
-    if let gen = generation, gen > 0 {
-      options.generation = UInt64(gen)
+    if object.generation > 0 {
+      options.generation = UInt64(object.generation)
     }
 
-    let readTask = client.readObject(from: bucketName, object: objectName, options: options)
+    let readTask = client.readObject(from: object.bucket, object: object.name, options: options)
     var transferSize = 0
     do {
       for try await chunk in readTask.body {
@@ -94,6 +94,7 @@ enum StorageOperations {
           let client = try StorageControlClient(
             ClientOptions().with { $0.credentials = credentials })
           let deleteReq = DeleteObjectRequest().with {
+            // TODO(https://github.com/googleapis/google-cloud-swift/issues/517) - cleanup this code
             $0.bucket = "projects/_/buckets/\(object.bucket)"
             $0.object = object.name
             $0.generation = object.generation

--- a/Tests/StorageW1R3/StorageOperations.swift
+++ b/Tests/StorageW1R3/StorageOperations.swift
@@ -84,19 +84,19 @@ enum StorageOperations {
   /// Deletes a batch of objects in parallel using StorageControlClient.
   static func batchDelete(
     credentials: Credentials,
-    bucketName: String,
-    objects: [String]
+    batch: [GoogleCloudStorage.Object]
   ) async throws {
-    guard !objects.isEmpty else { return }
+    guard !batch.isEmpty else { return }
 
     try await withThrowingTaskGroup(of: Void.self) { group in
-      for objectName in objects {
+      for object in batch {
         group.addTask {
           let client = try StorageControlClient(
             ClientOptions().with { $0.credentials = credentials })
           let deleteReq = DeleteObjectRequest().with {
-            $0.bucket = "projects/_/buckets/\(bucketName)"
-            $0.object = objectName
+            $0.bucket = "projects/_/buckets/\(object.bucket)"
+            $0.object = object.name
+            $0.generation = object.generation
           }
           do {
             try await client.deleteObject(request: deleteReq, options: .init())

--- a/Tests/StorageW1R3/StorageOperations.swift
+++ b/Tests/StorageW1R3/StorageOperations.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import GoogleCloudAuth
 import GoogleCloudGax
 import GoogleCloudStorage
 
@@ -82,6 +83,7 @@ enum StorageOperations {
 
   /// Deletes a batch of objects in parallel using StorageControlClient.
   static func batchDelete(
+    credentials: Credentials,
     bucketName: String,
     objects: [String]
   ) async throws {
@@ -90,7 +92,7 @@ enum StorageOperations {
     try await withThrowingTaskGroup(of: Void.self) { group in
       for objectName in objects {
         group.addTask {
-          let client = try StorageControlClient()
+          let client = try StorageControlClient(ClientOptions().with { $0.credentials = credentials })
           let deleteReq = DeleteObjectRequest().with {
             $0.bucket = "projects/_/buckets/\(bucketName)"
             $0.object = objectName

--- a/Tests/StorageW1R3/StorageW1R3.swift
+++ b/Tests/StorageW1R3/StorageW1R3.swift
@@ -1,0 +1,147 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArgumentParser
+import Foundation
+
+@main
+struct StorageW1R3: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "StorageW1R3",
+    abstract: "W1R3 Benchmark for Google Cloud Storage Swift client library.",
+    discussion: """
+      Benchmarks the Cloud Storage client library. The benchmark uploads an object and
+      reads it multiple times (default 3), reporting single-stream upload and download bandwidth.
+      """
+  )
+
+  @Option(
+    name: .customLong("bucket-name"),
+    help: "The name of the GCS bucket used by the benchmark."
+  )
+  var bucketName: String
+
+  @Option(
+    name: .customLong("min-object-size"),
+    help: "The minimum object size (e.g. 0, 128KiB, 1MiB).",
+    transform: SizeParser.parse
+  )
+  var minObjectSize: Int = 0
+
+  @Option(
+    name: .customLong("max-object-size"),
+    help: "The maximum object size (e.g. 128KiB, 1MiB, 16MiB).",
+    transform: SizeParser.parse
+  )
+  var maxObjectSize: Int = 0
+
+  @Option(
+    name: .customLong("task-count"),
+    help: "The number of concurrent tasks running the benchmark."
+  )
+  var taskCount: Int = 1
+
+  @Option(
+    name: .customLong("iterations"),
+    help: "The number of iterations for each task."
+  )
+  var iterations: Int = 1
+
+  @Option(
+    name: .customLong("min-delete-batch"),
+    help: "The minimum size for the delete batch."
+  )
+  var minDeleteBatch: Int = 20
+
+  @Option(
+    name: .customLong("max-delete-batch"),
+    help: "The maximum size for the delete batch."
+  )
+  var maxDeleteBatch: Int = 20
+
+  @Option(
+    name: .customLong("retry-timeout"),
+    help: "The maximum time for the retry loop (e.g. 900s).",
+    transform: DurationParser.parse
+  )
+  var retryTimeout: Duration?
+
+  @Option(
+    name: .customLong("attempt-timeout"),
+    help: "The maximum time for each attempt (e.g. 30s).",
+    transform: DurationParser.parse
+  )
+  var attemptTimeout: Duration = .seconds(30)
+
+  @Option(
+    name: .customLong("rampup-period"),
+    help: "The rampup period between new tasks (e.g. 500ms).",
+    transform: DurationParser.parse
+  )
+  var rampupPeriod: Duration = .milliseconds(500)
+
+  @Option(
+    name: .customLong("read-count"),
+    help: "Sets the number of reads on each object."
+  )
+  var readCount: Int = 3
+
+  @Flag(
+    name: .customLong("no-delete"),
+    help: "Skip deleting objects after the test."
+  )
+  var noDelete: Bool = false
+
+  @Flag(
+    name: .customLong("debug-retry"),
+    help: "Enable debug logs for retry policies."
+  )
+  var debugRetry: Bool = false
+
+  func validate() throws {
+    guard minObjectSize <= maxObjectSize else {
+      throw ValidationError(
+        "Invalid object size range: min (\(minObjectSize)) > max (\(maxObjectSize))")
+    }
+    guard minDeleteBatch <= maxDeleteBatch else {
+      throw ValidationError(
+        "Invalid delete batch size range: min (\(minDeleteBatch)) > max (\(maxDeleteBatch))")
+    }
+    guard taskCount >= 1 else {
+      throw ValidationError("task-count must be at least 1")
+    }
+    guard iterations >= 1 else {
+      throw ValidationError("iterations must be at least 1")
+    }
+    guard readCount >= 0 else {
+      throw ValidationError("read-count must be non-negative")
+    }
+  }
+
+  func run() async throws {
+    let runner = BenchmarkRunner(
+      bucketName: bucketName,
+      minObjectSize: minObjectSize,
+      maxObjectSize: maxObjectSize,
+      taskCount: taskCount,
+      iterations: iterations,
+      minDeleteBatch: minDeleteBatch,
+      maxDeleteBatch: maxDeleteBatch,
+      rampupPeriod: rampupPeriod,
+      readCount: readCount,
+      noDelete: noDelete
+    )
+    try await runner.execute()
+  }
+}

--- a/Tests/StorageW1R3/StorageW1R3.swift
+++ b/Tests/StorageW1R3/StorageW1R3.swift
@@ -46,21 +46,47 @@ struct StorageW1R3: AsyncParsableCommand, Sendable {
   )
 
   func run() async throws {
-    let runner = BenchmarkRunner(
-      bucketName: bucketName,
-      minObjectSize: minObjectSize,
-      maxObjectSize: maxObjectSize,
-      taskCount: taskCount,
-      iterations: iterations,
-      minDeleteBatch: minDeleteBatch,
-      maxDeleteBatch: maxDeleteBatch,
-      rampupPeriod: rampupPeriod,
-      readCount: readCount,
-      // The double negative is annoying, but that makes it easier define the default argument value.
-      delete: !noDelete,
-      skipOkSamples: skipOkSamples,
+    logToStderr(
+      "# Starting W1R3 benchmark with bucket: \(bucketName), tasks: \(taskCount), iterations: \(iterations)"
     )
-    try await runner.execute()
+
+    let counters = BenchmarkCounters()
+
+    logToStderr("Generating random payload buffer (\(maxObjectSize) bytes)...")
+    let randomBuffer = self.generateRandomBuffer()
+    logToStderr("Random payload buffer ready.")
+
+    // Print CSV header to stdout.
+    print(Sample.header)
+
+    // Start a background task to periodically report the counters to stderr.
+    let monitorTask = Task {
+      while !Task.isCancelled {
+        try? await Task.sleep(for: .seconds(5))
+        if Task.isCancelled { break }
+        let summary = await counters.formattedDescription()
+        logToStderr(summary)
+      }
+    }
+    defer {
+      monitorTask.cancel()
+    }
+
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      for taskIndex in 0..<taskCount {
+        group.addTask {
+          await self.runWorker(
+            taskIndex: taskIndex,
+            counters: counters,
+            buffer: randomBuffer
+          )
+        }
+      }
+      try await group.waitForAll()
+    }
+
+    let finalSummary = await counters.formattedDescription()
+    logToStderr("DONE. Final \(finalSummary)")
   }
 
   @Option(

--- a/Tests/StorageW1R3/StorageW1R3.swift
+++ b/Tests/StorageW1R3/StorageW1R3.swift
@@ -21,10 +21,43 @@ struct StorageW1R3: AsyncParsableCommand {
     commandName: "StorageW1R3",
     abstract: "W1R3 Benchmark for Google Cloud Storage Swift client library.",
     discussion: """
-      Benchmarks the Cloud Storage client library. The benchmark uploads an object and
-      reads it multiple times (default 3), reporting single-stream upload and download bandwidth.
+      The benchmark uploads an object and reads it multiple times (default 3), reporting
+      the time it takes to perform each of these operations to stdout. Usually the results are
+      analyzed using an external script or coLab notebook.
+
+      The benchmark runs multiple concurrrent tasks performing all these operations. This reduces
+      the time to collect enough samples for statistical analysis. If running the benchmark with
+      hundreds or a few thousand tasks, consider a rampup period between them to avoid contention
+      on the credentials.
+
+      To avoid biasing the results, the benchmark randomizes the upload size, the type of upload
+      (resumable vs. single-shot), and even the name of the object. If you want to use an specific
+      object size, set the range accordingly.
+
+      The benchmark cleans up after itself by deleting the objects it uploads. Deleting these
+      objects can become a bottleneck when using many small objects. The benchmark can be configured
+      to delete the objects in batches. The size of the batch is selected at random, from a range
+      specified in the commend line. You can also disable deletion altogether.
       """
   )
+
+  func run() async throws {
+    let runner = BenchmarkRunner(
+      bucketName: bucketName,
+      minObjectSize: minObjectSize,
+      maxObjectSize: maxObjectSize,
+      taskCount: taskCount,
+      iterations: iterations,
+      minDeleteBatch: minDeleteBatch,
+      maxDeleteBatch: maxDeleteBatch,
+      rampupPeriod: rampupPeriod,
+      readCount: readCount,
+      // The double negative is annoying, but that makes it easier define the default argument value.
+      delete: !noDelete,
+      skipOkSamples: skipOkSamples,
+    )
+    try await runner.execute()
+  }
 
   @Option(
     name: .customLong("bucket-name"),
@@ -44,7 +77,7 @@ struct StorageW1R3: AsyncParsableCommand {
     help: "The maximum object size (e.g. 128KiB, 1MiB, 16MiB).",
     transform: SizeParser.parse
   )
-  var maxObjectSize: Int = 0
+  var maxObjectSize: Int = 128 * 1024
 
   @Option(
     name: .customLong("task-count"),
@@ -71,20 +104,6 @@ struct StorageW1R3: AsyncParsableCommand {
   var maxDeleteBatch: Int = 20
 
   @Option(
-    name: .customLong("retry-timeout"),
-    help: "The maximum time for the retry loop (e.g. 900s).",
-    transform: DurationParser.parse
-  )
-  var retryTimeout: Duration?
-
-  @Option(
-    name: .customLong("attempt-timeout"),
-    help: "The maximum time for each attempt (e.g. 30s).",
-    transform: DurationParser.parse
-  )
-  var attemptTimeout: Duration = .seconds(30)
-
-  @Option(
     name: .customLong("rampup-period"),
     help: "The rampup period between new tasks (e.g. 500ms).",
     transform: DurationParser.parse
@@ -104,10 +123,10 @@ struct StorageW1R3: AsyncParsableCommand {
   var noDelete: Bool = false
 
   @Flag(
-    name: .customLong("debug-retry"),
-    help: "Enable debug logs for retry policies."
+    name: .customLong("skip-ok-samples"),
+    help: "Only print samples that failed."
   )
-  var debugRetry: Bool = false
+  var skipOkSamples: Bool = false
 
   func validate() throws {
     guard minObjectSize <= maxObjectSize else {
@@ -127,21 +146,5 @@ struct StorageW1R3: AsyncParsableCommand {
     guard readCount >= 0 else {
       throw ValidationError("read-count must be non-negative")
     }
-  }
-
-  func run() async throws {
-    let runner = BenchmarkRunner(
-      bucketName: bucketName,
-      minObjectSize: minObjectSize,
-      maxObjectSize: maxObjectSize,
-      taskCount: taskCount,
-      iterations: iterations,
-      minDeleteBatch: minDeleteBatch,
-      maxDeleteBatch: maxDeleteBatch,
-      rampupPeriod: rampupPeriod,
-      readCount: readCount,
-      noDelete: noDelete
-    )
-    try await runner.execute()
   }
 }

--- a/Tests/StorageW1R3/StorageW1R3.swift
+++ b/Tests/StorageW1R3/StorageW1R3.swift
@@ -16,25 +16,29 @@ import ArgumentParser
 import Foundation
 
 @main
-struct StorageW1R3: AsyncParsableCommand {
+struct StorageW1R3: AsyncParsableCommand, Sendable {
   static let configuration = CommandConfiguration(
     commandName: "StorageW1R3",
     abstract: "W1R3 Benchmark for Google Cloud Storage Swift client library.",
     discussion: """
-      The benchmark uploads an object and reads it multiple times (default 3), reporting
-      the time it takes to perform each of these operations to stdout. Usually the results are
-      analyzed using an external script or coLab notebook.
+      This program is a benchmark for the Google Cloud Storage client library.
+
+      The benchmark uploads an object and reads it multiple times (default 3), reporting the time it
+      takes to perform each of these operations to stdout. Usually the results are analyzed using an
+      external script or coLab notebook.
 
       The benchmark runs multiple concurrrent tasks performing all these operations. This reduces
       the time to collect enough samples for statistical analysis. If running the benchmark with
       hundreds or a few thousand tasks, consider a rampup period between them to avoid contention
-      on the credentials.
+      on the credentials and other resources used during initialization (e.g. DNS).
 
       To avoid biasing the results, the benchmark randomizes the upload size, the type of upload
-      (resumable vs. single-shot), and even the name of the object. If you want to use an specific
-      object size, set the range accordingly.
+      (resumable vs. single-shot), and even the name of the object. This also removes some of the
+      problems associated with seasonal / diurnal variation in performance for the service.
 
-      The benchmark cleans up after itself by deleting the objects it uploads. Deleting these
+      If you want to use an specific object size, set the range accordingly.
+
+      The benchmark cleans up after itself by deleting the objects it creates. Deleting these
       objects can become a bottleneck when using many small objects. The benchmark can be configured
       to delete the objects in batches. The size of the batch is selected at random, from a range
       specified in the commend line. You can also disable deletion altogether.


### PR DESCRIPTION
This is a canonical benchmark for the Storage SDKs: upload an object, and then read it back 3 times. The upload operation, name, and size of the object are selected at random. The benchmark runs multiple concurrent tasks, reporting single-stream upload and download latency.

The data can be analyzed later to extract throughput, and estimate time-to-first-byte latency.


