### PR TITLE
fix(storage)!: make ReadObjectRange accept ClosedRange

### DIFF
--- a/doc/design/storage_download_api_design.md
+++ b/doc/design/storage_download_api_design.md
@@ -112,12 +112,12 @@ public enum ReadObjectRange: Sendable, Hashable, Equatable {
   /// Read the last `count` bytes of the object (HTTP `bytes=-N`).
   case suffix(UInt64)
 
-  /// Read a bounded range of bytes from `start` to `end` inclusive (HTTP `bytes=start-end`).
-  case bounded(start: UInt64, end: UInt64)
+  /// Read a bounded range of bytes from `range.lowerBound` to `range.upperBound` inclusive (HTTP `bytes=start-end`).
+  case bounded(ClosedRange<UInt64>)
 
   /// Convenience initializer for Swift `ClosedRange<UInt64>`.
   public init(_ range: ClosedRange<UInt64>) {
-    self = .bounded(start: range.lowerBound, end: range.upperBound)
+    self = .bounded(range)
   }
 
   /// Converts the range specification to an HTTP `Range` header value string.
@@ -129,8 +129,8 @@ public enum ReadObjectRange: Sendable, Hashable, Equatable {
       return "bytes=\(offset)-"
     case .suffix(let count):
       return "bytes=-\(count)"
-    case .bounded(let start, let end):
-      return "bytes=\(start)-\(end)"
+    case .bounded(let range):
+      return "bytes=\(range.lowerBound)-\(range.upperBound)"
     }
   }
 }
@@ -216,7 +216,7 @@ public enum ReadObjectRange: Sendable, Hashable, Equatable {
   case entire
   case fromOffset(UInt64)
   case suffix(UInt64)
-  case bounded(start: UInt64, end: UInt64)
+  case bounded(ClosedRange<UInt64>)
 
   public init(_ range: ClosedRange<UInt64>)
   public var headerValue: String? { get }

--- a/packages/storage/Sources/GoogleCloudStorage/DownloadOptions.swift
+++ b/packages/storage/Sources/GoogleCloudStorage/DownloadOptions.swift
@@ -30,12 +30,28 @@ public enum ReadObjectRange: Sendable, Hashable, Equatable {
   /// Read the last `count` bytes of the object (HTTP `bytes=-N`).
   case suffix(UInt64)
 
-  /// Read a bounded range of bytes from `start` to `end` inclusive (HTTP `bytes=start-end`).
-  case bounded(start: UInt64, end: UInt64)
+  /// Read a bounded range of bytes from `range.lowerBound` to `range.upperBound` inclusive (HTTP `bytes=start-end`).
+  case bounded(ClosedRange<UInt64>)
 
   /// Convenience initializer for Swift `ClosedRange<UInt64>`.
   public init(_ range: ClosedRange<UInt64>) {
-    self = .bounded(start: range.lowerBound, end: range.upperBound)
+    self = .bounded(range)
+  }
+
+  /// Convenience initializer for Swift `PartialRangeFrom<UInt64>` (e.g. `1024...`).
+  public init(_ range: PartialRangeFrom<UInt64>) {
+    self = .fromOffset(range.lowerBound)
+  }
+
+  /// Convenience initializer for Swift `PartialRangeThrough<UInt64>` (e.g. `...1024`).
+  public init(_ range: PartialRangeThrough<UInt64>) {
+    self = .bounded(0...range.upperBound)
+  }
+
+  /// Creates a bounded range from `start` to `end` inclusive, or returns `nil` if `end < start`.
+  public init?(start: UInt64, end: UInt64) {
+    guard start <= end else { return nil }
+    self = .bounded(start...end)
   }
 
   /// Converts the range specification to an HTTP `Range` header value string.
@@ -49,8 +65,8 @@ public enum ReadObjectRange: Sendable, Hashable, Equatable {
       return count > 0 ? "bytes=0-\(count - 1)" : "bytes=0-0"
     case .suffix(let count):
       return "bytes=-\(count)"
-    case .bounded(let start, let end):
-      return "bytes=\(start)-\(end)"
+    case .bounded(let range):
+      return "bytes=\(range.lowerBound)-\(range.upperBound)"
     }
   }
 }
@@ -113,7 +129,7 @@ struct HttpContentRange: Sendable, Hashable, Equatable {
 ///
 /// ```swift
 /// let options = ReadObjectOptions().with {
-///   $0.range = .bounded(start: 0, end: 1024)
+///   $0.range = .bounded(0...1024)
 /// }
 /// ```
 ///
@@ -255,11 +271,11 @@ package func calculateResumeRange(
     return .fromOffset(offset + bytesReceived)
   case .prefix(let count):
     guard count > bytesReceived else { return nil }
-    return .bounded(start: bytesReceived, end: count - 1)
-  case .bounded(let start, let end):
-    let newStart = start + bytesReceived
-    guard newStart <= end else { return nil }
-    return .bounded(start: newStart, end: end)
+    return .bounded(bytesReceived...(count - 1))
+  case .bounded(let range):
+    let newStart = range.lowerBound + bytesReceived
+    guard newStart <= range.upperBound else { return nil }
+    return .bounded(newStart...range.upperBound)
   case .suffix(let count):
     guard let totalSize = totalSize, totalSize > 0 else {
       return .fromOffset(bytesReceived)
@@ -267,7 +283,7 @@ package func calculateResumeRange(
     let startOffset = totalSize > count ? (totalSize - count) : 0
     let newStart = startOffset + bytesReceived
     guard newStart < totalSize else { return nil }
-    return .bounded(start: newStart, end: totalSize - 1)
+    return .bounded(newStart...(totalSize - 1))
   }
 }
 
@@ -658,11 +674,6 @@ package final class ReadObjectCoordinator: @unchecked Sendable {
     resumeLoop: _ResumeLoop<DownloadDetails>,
     resumeState: ResumeState<DownloadDetails>
   ) async throws -> (_HTTPClientResponse, ReadObjectMetadata) {
-    if case .bounded(let start, let end) = options.range {
-      guard start <= end else {
-        throw DownloadError.invalidRangeHeader("Range start (\(start)) must be <= end (\(end)).")
-      }
-    }
     do {
       return try await resumeLoop.run(state: resumeState) { _ in
         let request = try await httpClient.buildReadObjectRequest(

--- a/packages/storage/Tests/DownloadChecksumTests.swift
+++ b/packages/storage/Tests/DownloadChecksumTests.swift
@@ -516,7 +516,7 @@ import Testing
 
     let client = try makeClient(registry: registry)
     let options = ReadObjectOptions().with {
-      $0.range = .bounded(start: 0, end: 9)
+      $0.range = .bounded(0...9)
     }
     let result = client.readObject(from: bucket, object: objectName, options: options)
 
@@ -563,7 +563,7 @@ import Testing
 
     let client = try makeClient(registry: registry)
     let options = ReadObjectOptions().with {
-      $0.range = .bounded(start: 0, end: 9)
+      $0.range = .bounded(0...9)
       $0.checksums = ChecksumOptions(crc32c: .value(rangeCrcBase64), md5: nil)
     }
     let result = client.readObject(from: bucket, object: objectName, options: options)
@@ -576,7 +576,7 @@ import Testing
 
     // User provided wrong CRC for range throws mismatch
     let wrongOptions = ReadObjectOptions().with {
-      $0.range = .bounded(start: 0, end: 9)
+      $0.range = .bounded(0...9)
       $0.checksums = ChecksumOptions(crc32c: "wrong_range_crc", md5: nil)
     }
     let wrongResult = client.readObject(from: bucket, object: objectName, options: wrongOptions)

--- a/packages/storage/Tests/DownloadOptionsTests.swift
+++ b/packages/storage/Tests/DownloadOptionsTests.swift
@@ -24,9 +24,13 @@ import Testing
     #expect(ReadObjectRange.prefix(500).headerValue == "bytes=0-499")
     #expect(ReadObjectRange.prefix(0).headerValue == "bytes=0-0")
     #expect(ReadObjectRange.suffix(100).headerValue == "bytes=-100")
-    #expect(ReadObjectRange.bounded(start: 10, end: 50).headerValue == "bytes=10-50")
+    #expect(ReadObjectRange.bounded(10...50).headerValue == "bytes=10-50")
     #expect(ReadObjectRange(10...50).headerValue == "bytes=10-50")
-    #expect(ReadObjectRange(10...50) == ReadObjectRange.bounded(start: 10, end: 50))
+    #expect(ReadObjectRange(10...50) == ReadObjectRange.bounded(10...50))
+    #expect(ReadObjectRange(10...).headerValue == "bytes=10-")
+    #expect(ReadObjectRange(...50).headerValue == "bytes=0-50")
+    #expect(ReadObjectRange(start: 10, end: 50) == ReadObjectRange.bounded(10...50))
+    #expect(ReadObjectRange(start: 50, end: 10) == nil)
   }
 
   @Test func readObjectOptionsDefaults() throws {
@@ -50,7 +54,7 @@ import Testing
       $0.generation = 456
       $0.preconditions = preconditions
       $0.customerEncryptionKey = csek
-      $0.range = .bounded(start: 0, end: 1024)
+      $0.range = .bounded(0...1024)
       $0.enableDecompressiveTranscoding = false
       $0.resumePolicy = NeverResume<DownloadDetails>()
       $0.checksums = .none
@@ -59,7 +63,7 @@ import Testing
     #expect(options.generation == 456)
     #expect(options.preconditions?.ifGenerationMatch == 123)
     #expect(options.customerEncryptionKey == csek)
-    #expect(options.range == ReadObjectRange.bounded(start: 0, end: 1024))
+    #expect(options.range == ReadObjectRange.bounded(0...1024))
     #expect(options.enableDecompressiveTranscoding == false)
     #expect(options.resumePolicy != nil)
     #expect(options.checksums == .none)
@@ -115,7 +119,7 @@ import Testing
     // Prefix
     #expect(
       calculateResumeRange(originalRange: .prefix(100), bytesReceived: 40, totalSize: 1000)
-        == .bounded(start: 40, end: 99))
+        == .bounded(40...99))
     #expect(
       calculateResumeRange(originalRange: .prefix(100), bytesReceived: 100, totalSize: 1000) == nil)
     #expect(
@@ -124,16 +128,16 @@ import Testing
     // Bounded
     #expect(
       calculateResumeRange(
-        originalRange: .bounded(start: 10, end: 50), bytesReceived: 20, totalSize: 1000)
-        == .bounded(start: 30, end: 50))
+        originalRange: .bounded(10...50), bytesReceived: 20, totalSize: 1000)
+        == .bounded(30...50))
     #expect(
       calculateResumeRange(
-        originalRange: .bounded(start: 10, end: 50), bytesReceived: 41, totalSize: 1000) == nil)
+        originalRange: .bounded(10...50), bytesReceived: 41, totalSize: 1000) == nil)
 
     // Suffix
     #expect(
       calculateResumeRange(originalRange: .suffix(50), bytesReceived: 10, totalSize: 200)
-        == .bounded(start: 160, end: 199))
+        == .bounded(160...199))
     #expect(
       calculateResumeRange(originalRange: .suffix(50), bytesReceived: 50, totalSize: 200) == nil)
     #expect(

--- a/packages/storage/Tests/DownloadTests.swift
+++ b/packages/storage/Tests/DownloadTests.swift
@@ -489,7 +489,7 @@ import Testing
 
     let client = try makeClient(registry: registry)
     let options = ReadObjectOptions().with {
-      $0.range = .bounded(start: 10, end: 29)
+      $0.range = .bounded(10...29)
     }
 
     let result = client.readObject(from: bucket, object: objectName, options: options)
@@ -530,25 +530,6 @@ import Testing
     ).metadata
     #expect(
       registry.lastRequest(for: downloadUrl)?.value(forHTTPHeaderField: "Range") == "bytes=10-29")
-  }
-
-  @Test func rangedDownloadInvalidRangeThrows() async throws {
-    let registry = MockRegistry.create()
-    let client = try makeClient(registry: registry)
-    let options = ReadObjectOptions().with {
-      $0.range = .bounded(start: 30, end: 10)
-    }
-
-    do {
-      _ = try await client.readObject(from: "test-bucket", object: "test.txt", options: options)
-        .metadata
-      Issue.record("Expected invalidRangeHeader error to be thrown")
-    } catch let DownloadError.invalidRangeHeader(msg) {
-      #expect(msg.contains("30"))
-      #expect(msg.contains("10"))
-    } catch {
-      Issue.record("Expected invalidRangeHeader, but got \(error)")
-    }
   }
 
   @Test func rangedDownloadZeroCountRanges() async throws {
@@ -1075,7 +1056,7 @@ import Testing
 
     let client = try makeClient(registry: registry)
     let options = ReadObjectOptions().with {
-      $0.range = .bounded(start: 10, end: 29)
+      $0.range = .bounded(10...29)
     }
 
     let result = client.readObject(from: bucket, object: objectName, options: options)

--- a/packages/storage/Tests/IntegrationTests/StorageClientDownloadChecksumIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientDownloadChecksumIntegrationTests.swift
@@ -199,7 +199,7 @@ struct StorageClientDownloadChecksumIntegrationTests {
 
     // 1. Ranged download with default .auto skips full-object checksum verification
     let rangedAutoOptions = ReadObjectOptions().with {
-      $0.range = .bounded(start: 0, end: 9)
+      $0.range = .bounded(0...9)
     }
     let rangedAutoResult = storage.readObject(
       from: fixture.bucketName, object: fixture.objectName, options: rangedAutoOptions)
@@ -219,7 +219,7 @@ struct StorageClientDownloadChecksumIntegrationTests {
 
     // 2a. User-provided range CRC32C
     let rangedCrcOptions = ReadObjectOptions().with {
-      $0.range = .bounded(start: 0, end: 9)
+      $0.range = .bounded(0...9)
       $0.checksums = ChecksumOptions(crc32c: .value(rangeCrcBase64), md5: nil)
     }
     let rangedCrcResult = storage.readObject(
@@ -232,7 +232,7 @@ struct StorageClientDownloadChecksumIntegrationTests {
 
     // 2b. User-provided range MD5
     let rangedMd5Options = ReadObjectOptions().with {
-      $0.range = .bounded(start: 0, end: 9)
+      $0.range = .bounded(0...9)
       $0.checksums = ChecksumOptions(crc32c: nil, md5: .value(rangeMd5Base64))
     }
     let rangedMd5Result = storage.readObject(
@@ -257,7 +257,7 @@ struct StorageClientDownloadChecksumIntegrationTests {
     let storage = try StorageClient()
 
     let options = ReadObjectOptions().with {
-      $0.range = .bounded(start: 0, end: 9)
+      $0.range = .bounded(0...9)
       $0.checksums = checksums
     }
     let result = storage.readObject(

--- a/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/packages/storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -909,7 +909,7 @@ struct StorageClientRangedDownloadIntegrationTests {
   }
 
   @Test(arguments: [
-    (ReadObjectRange.bounded(start: 10, end: 19), "abcdefghij"),
+    (ReadObjectRange.bounded(10...19), "abcdefghij"),
     (ReadObjectRange.fromOffset(36), "ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
     (ReadObjectRange.prefix(10), "0123456789"),
     (ReadObjectRange.suffix(10), "QRSTUVWXYZ"),
@@ -960,7 +960,7 @@ struct StorageClientRangedDownloadIntegrationTests {
   @Test(arguments: [
     ReadObjectRange.prefix(0),
     ReadObjectRange.suffix(0),
-    ReadObjectRange.bounded(start: 10, end: 19),
+    ReadObjectRange.bounded(10...19),
     ReadObjectRange.fromOffset(36),
     ReadObjectRange.prefix(10),
     ReadObjectRange.suffix(10),


### PR DESCRIPTION
Fixes #219

note: this removes the `.bounded(start: X, end: Y)` option. Instead, use: `.bounded(X...Y)` which is also easier to write.