### PR TITLE
docs(storage): initial object samples

### DIFF
--- a/Sources/StorageSamples/Objects/DeleteFile.swift
+++ b/Sources/StorageSamples/Objects/DeleteFile.swift
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_delete_file]
+import GoogleCloudStorage
+
+public func deleteFile(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objectName = "deleted-object-name"
+  try await client.deleteObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+    },
+    options: .init()
+  )
+  print("successfully deleted object \(objectName) in bucket \(bucketId)")
+}
+// [END storage_delete_file]

--- a/Sources/StorageSamples/Objects/DownloadFile.swift
+++ b/Sources/StorageSamples/Objects/DownloadFile.swift
@@ -20,7 +20,9 @@ public func downloadFile(
   client: StorageClient, bucketId: String, objectName: String, filePath: String
 ) async throws {
   let reader = client.readObject(from: "projects/_/buckets/\(bucketId)", object: objectName)
-  FileManager.default.createFile(atPath: filePath, contents: nil)
+  if !FileManager.default.createFile(atPath: filePath, contents: nil) {
+    throw POSIXError(.EEXIST)
+  }
   let fileHandle = try FileHandle(forWritingTo: URL(fileURLWithPath: filePath))
   defer {
     try? fileHandle.close()

--- a/Sources/StorageSamples/Objects/DownloadFile.swift
+++ b/Sources/StorageSamples/Objects/DownloadFile.swift
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_download_file]
+import Foundation
+import GoogleCloudStorage
+
+public func downloadFile(
+  client: StorageClient, bucketId: String, objectName: String, filePath: String
+) async throws {
+  let reader = client.readObject(from: "projects/_/buckets/\(bucketId)", object: objectName)
+  FileManager.default.createFile(atPath: filePath, contents: nil)
+  let fileHandle = try FileHandle(forWritingTo: URL(fileURLWithPath: filePath))
+  defer {
+    try? fileHandle.close()
+  }
+
+  for try await buffer in reader.body {
+    try fileHandle.write(contentsOf: buffer.data)
+  }
+
+  print("Downloaded \(objectName) in bucket \(bucketId) to \(filePath).")
+}
+// [END storage_download_file]

--- a/Sources/StorageSamples/Objects/FileUploadFromMemory.swift
+++ b/Sources/StorageSamples/Objects/FileUploadFromMemory.swift
@@ -1,0 +1,27 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_file_upload_from_memory]
+import Foundation
+import GoogleCloudStorage
+
+public func fileUploadFromMemory(
+  client: StorageClient, bucketId: String
+) async throws {
+  let objectName = "object-to-upload.txt"
+  let data = Data("Hello, world!".utf8)
+  let _ = try await client.upload(data, to: "projects/_/buckets/\(bucketId)", as: objectName)
+  print("Uploaded to \(objectName) in bucket \(bucketId) from memory.")
+}
+// [END storage_file_upload_from_memory]

--- a/Sources/StorageSamples/Objects/ListFiles.swift
+++ b/Sources/StorageSamples/Objects/ListFiles.swift
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_list_files]
+import GoogleCloudStorage
+
+public func listFiles(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objects = try client.listObjects(
+    byItem: .init().with { $0.parent = "projects/_/buckets/\(bucketId)" },
+    options: .init()
+  )
+  print("listing objects in bucket \(bucketId)")
+  for try await object in objects {
+    print(object)
+  }
+  print("DONE")
+}
+// [END storage_list_files]

--- a/Sources/StorageSamples/Objects/ListFilesWithPrefix.swift
+++ b/Sources/StorageSamples/Objects/ListFilesWithPrefix.swift
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_list_files_with_prefix]
+import GoogleCloudStorage
+
+public func listFilesWithPrefix(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let prefix = "prefixes/are-not-always/folders-"
+  let objects = try client.listObjects(
+    byItem: .init().with {
+      $0.parent = "projects/_/buckets/\(bucketId)"
+      $0.prefix = prefix
+    },
+    options: .init()
+  )
+  print("listing objects in bucket \(bucketId) with prefix \(prefix)")
+  for try await object in objects {
+    print(object)
+  }
+  print("DONE")
+}
+// [END storage_list_files_with_prefix]

--- a/Sources/StorageSamples/Objects/StreamFileDownload.swift
+++ b/Sources/StorageSamples/Objects/StreamFileDownload.swift
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_stream_file_download]
+import GoogleCloudStorage
+
+public func streamFileDownload(
+  client: StorageClient, bucketId: String
+) async throws {
+  let objectName = "object-to-download.txt"
+  let reader = client.readObject(from: "projects/_/buckets/\(bucketId)", object: objectName)
+  print("counting newlines \(objectName) in bucket \(bucketId)")
+  var count = 0
+  for try await buffer in reader.body {
+    count += buffer.filter { $0 == UInt8(ascii: "\n") }.count
+  }
+  print("object \(objectName) in bucket \(bucketId) contains \(count) newlines")
+}
+// [END storage_stream_file_download]

--- a/Sources/StorageSamples/RunObjectSamples.swift
+++ b/Sources/StorageSamples/RunObjectSamples.swift
@@ -1,0 +1,68 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import GoogleCloudStorage
+
+public func runObjectSamples(
+  controlClient: StorageControlClient, dataClient: StorageClient, projectId: String,
+  bucketNames: inout [String]
+) async throws {
+  let id = randomBucketId()
+  let name = "projects/_/buckets/\(id)"
+  bucketNames.append(name)
+
+  let _ = try await controlClient.createBucket(
+    request: .init().with {
+      $0.parent = "projects/_"
+      $0.bucketId = id
+      $0.bucket = .init().with {
+        $0.project = "projects/\(projectId)"
+      }
+    },
+    options: .init()
+  )
+
+  let sampleText = "how vexingly quick daft zebras jump\n"
+  let sampleData = Data(sampleText.utf8)
+
+  // Seed test objects
+  _ = try await dataClient.upload(sampleData, to: id, as: "object-to-download.txt")
+  _ = try await dataClient.upload(sampleData, to: id, as: "prefixes/are-not-always/folders-001")
+  _ = try await dataClient.upload(sampleData, to: id, as: "prefixes/are-not-always/folders-002")
+  _ = try await dataClient.upload(sampleData, to: id, as: "prefixes/are-not-always/folders-003")
+  _ = try await dataClient.upload(sampleData, to: id, as: "uploaded-file.txt")
+  _ = try await dataClient.upload(sampleData, to: id, as: "deleted-object-name")
+
+  let tempFilePath = FileManager.default.temporaryDirectory.appendingPathComponent(
+    "downloaded-file-\(UUID().uuidString).txt"
+  ).path
+  defer {
+    try? FileManager.default.removeItem(atPath: tempFilePath)
+  }
+
+  print("running streamFileDownload() sample")
+  try await streamFileDownload(client: dataClient, bucketId: id)
+  print("running fileUploadFromMemory() sample")
+  try await fileUploadFromMemory(client: dataClient, bucketId: id)
+  print("running downloadFile() sample")
+  try await downloadFile(
+    client: dataClient, bucketId: id, objectName: "uploaded-file.txt", filePath: tempFilePath)
+  print("running listFiles() sample")
+  try await listFiles(client: controlClient, bucketId: id)
+  print("running listFilesWithPrefix() sample")
+  try await listFilesWithPrefix(client: controlClient, bucketId: id)
+  print("running deleteFile() sample")
+  try await deleteFile(client: controlClient, bucketId: id)
+}

--- a/Tests/StorageSamplesDriver/Driver.swift
+++ b/Tests/StorageSamplesDriver/Driver.swift
@@ -36,6 +36,22 @@ import Testing
     }
   }
 
+  @Test(.enabled(if: Self.enabled())) func runObjectSamples() async throws {
+    let projectId = ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"]!
+    let controlClient = try Self.makeClient()
+    let dataClient = try Self.makeDataClient()
+    var bucketNames: [String] = []
+    do {
+      try await StorageSamples.runObjectSamples(
+        controlClient: controlClient, dataClient: dataClient, projectId: projectId,
+        bucketNames: &bucketNames)
+      await StorageSamples.cleanupTestBuckets(client: controlClient, bucketNames: bucketNames)
+    } catch {
+      await StorageSamples.cleanupTestBuckets(client: controlClient, bucketNames: bucketNames)
+      throw error
+    }
+  }
+
   /// Deletes stale buckets that are not cleaned up by their tests.
   @Test(.enabled(if: Self.enabled())) func stale() async throws {
     let projectId = ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"]!
@@ -49,6 +65,10 @@ import Testing
         $0.backoffPolicy = ExponentialBackoff(
           clamping: .init().with { $0.initialDelay = .seconds(2) })
       })
+  }
+
+  static func makeDataClient() throws -> StorageClient {
+    try StorageClient()
   }
 
   static func enabled() -> Bool {


### PR DESCRIPTION
Create enough structure to write object samples. Confusingly the devrel snippets call these "files", the nomenclature is wrong, but nothing we can do about that.

Fixes #578 