### PR TITLE
impl(gax): use `grpc-swift-2`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8e1a366dde2df7f8378a9f11a371ebcf11d279e49eec83cbc8872ea43a35ceae",
+  "originHash" : "4099d176e927e5d6485064ddbf8cb049b1f30f436e9e276be671d1ec45541986",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -11,12 +11,21 @@
       }
     },
     {
-      "identity" : "grpc-swift",
+      "identity" : "grpc-swift-2",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-swift.git",
+      "location" : "https://github.com/grpc/grpc-swift-2.git",
       "state" : {
-        "revision" : "6a8927df5a91710b414caba4f8a088dead4633db",
-        "version" : "1.27.5"
+        "revision" : "28cdd63ef88583ddc67d7bb179eab46fab465ce9",
+        "version" : "2.4.2"
+      }
+    },
+    {
+      "identity" : "grpc-swift-nio-transport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-nio-transport.git",
+      "state" : {
+        "revision" : "eaad084d6c26ff1f2e96f9c2ab76ef84d7165ab6",
+        "version" : "2.9.2"
       }
     },
     {

--- a/packages/gax/Package.swift
+++ b/packages/gax/Package.swift
@@ -32,7 +32,8 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-collections", from: "1.6.0"),
     .package(url: "https://github.com/apple/swift-nio", from: "2.101.0"),
     .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.28.2"),
-    .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.23.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.3.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.3.0"),
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.36.0"),
   ],
   targets: [
@@ -52,7 +53,8 @@ let package = Package(
       dependencies: [
         "GoogleCloudGax",
         .product(name: "GoogleCloudAuth", package: "auth"),
-        .product(name: "GRPC", package: "grpc-swift"),
+        .product(name: "GRPCCore", package: "grpc-swift-2"),
+        .product(name: "GRPCNIOTransportHTTP2Posix", package: "grpc-swift-nio-transport"),
         .product(name: "NIOCore", package: "swift-nio"),
         .product(name: "SwiftProtobuf", package: "swift-protobuf"),
       ]

--- a/packages/gax/Sources/GoogleCloudGaxGRPC/GRPCClient.swift
+++ b/packages/gax/Sources/GoogleCloudGaxGRPC/GRPCClient.swift
@@ -13,16 +13,32 @@
 // limitations under the License.
 
 import Foundation
-import GRPC
+import GRPCCore
+import GRPCNIOTransportHTTP2Posix
 import GoogleCloudAuth
 @_spi(GoogleCloudInternal) import GoogleCloudGax
-import NIO
 import SwiftProtobuf
 
 /// Implements a generic gRPC client for the Swift SDK client libraries.
+///
+/// ## Usage and Lifecycle Guidelines
+/// - **Resource Management**: Each `_GRPCClient` manages an underlying HTTP/2 transport connection
+///   loop running inside a background `Task`.
+/// - **Shutdown**:
+///   - Calling ``close()`` initiates a graceful shutdown (`beginGracefulShutdown()`). In-flight RPCs
+///     are allowed to finish executing, while any new RPCs will be rejected.
+///   - If ``close()`` is not explicitly called, the background connection task is automatically shut down
+///     when the `_GRPCClient` instance is deallocated (`deinit`).
+/// - **Async Invariants & Lifetimes**:
+///   - Calls to ``execute(path:request:options:clientHeader:routingParams:)`` retain the `_GRPCClient`
+///     instance for the duration of the asynchronous execution, so the instance will not be deallocated
+///     while an RPC is in flight.
+///   - Calling ``close()`` will allow active in-flight RPCs to drain, but any subsequent calls to
+///     ``execute`` will fail.
 @_spi(GoogleCloudInternal)
-public struct _GRPCClient: Sendable {
-  let connection: ClientConnection
+public final class _GRPCClient: Sendable {
+  let client: GRPCClient<HTTP2ClientTransport.Posix>
+  let connectionTask: Task<Void, any Error>
   let credentials: GoogleCloudAuth.Credentials
 
   public init(from options: ClientOptions, withDefaultEndpoint defaultEndpoint: String) throws {
@@ -38,13 +54,31 @@ public struct _GRPCClient: Sendable {
 
     let isSecure = components.scheme == "https"
     let port = components.port ?? (isSecure ? 443 : 80)
-    let group = MultiThreadedEventLoopGroup.singleton
-    let builder =
-      isSecure
-      ? ClientConnection.usingPlatformAppropriateTLS(for: group)
-      : ClientConnection.insecure(group: group)
+    let transportSecurity: HTTP2ClientTransport.Posix.TransportSecurity =
+      isSecure ? .tls : .plaintext
 
-    self.connection = builder.connect(host: host, port: port)
+    let transport = try HTTP2ClientTransport.Posix(
+      target: .dns(host: host, port: port),
+      transportSecurity: transportSecurity
+    )
+
+    let client = GRPCClient(transport: transport)
+    self.client = client
+    self.connectionTask = Task {
+      try await client.runConnections()
+    }
+  }
+
+  /// Initiates graceful shutdown of the client connection.
+  ///
+  /// In-flight RPCs are allowed to finish, but no new requests will be accepted.
+  public func close() {
+    self.client.beginGracefulShutdown()
+  }
+
+  deinit {
+    self.client.beginGracefulShutdown()
+    self.connectionTask.cancel()
   }
 
   /// Executes a generic unary gRPC request.
@@ -63,30 +97,48 @@ public struct _GRPCClient: Sendable {
     clientHeader: String,
     routingParams: [String] = []
   ) async throws -> Resp {
-    var callOptions = CallOptions()
-
+    var callOptions = CallOptions.defaults
     if let attemptTimeout = options.attemptTimeout {
-      callOptions.timeLimit = .timeout(.nanoseconds(Int64(attemptTimeout / .nanoseconds(1))))
+      callOptions.timeout = attemptTimeout
     }
 
+    var metadata = Metadata()
     let authHeaders = try await self.credentials.headers()
     for (key, value) in authHeaders {
-      callOptions.customMetadata.add(name: key, value: value)
+      metadata.addString(value, forKey: key)
     }
 
-    callOptions.customMetadata.add(name: _HeaderNames.apiClient, value: clientHeader)
+    metadata.addString(clientHeader, forKey: _HeaderNames.apiClient)
     if !routingParams.isEmpty {
-      callOptions.customMetadata.add(
-        name: _HeaderNames.requestParams,
-        value: routingParams.joined(separator: "&")
+      metadata.addString(
+        routingParams.joined(separator: "&"),
+        forKey: _HeaderNames.requestParams
       )
     }
 
-    let call: UnaryCall<Req, Resp> = self.connection.makeUnaryCall(
-      path: path,
-      request: request,
-      callOptions: callOptions
+    let normalizedPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
+    let parts = normalizedPath.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: true)
+    guard parts.count == 2 else {
+      throw ClientError.invalidEndpoint("Invalid gRPC path: \(path)")
+    }
+    let service = String(parts[0])
+    let method = String(parts[1])
+
+    let descriptor = MethodDescriptor(
+      service: ServiceDescriptor(fullyQualifiedService: service),
+      method: method
     )
-    return try await call.response.get()
+
+    let clientRequest = ClientRequest(message: request, metadata: metadata)
+    return try await self.client.unary(
+      request: clientRequest,
+      descriptor: descriptor,
+      serializer: ProtobufSerializer<Req>(),
+      deserializer: ProtobufDeserializer<Resp>(),
+      options: callOptions,
+      onResponse: { response in
+        try response.message
+      }
+    )
   }
 }

--- a/packages/gax/Sources/GoogleCloudGaxGRPC/ProtobufDeserializer.swift
+++ b/packages/gax/Sources/GoogleCloudGaxGRPC/ProtobufDeserializer.swift
@@ -1,0 +1,37 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import GRPCCore
+import SwiftProtobuf
+
+/// A Protobuf message deserializer for gRPC Swift 2.
+///
+/// ## Architectural Background
+/// In gRPC Swift 2 (`GRPCCore`), the core RPC execution engine is decoupled from any specific serialization
+/// format (such as Protocol Buffers, JSON, or FlatBuffers). Incoming message payloads are delivered from
+/// the transport as raw bytes conforming to `GRPCContiguousBytes`, and deserialization is delegated to
+/// types conforming to `GRPCCore.MessageDeserializer`.
+///
+/// While the official companion package [`grpc-swift-protobuf`](https://github.com/grpc/grpc-swift-protobuf)
+/// provides protobuf deserialization, implementing this lightweight bridge directly avoids an additional
+/// package dependency while fulfilling the `GRPCCore.MessageDeserializer` protocol requirement.
+struct ProtobufDeserializer<Message: SwiftProtobuf.Message>: MessageDeserializer {
+  func deserialize<Bytes: GRPCContiguousBytes>(_ serializedMessageBytes: Bytes) throws -> Message {
+    try serializedMessageBytes.withUnsafeBytes { rawBuffer in
+      let data = Data(rawBuffer)
+      return try Message(serializedBytes: data)
+    }
+  }
+}

--- a/packages/gax/Sources/GoogleCloudGaxGRPC/ProtobufSerializer.swift
+++ b/packages/gax/Sources/GoogleCloudGaxGRPC/ProtobufSerializer.swift
@@ -1,0 +1,37 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import GRPCCore
+import SwiftProtobuf
+
+/// A Protobuf message serializer for gRPC Swift 2.
+///
+/// ## Background
+///
+/// In gRPC Swift 2 (`GRPCCore`), the core RPC execution engine is decoupled from any specific serialization
+/// format (such as Protocol Buffers, JSON, or FlatBuffers). `GRPCCore` operates exclusively on generic
+/// byte representations conforming to `GRPCContiguousBytes` and delegates message transformation to types
+/// conforming to `GRPCCore.MessageSerializer`.
+///
+/// While the official companion package [`grpc-swift-protobuf`](https://github.com/grpc/grpc-swift-protobuf)
+/// provides protobuf serialization, implementing this lightweight bridge directly avoids an additional
+/// package dependency while fulfilling the `GRPCCore.MessageSerializer` protocol requirement.
+///
+/// If we need to change this and take the dependency, that is an easy change that does not affect the public API.
+struct ProtobufSerializer<Message: SwiftProtobuf.Message>: MessageSerializer {
+  func serialize<Bytes: GRPCContiguousBytes>(_ message: Message) throws -> Bytes {
+    let data = try message.serializedData()
+    return Bytes(data)
+  }
+}

--- a/packages/gax/Tests/GRPCClientTests.swift
+++ b/packages/gax/Tests/GRPCClientTests.swift
@@ -24,7 +24,7 @@ import GoogleCloudGax
     let options = ClientOptions().with { $0.credentials = credentials }
     let client = try _GRPCClient(
       from: options, withDefaultEndpoint: "https://storage.googleapis.com")
-    _ = client.connection.close()
+    client.close()
   }
 
   @Test func customEndpoints() throws {
@@ -37,7 +37,7 @@ import GoogleCloudGax
     }
     let secureClient = try _GRPCClient(
       from: secureOptions, withDefaultEndpoint: "https://storage.googleapis.com")
-    _ = secureClient.connection.close()
+    secureClient.close()
 
     // With explicit http (insecure emulator)
     let insecureOptions = ClientOptions().with {
@@ -46,7 +46,7 @@ import GoogleCloudGax
     }
     let insecureClient = try _GRPCClient(
       from: insecureOptions, withDefaultEndpoint: "https://storage.googleapis.com")
-    _ = insecureClient.connection.close()
+    insecureClient.close()
 
     // Without scheme (auto https)
     let bareOptions = ClientOptions().with {
@@ -55,7 +55,7 @@ import GoogleCloudGax
     }
     let bareClient = try _GRPCClient(
       from: bareOptions, withDefaultEndpoint: "https://storage.googleapis.com")
-    _ = bareClient.connection.close()
+    bareClient.close()
   }
 
   @Test(arguments: [
@@ -71,7 +71,7 @@ import GoogleCloudGax
     #expect(throws: ClientError.self) {
       let client = try _GRPCClient(
         from: options, withDefaultEndpoint: "https://storage.googleapis.com")
-      _ = client.connection.close()
+      client.close()
     }
   }
 }

--- a/packages/gax/Tests/ProtobufCodingGRPCTests.swift
+++ b/packages/gax/Tests/ProtobufCodingGRPCTests.swift
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import GRPCCore
+@_spi(GoogleCloudInternal) @testable import GoogleCloudGaxGRPC
+import SwiftProtobuf
+import Testing
+
+@Suite struct ProtobufCodingGRPCTests {
+  @Test func roundtripDurationMessage() throws {
+    var duration = Google_Protobuf_Duration()
+    duration.seconds = 120
+    duration.nanos = 500_000
+
+    let serializer = ProtobufSerializer<Google_Protobuf_Duration>()
+    let bytes: [UInt8] = try serializer.serialize(duration)
+
+    let deserializer = ProtobufDeserializer<Google_Protobuf_Duration>()
+    let decoded: Google_Protobuf_Duration = try deserializer.deserialize(bytes)
+
+    #expect(decoded.seconds == duration.seconds)
+    #expect(decoded.nanos == duration.nanos)
+  }
+
+  @Test func deserializeEmptyBytes() throws {
+    let deserializer = ProtobufDeserializer<Google_Protobuf_Empty>()
+    let emptyBytes: [UInt8] = []
+    let decoded: Google_Protobuf_Empty = try deserializer.deserialize(emptyBytes)
+
+    #expect(decoded == Google_Protobuf_Empty())
+  }
+}


### PR DESCRIPTION
Change the implementation to use `grpc-swift-2`, which is the new shinny, designed to use Swift structured concurrency from the bottom up

LLM Disclosure: largely implemented by Jetski.

Fixes #513 and fixes #520 