### PR TITLE
feat(storage): `StorageClient` is `Sendable` (#531)

### DIFF
--- a/packages/gax/Sources/GoogleCloudGax/RequestOptions.swift
+++ b/packages/gax/Sources/GoogleCloudGax/RequestOptions.swift
@@ -40,6 +40,18 @@ public struct RequestOptions: Sendable {
   /// policy.
   public var attemptTimeout: Duration? = nil
 
+  /// Overrides the request idempotency.
+  ///
+  /// Use this option if the service documentation describes the request as idempotent under certain
+  /// conditions or if the heuristic used by the client libraries is overly conservative.
+  ///
+  /// The client libraries use a (conservative) heuristic to determine which requests are
+  /// idempotent: only `GET` and `PUT` requests are considered idempotent. In some services, the
+  /// idempotency depends on the request parameters. And in some services, `POST` or `DELETE`
+  /// requests are idempotent though in general they might not be. Use this setting to override the
+  /// default.
+  public var idempotency: Bool? = nil
+
   /// Overrides the default retry policy.
   ///
   /// Without an override, the request uses the retry policy configured in the client.

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient.swift
@@ -21,7 +21,7 @@ import GoogleCloudAuth
 /// Use this client to write (upload) and read (download) objects in the Cloud Storage service.
 ///
 /// [Cloud Storage]: https://docs.cloud.google.com/storage
-public final class StorageClient: StorageClientProtocol {
+public final class StorageClient: StorageClientProtocol, Sendable {
   public static let defaultEndpoint = "https://storage.googleapis.com"
 
   let inner: GoogleCloudGax._HTTPClient

--- a/packages/storage/Tests/StorageClientTests.swift
+++ b/packages/storage/Tests/StorageClientTests.swift
@@ -30,4 +30,10 @@ import Testing
     let client = try StorageClient(options)
     #expect(client.options.client.endpoint == "https://override.googleapis.com")
   }
+
+  static func assertSendable<T: Sendable>(_ type: T.Type) {}
+
+  @Test func clientIsSendable() {
+    Self.assertSendable(StorageClient.self)
+  }
 }


### PR DESCRIPTION
We need to explicitly declare the clients as sendable so we can share them across tasks. 

Towards #516, the field is unused until the generator changes.