### PR TITLE
test(storage): verify control client is `Sendable`

### DIFF
--- a/packages/storage/Tests/StorageControlClientTests.swift
+++ b/packages/storage/Tests/StorageControlClientTests.swift
@@ -27,6 +27,12 @@ import Testing
     let _ = try StorageControlClient(options)
   }
 
+  static func assertSendable<T: Sendable>(_ type: T.Type) {}
+
+  @Test func clientIsSendable() {
+    Self.assertSendable(StorageControlClient.self)
+  }
+
   @Test func initializationWithCustomEndpoints() throws {
     let credentials = try Credentials(configuration: .anonymous)
 


### PR DESCRIPTION
Just because we have a test for the normal client. This is generated code after all.