### PR TITLE
feat(gax): idempotency override in `RequestOption`

### DIFF
--- a/packages/gax/Sources/GoogleCloudGax/RequestOptions.swift
+++ b/packages/gax/Sources/GoogleCloudGax/RequestOptions.swift
@@ -40,6 +40,18 @@ public struct RequestOptions: Sendable {
   /// policy.
   public var attemptTimeout: Duration? = nil
 
+  /// Overrides the request idempotency.
+  ///
+  /// Use this option if the service documentation describes the request as idempotent under certain
+  /// conditions or if the heuristic used by the client libraries is overly conservative.
+  ///
+  /// The client libraries use a (conservative) heuristic to determine which requests are
+  /// idempotent: only `GET` and `PUT` requests are considered idempotent. In some services, the
+  /// idempotency depends on the request parameters. And in some services, `POST` or `DELETE`
+  /// requests are idempotent though in general they might not be. Use this setting to override the
+  /// default.
+  public var idempotency: Bool? = nil
+
   /// Overrides the default retry policy.
   ///
   /// Without an override, the request uses the retry policy configured in the client.

--- a/packages/gax/Sources/GoogleCloudGax/RetryLoop.swift
+++ b/packages/gax/Sources/GoogleCloudGax/RetryLoop.swift
@@ -49,7 +49,7 @@ import Foundation
     self.retryPolicy = options.retryPolicy ?? withDefault.retryPolicy
     self.backoffPolicy = options.backoffPolicy ?? withDefault.backoffPolicy
     self.retryThrottler = options.retryThrottler ?? withDefault.retryThrottler
-    self.idempotent = idempotent
+    self.idempotent = options.idempotency ?? idempotent
   }
 
   /// Runs the retry loop.

--- a/packages/gax/Tests/RetryLoopTests.swift
+++ b/packages/gax/Tests/RetryLoopTests.swift
@@ -16,7 +16,7 @@ import Foundation
 import GoogleRpc
 import Synchronization
 import Testing
-@_spi(GoogleCloudInternal) import GoogleCloudGax
+@_spi(GoogleCloudInternal) @testable import GoogleCloudGax
 
 @Suite struct RetryLoopTest {
   func permanent() -> RequestError {
@@ -25,6 +25,62 @@ import Testing
 
   func transient() -> RequestError {
     RequestError.service(ServiceError(code: Code.unavailable, message: "try-again"))
+  }
+
+  @Test func retryPolicyFromDefault() {
+    let defaultOptions = ClientOptions().with { $0.retryPolicy = AlwaysRetry() }
+    let requestOptions = RequestOptions()
+    let loop = _RetryLoop(options: requestOptions, withDefault: defaultOptions, idempotent: true)
+    #expect(loop.retryPolicy is AlwaysRetry)
+  }
+
+  @Test func retryPolicyFromRequest() {
+    let defaultOptions = ClientOptions().with { $0.retryPolicy = AlwaysRetry() }
+    let requestOptions = RequestOptions().with { $0.retryPolicy = NeverRetry() }
+    let loop = _RetryLoop(options: requestOptions, withDefault: defaultOptions, idempotent: true)
+    #expect(loop.retryPolicy is NeverRetry)
+  }
+
+  @Test func backoffPolicyFromDefault() {
+    let defaultOptions = ClientOptions().with { $0.backoffPolicy = LinearBackoffPolicy() }
+    let requestOptions = RequestOptions()
+    let loop = _RetryLoop(options: requestOptions, withDefault: defaultOptions, idempotent: true)
+    #expect(loop.backoffPolicy is LinearBackoffPolicy)
+  }
+
+  @Test func backoffPolicyFromRequest() {
+    let defaultOptions = ClientOptions().with { $0.backoffPolicy = LinearBackoffPolicy() }
+    let requestOptions = RequestOptions().with { $0.backoffPolicy = ExponentialBackoff() }
+    let loop = _RetryLoop(options: requestOptions, withDefault: defaultOptions, idempotent: true)
+    #expect(loop.backoffPolicy is ExponentialBackoff)
+  }
+
+  @Test func throttlerFromDefault() {
+    let defaultOptions = ClientOptions().with { $0.retryThrottler = CircuitBreaker() }
+    let requestOptions = RequestOptions()
+    let loop = _RetryLoop(options: requestOptions, withDefault: defaultOptions, idempotent: true)
+    #expect(loop.retryThrottler is CircuitBreaker)
+  }
+
+  @Test func throttlerFromRequest() {
+    let defaultOptions = ClientOptions().with { $0.retryThrottler = CircuitBreaker() }
+    let requestOptions = RequestOptions().with { $0.retryThrottler = AdaptiveThrottler() }
+    let loop = _RetryLoop(options: requestOptions, withDefault: defaultOptions, idempotent: true)
+    #expect(loop.retryThrottler is AdaptiveThrottler)
+  }
+
+  @Test(arguments: [
+    (nil, true, true),
+    (nil, false, false),
+    (true, false, true),
+    (false, true, false),
+  ])
+  func idempotencyInitialization(override: Bool?, heuristic: Bool, want: Bool) {
+    let defaultOptions = ClientOptions()
+    let requestOptions = RequestOptions().with { $0.idempotency = override }
+    let loop = _RetryLoop(
+      options: requestOptions, withDefault: defaultOptions, idempotent: heuristic)
+    #expect(loop.idempotent == want)
   }
 
   @Test func immediateSuccess() async throws {


### PR DESCRIPTION
Add a new field to `RequestOptions` to override the default request idempotency.

Change the initializer used by all the GAPICs to use this field.

The initializer is almost trivial, but I wrote some tests anyway.

Towards #516, at least all the GAPICs (including `StorageControl`) are fixed. We may want to do something in the resume loop for storage.
