### PR TITLE
impl: framework for storage samples

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -149,6 +149,24 @@ let package = Package(
       path: "Tests/StorageW1R3",
       exclude: ["README.md"]
     ),
+    .target(
+      name: "StorageSamples",
+      dependencies: [
+        .product(name: "GoogleCloudStorage", package: "swift-google-cloud-storage"),
+        .product(name: "GoogleCloudAuth", package: "swift-google-auth"),
+        .product(name: "GoogleCloudGax", package: "swift-google-gax"),
+        .product(name: "Logging", package: "swift-log"),
+      ],
+    ),
+    .testTarget(
+      name: "StorageSamplesDriver",
+      dependencies: [
+        "StorageSamples",
+        .product(name: "GoogleCloudStorage", package: "swift-google-cloud-storage"),
+        .product(name: "Logging", package: "swift-log"),
+      ],
+      path: "Tests/StorageSamplesDriver",
+    ),
   ]
 )
 

--- a/Sources/StorageSamples/Buckets/CreateBucket.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucket.swift
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_create_bucket]
+import GoogleCloudStorage
+
+public func createBucket(
+  client: StorageControlClient, projectId: String, bucketId: String
+) async throws {
+  let bucket =
+    try await client
+    .createBucket(
+      request: .init().with {
+        $0.parent = "projects/_"
+        $0.bucketId = bucketId
+        $0.bucket = .init().with {
+          $0.project = "projects/\(projectId)"
+        }
+      }, options: .init())
+  print("successfully created bucket \(bucket)")
+}
+// [END storage_create_bucket]

--- a/Sources/StorageSamples/Buckets/DeleteBucket.swift
+++ b/Sources/StorageSamples/Buckets/DeleteBucket.swift
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_delete_bucket]
+import GoogleCloudStorage
+
+public func deleteBucket(
+  client: StorageControlClient, projectId: String, bucketId: String
+) async throws {
+  try await client
+    .deleteBucket(
+      request: .init().with { $0.name = "projects/_/buckets/\(bucketId)" },
+      options: .init(),
+    )
+  print("successfully deleted bucket \(bucketId)")
+}
+// [END storage_delete_bucket]

--- a/Sources/StorageSamples/CleanupBucket.swift
+++ b/Sources/StorageSamples/CleanupBucket.swift
@@ -23,6 +23,7 @@ fileprivate let maxStaleness = 48 * hour
 /// Cleans up any stale buckets in the given project.
 public func cleanupStaleTestBuckets(client: StorageControlClient, projectId: String) async {
   var bucketNames: [String] = []
+  var requesterNames: [String] = []
   do {
     let deadline = Int(Date().timeIntervalSince1970) - maxStaleness
     let buckets = try client.listBuckets(
@@ -35,16 +36,29 @@ public func cleanupStaleTestBuckets(client: StorageControlClient, projectId: Str
         continue
       }
       bucketNames.append(b.name)
+      if let v = b.billing?.requesterPays, v {
+        requesterNames.append(b.name)
+      }
     }
   } catch {
     print("ERROR listing buckets for cleanup: \(error)")
   }
-  await cleanupTestBuckets(client: client, bucketNames: bucketNames)
+  await clearRequesterFlags(client: client, bucketNames: requesterNames)
+  await sweepTestBuckets(client: client, bucketNames: bucketNames)
 }
 
-/// Cleans up the provide list of test buckets.
+/// Cleans up the provided list of test buckets.
+///
+/// This is called immediately after running an integration test.
 public func cleanupTestBuckets(client: StorageControlClient, bucketNames: [String]) async {
+  // Many of the buckets created in tests are created as part of a sample. We don't want to show
+  // the labels we use for cleanup, as that complicates the example. So the first thing we do is
+  // add all the labels that mark the bucket as part of an integration test. We also  reset any
+  // attributes that make it hard to delete the bucket.
   await markTestBuckets(client: client, bucketNames: bucketNames)
+  // After this we clear the contents and delete the bucket. Rarely this fails either some failed
+  // request, or the contents have some retention period. In that case, the bucket will be deleted
+  // in a few days, as the integration tests call `cleanupStaleTestBuckets()`.
   await sweepTestBuckets(client: client, bucketNames: bucketNames)
 }
 
@@ -52,7 +66,7 @@ public func cleanupTestBuckets(client: StorageControlClient, bucketNames: [Strin
 ///
 /// When testing the samples, we create any number of buckets. This function marks the buckets for
 /// garbage collection. Normally `sweepTestBuckets` step will attempt to delete the buckets too.
-public func markTestBuckets(client: StorageControlClient, bucketNames: [String]) async {
+func markTestBuckets(client: StorageControlClient, bucketNames: [String]) async {
   for name in bucketNames {
     do {
       let bucket = Bucket().with {
@@ -74,11 +88,37 @@ public func markTestBuckets(client: StorageControlClient, bucketNames: [String])
   }
 }
 
+/// Resets the requesterPays flag so we can easily delete the bucket.
+///
+/// On buckets with `requesterPays == false` we need to do a number of
+/// When testing the samples, we create any number of buckets. This function marks the buckets for
+/// garbage collection. Normally `sweepTestBuckets` step will attempt to delete the buckets too.
+func clearRequesterFlags(client: StorageControlClient, bucketNames: [String]) async {
+  for name in bucketNames {
+    do {
+      let bucket = Bucket().with {
+        $0.name = name
+        $0.billing = .init().with { $0.requesterPays = false }
+      }
+      let options = RequestOptions().with {
+        $0.idempotency = true
+      }
+      let _ = try await client.updateBucket(
+        request: .init().with {
+          $0.bucket = bucket
+          $0.updateMask = .init(paths: ["billing.requester_pays"])
+        }, options: options)
+    } catch {
+      print("ERROR clearing requester pays bucket \(name): \(error)")
+    }
+  }
+}
+
 /// Deletes a number of test bucket and their contents.
 ///
 /// When testing the samples, we create any number of buckets. This function deletes buckets based
 /// on their id.
-public func sweepTestBuckets(client: StorageControlClient, bucketNames: [String]) async {
+func sweepTestBuckets(client: StorageControlClient, bucketNames: [String]) async {
   for name in bucketNames {
     do {
       let bucket: Bucket

--- a/Sources/StorageSamples/CleanupBucket.swift
+++ b/Sources/StorageSamples/CleanupBucket.swift
@@ -1,0 +1,128 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import GoogleCloudStorage
+import GoogleCloudGax
+
+fileprivate let integrationTestMark = "integration-test"
+fileprivate let hour = 3600
+fileprivate let maxStaleness = 48 * hour
+
+/// Cleans up any stale buckets in the given project.
+public func cleanupStaleTestBuckets(client: StorageControlClient, projectId: String) async {
+  var bucketNames: [String] = []
+  do {
+    let deadline = Int(Date().timeIntervalSince1970) - maxStaleness
+    let buckets = try client.listBuckets(
+      byItem: .init().with { $0.parent = "projects/\(projectId)" }, options: .init())
+    for try await b in buckets {
+      guard let v = b.labels[integrationTestMark], v == "true" else {
+        continue
+      }
+      guard let created = b.createTime, created.seconds < deadline else {
+        continue
+      }
+      bucketNames.append(b.name)
+    }
+  } catch {
+    print("ERROR listing buckets for cleanup: \(error)")
+  }
+  await cleanupTestBuckets(client: client, bucketNames: bucketNames)
+}
+
+/// Cleans up the provide list of test buckets.
+public func cleanupTestBuckets(client: StorageControlClient, bucketNames: [String]) async {
+  await markTestBuckets(client: client, bucketNames: bucketNames)
+  await sweepTestBuckets(client: client, bucketNames: bucketNames)
+}
+
+/// Marks a number of test buckets for garbage collection.
+///
+/// When testing the samples, we create any number of buckets. This function marks the buckets for
+/// garbage collection. Normally `sweepTestBuckets` step will attempt to delete the buckets too.
+public func markTestBuckets(client: StorageControlClient, bucketNames: [String]) async {
+  for name in bucketNames {
+    do {
+      let bucket = Bucket().with {
+        $0.name = name
+        $0.labels = [integrationTestMark: "true"]
+        $0.billing = .init().with { $0.requesterPays = false }
+      }
+      let options = RequestOptions().with {
+        $0.idempotency = true
+      }
+      let _ = try await client.updateBucket(
+        request: .init().with {
+          $0.bucket = bucket
+          $0.updateMask = .init(paths: ["labels", "billing.requester_pays"])
+        }, options: options)
+    } catch {
+      print("ERROR marking bucket \(name): \(error)")
+    }
+  }
+}
+
+/// Deletes a number of test bucket and their contents.
+///
+/// When testing the samples, we create any number of buckets. This function deletes buckets based
+/// on their id.
+public func sweepTestBuckets(client: StorageControlClient, bucketNames: [String]) async {
+  for name in bucketNames {
+    do {
+      let bucket: Bucket
+      do {
+        bucket = try await client.getBucket(
+          request: .init().with { $0.name = name }, options: .init())
+      } catch {
+        print("ERROR getting bucket properties for \(name): \(error)")
+        continue
+      }
+
+      let objects = try client.listObjects(
+        byItem: .init().with { $0.parent = bucket.name }, options: .init())
+      for try await o in objects {
+        try await client.deleteObject(
+          request: .init().with {
+            $0.bucket = o.bucket
+            $0.object = o.name
+            $0.generation = o.generation
+          }, options: .init().with { $0.idempotency = true })
+      }
+
+      let caches = try client.listAnywhereCaches(
+        byItem: .init().with { $0.parent = bucket.name }, options: .init())
+      for try await c in caches {
+        let _ = try await client.disableAnywhereCache(
+          request: .init().with { $0.name = c.name },
+          options: .init().with { $0.idempotency = true })
+      }
+
+      guard let enabled = bucket.hierarchicalNamespace?.enabled, enabled else {
+        // Only try to delete folders if the bucket can have folders.
+        continue
+      }
+
+      let folders = try client.listManagedFolders(
+        byItem: .init().with { $0.parent = bucket.name }, options: .init())
+      for try await f in folders {
+        try await client.deleteFolder(
+          request: .init().with { $0.name = f.name },
+          options: .init().with { $0.idempotency = true })
+      }
+    } catch {
+      print("ERROR sweeping bucket \(name): \(error)")
+    }
+  }
+}

--- a/Sources/StorageSamples/RunBucketSamples.swift
+++ b/Sources/StorageSamples/RunBucketSamples.swift
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import GoogleCloudStorage
+
+/// The maximum length for a bucket ID.
+fileprivate let bucketIdLength = 63
+
+/// A common prefix for resource ids.
+///
+/// Where possible, we use this prefix for randomly generated resource ids.
+fileprivate let prefix = "swift-sdk-testing-"
+fileprivate let lowerCaseAlphanumeric = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+public func runBucketSamples(
+  client: StorageControlClient, projectId: String, bucketNames: inout [String]
+) async throws {
+  let id = randomBucketId()
+  let name = "projects/_/buckets/\(id)"
+  bucketNames.append(name)
+
+  print("running createBucket() sample")
+  try await createBucket(client: client, projectId: projectId, bucketId: id)
+  print("running deleteBucket() sample")
+  try await deleteBucket(client: client, projectId: projectId, bucketId: id)
+}
+
+/// Generates a random bucket ID.
+public func randomBucketId() -> String {
+  assert(prefix.count < bucketIdLength)
+  let length = bucketIdLength - prefix.count
+  let suffix = String((0..<length).map { _ in lowerCaseAlphanumeric.randomElement()! })
+  return prefix + suffix
+}

--- a/Tests/StorageSamplesDriver/Driver.swift
+++ b/Tests/StorageSamplesDriver/Driver.swift
@@ -28,11 +28,15 @@ import Testing
         client: client, projectId: projectId, bucketNames: &bucketNames)
       await StorageSamples.cleanupTestBuckets(client: client, bucketNames: bucketNames)
     } catch {
+      // Automatically clean up any buckets created during the test, even after an error. Some may
+      // still leak, due to crashes in the test, or because they have contents with a retention
+      // period.
       await StorageSamples.cleanupTestBuckets(client: client, bucketNames: bucketNames)
       throw error
     }
   }
 
+  /// Deletes stale buckets that are not cleaned up by their tests.
   @Test(.enabled(if: Self.enabled())) func stale() async throws {
     let projectId = ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"]!
     let client = try Self.makeClient()

--- a/Tests/StorageSamplesDriver/Driver.swift
+++ b/Tests/StorageSamplesDriver/Driver.swift
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import StorageSamples
+import GoogleCloudGax
+import GoogleCloudStorage
+import Testing
+
+@Suite struct StorageSamplesDriver {
+  @Test(.enabled(if: Self.enabled())) func runBucketSamples() async throws {
+    let projectId = ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"]!
+    let client = try Self.makeClient()
+    var bucketNames: [String] = []
+    do {
+      try await StorageSamples.runBucketSamples(
+        client: client, projectId: projectId, bucketNames: &bucketNames)
+      await StorageSamples.cleanupTestBuckets(client: client, bucketNames: bucketNames)
+    } catch {
+      await StorageSamples.cleanupTestBuckets(client: client, bucketNames: bucketNames)
+      throw error
+    }
+  }
+
+  @Test(.enabled(if: Self.enabled())) func stale() async throws {
+    let projectId = ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"]!
+    let client = try Self.makeClient()
+    await StorageSamples.cleanupStaleTestBuckets(client: client, projectId: projectId)
+  }
+
+  static func makeClient() throws -> StorageControlClient {
+    try StorageControlClient(
+      .init().with {
+        $0.backoffPolicy = ExponentialBackoff(
+          clamping: .init().with { $0.initialDelay = .seconds(2) })
+      })
+  }
+
+  static func enabled() -> Bool {
+    ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"] != nil
+  }
+}


### PR DESCRIPTION
Create a framework to populate the storage samples. Things that I like about this structure include:

- Each sample in its own file, so we can show the imports and the function parameters.
- All the samples are in one product, so they are compiled and linked only once.
- The samples can be part of the integration tests.
- Cleaning up buckets is in a single place.
- The structure is somewhat similar to Rust, so maybe the LLMs can translate.

Things I don't like:

- The logging is not awesome.
- Cleaning up stale buckets may take multiple days.

Fixes #556 