### PR TITLE
feat(storage): `StorageClient` is `Sendable`

### DIFF
--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient.swift
@@ -21,7 +21,7 @@ import GoogleCloudAuth
 /// Use this client to write (upload) and read (download) objects in the Cloud Storage service.
 ///
 /// [Cloud Storage]: https://docs.cloud.google.com/storage
-public final class StorageClient: StorageClientProtocol {
+public final class StorageClient: StorageClientProtocol, Sendable {
   public static let defaultEndpoint = "https://storage.googleapis.com"
 
   let inner: GoogleCloudGax._HTTPClient

--- a/packages/storage/Tests/StorageClientTests.swift
+++ b/packages/storage/Tests/StorageClientTests.swift
@@ -30,4 +30,10 @@ import Testing
     let client = try StorageClient(options)
     #expect(client.options.client.endpoint == "https://override.googleapis.com")
   }
+
+  static func assertSendable<T: Sendable>(_ type: T.Type) {}
+
+  @Test func clientIsSendable() {
+    Self.assertSendable(StorageClient.self)
+  }
 }


### PR DESCRIPTION
We need to explicitly declare the clients as sendable so we can share them across tasks.

Towards #515 