### PR TITLE
cleanup(storage)!: consistent  `*Protocol` names

### DIFF
--- a/doc/design/storage_download_api_design.md
+++ b/doc/design/storage_download_api_design.md
@@ -315,7 +315,7 @@ public struct ReadObjectTask: Sendable {
 ### StorageClient Extensions & Protocols
 
 ```swift
-public protocol StorageClientProtocol {
+public protocol StorageProtocol {
   func readObject(
     from bucket: String,
     object: String,
@@ -323,7 +323,7 @@ public protocol StorageClientProtocol {
   ) -> ReadObjectTask
 }
 
-extension StorageClientProtocol {
+extension StorageProtocol {
   public func readObject(
     from bucket: String,
     object: String
@@ -364,8 +364,8 @@ extension StorageClient {
 - *Description:* Use Swift 5.7+ opaque return types (`func readObject(...) -> some AsyncSequence<Data, any Error> & Sendable`) instead of exposing `ReadObjectSequence`.
 - *Trade-offs:*
   - *Pros:* Hides internal implementation details and allows changing the underlying stream implementation in future releases without breaking API signature compatibility.
-  - *Cons:* In Swift protocol declarations (`StorageClientProtocol`), returning `some` forces all conforming implementations (including test mocks) to use the exact same underlying concrete type, or requires adding an `associatedtype` requirement to the protocol.
-- *Recommendation:* If `StorageClientProtocol` needs flexibility across different mock implementations without complex protocol generic constraints, returning `ReadObjectSequence` or `any AsyncSequence<Data, any Error> & Sendable` (or an `AsyncThrowingStream<Data, Error>`) is preferable.
+  - *Cons:* In Swift protocol declarations (`StorageProtocol`), returning `some` forces all conforming implementations (including test mocks) to use the exact same underlying concrete type, or requires adding an `associatedtype` requirement to the protocol.
+- *Recommendation:* If `StorageProtocol` needs flexibility across different mock implementations without complex protocol generic constraints, returning `ReadObjectSequence` or `any AsyncSequence<Data, any Error> & Sendable` (or an `AsyncThrowingStream<Data, Error>`) is preferable.
 
 ### Option E: Returning `ReadObjectSequence` Directly (Without Metadata Container)
 - *Description:* Return `ReadObjectSequence` directly from `readObject` non-asynchronously without an initial handshake, deferring HTTP connection until iteration starts.

--- a/packages/storage/Sources/GoogleCloudStorage/GoogleCloudStorage.docc/GoogleCloudStorage.md
+++ b/packages/storage/Sources/GoogleCloudStorage/GoogleCloudStorage.docc/GoogleCloudStorage.md
@@ -20,5 +20,5 @@ Use ``StorageControlClient`` for other operations, including listing, deleting,
 updating object metadata, object rewrites, and object composition. The same
 type can be used to perform all operations on [buckets].
 
-Use ``StorageClientProtocol`` and ``StorageControlProtocol`` if you want
+Use ``StorageProtocol`` and ``StorageControlProtocol`` if you want
 to mock the clients in your tests.

--- a/packages/storage/Sources/GoogleCloudStorage/StorageClient.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageClient.swift
@@ -21,7 +21,7 @@ import GoogleCloudAuth
 /// Use this client to write (upload) and read (download) objects in the Cloud Storage service.
 ///
 /// [Cloud Storage]: https://docs.cloud.google.com/storage
-public final class StorageClient: StorageClientProtocol, Sendable {
+public final class StorageClient: StorageProtocol, Sendable {
   public static let defaultEndpoint = "https://storage.googleapis.com"
 
   let inner: GoogleCloudGax._HTTPClient

--- a/packages/storage/Sources/GoogleCloudStorage/StorageProtocol.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/StorageProtocol.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// Protocol defining the high-level object data-plane operations.
-public protocol StorageClientProtocol {
+public protocol StorageProtocol {
   /// Core upload method accepting any upload source.
   func upload(
     _ source: some UploadSource,


### PR DESCRIPTION
The names were inconsistent:

- StorageControlClient -> StorageControlProtocol
- StorageClient -> StorageClientProtocol (extra "Client")

This renames `StorageClientProtocol` to simply `StorageProtocol`.

Fixes #530 