### PR TITLE
cleanup: public classes are `final`

### DIFF
--- a/packages/swift-google-gax/Sources/GoogleCloudGax/QueryParameter.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/QueryParameter.swift
@@ -22,7 +22,7 @@ import Foundation
 ///     <https://github.com/googleapis/googleapis/blob/16b4737e7b870914e0c384b87f0e50ed388aa225/google/api/http.proto#L87-L118>
 ///
 /// This type implements the rules for any encodable type, including well-known types.
-@_spi(GoogleCloudInternal) public class _QueryParameterEncoder {
+@_spi(GoogleCloudInternal) final public class _QueryParameterEncoder {
   public init() {}
 
   /// Encodes `value` as an array of query parameters with `prefix` as the base name.

--- a/packages/swift-google-wkt/Sources/GoogleCloudWKT/ProtoJSONDecoder.swift
+++ b/packages/swift-google-wkt/Sources/GoogleCloudWKT/ProtoJSONDecoder.swift
@@ -30,7 +30,7 @@ import Foundation
 /// Unfortunately the system types conforming to the `Decoder` protocol are not public, they cannot be named to implement
 /// any wrapper types. The approach is to use an `Interceptor<T>` type that implements `Decodable` and wraps the `any Decoder`
 /// it receives.
-@_spi(GoogleCloudInternal) public class _ProtoJSONDecoder {
+@_spi(GoogleCloudInternal) final public class _ProtoJSONDecoder {
   public init() {}
 
   public func decode<T>(_ type: T.Type, from: Data) throws -> T where T: Decodable {


### PR DESCRIPTION
We don't have that many classes, most compound types are `struct` or `enum`. The classes we do define are not intended to be derived from. Mark them as `final` to prevent accidents.

Fixes #525 , verify with `git grep 'public class'`.
