### PR TITLE
docs(storage): create bucket samples

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -28,6 +28,8 @@ IZ = "IZ"
 
 [default]
 extend-ignore-re = [
-    # Wwarning seems like a typo, but it is not.
-    "-Xswiftc -Wwarning"
+  # Wwarning seems like a typo, but it is not.
+  "-Xswiftc -Wwarning",
+  # NAM4 looks like NAME, but it is intentional.
+  "NAM4",
 ]

--- a/Sources/StorageSamples/Buckets/CreateBucket.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucket.swift
@@ -24,8 +24,8 @@ public func createBucket(
       request: .init().with {
         $0.parent = "projects/_"
         $0.bucketId = bucketId
-        $0.bucket = .init().with {
-          $0.project = "projects/\(projectId)"
+        $0.bucket = .init().with { bucket in
+          bucket.project = "projects/\(projectId)"
         }
       }, options: .init())
   print("successfully created bucket \(bucket)")

--- a/Sources/StorageSamples/Buckets/CreateBucketClassLocation.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucketClassLocation.swift
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_create_bucket_class_location]
+import GoogleCloudStorage
+
+public func createBucketClassLocation(
+  client: StorageControlClient, projectId: String, bucketId: String
+) async throws {
+  let bucket =
+    try await client
+    .createBucket(
+      request: .init().with {
+        $0.parent = "projects/_"
+        $0.bucketId = bucketId
+        $0.bucket = .init().with {
+          $0.project = "projects/\(projectId)"
+          $0.storageClass = "NEARLINE"
+          $0.location = "US-CENTRAL1"
+        }
+      }, options: .init())
+  print("successfully created bucket \(bucket)")
+}
+// [END storage_create_bucket_class_location]

--- a/Sources/StorageSamples/Buckets/CreateBucketClassLocation.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucketClassLocation.swift
@@ -24,10 +24,10 @@ public func createBucketClassLocation(
       request: .init().with {
         $0.parent = "projects/_"
         $0.bucketId = bucketId
-        $0.bucket = .init().with {
-          $0.project = "projects/\(projectId)"
-          $0.storageClass = "NEARLINE"
-          $0.location = "US-CENTRAL1"
+        $0.bucket = .init().with { bucket in
+          bucket.project = "projects/\(projectId)"
+          bucket.storageClass = "NEARLINE"
+          bucket.location = "US-CENTRAL1"
         }
       }, options: .init())
   print("successfully created bucket \(bucket)")

--- a/Sources/StorageSamples/Buckets/CreateBucketDualRegion.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucketDualRegion.swift
@@ -24,10 +24,10 @@ public func createBucketDualRegion(
       request: .init().with {
         $0.parent = "projects/_"
         $0.bucketId = bucketId
-        $0.bucket = .init().with {
-          $0.project = "projects/\(projectId)"
-          $0.customPlacementConfig = .init().with {
-            $0.dataLocations = ["US-EAST4", "US-CENTRAL1"]
+        $0.bucket = .init().with { bucket in
+          bucket.project = "projects/\(projectId)"
+          bucket.customPlacementConfig = .init().with { placementConfig in
+            placementConfig.dataLocations = ["US-EAST4", "US-CENTRAL1"]
           }
         }
       }, options: .init())

--- a/Sources/StorageSamples/Buckets/CreateBucketDualRegion.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucketDualRegion.swift
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_create_bucket_dual_region]
+import GoogleCloudStorage
+
+public func createBucketDualRegion(
+  client: StorageControlClient, projectId: String, bucketId: String
+) async throws {
+  let bucket =
+    try await client
+    .createBucket(
+      request: .init().with {
+        $0.parent = "projects/_"
+        $0.bucketId = bucketId
+        $0.bucket = .init().with {
+          $0.project = "projects/\(projectId)"
+          $0.customPlacementConfig = .init().with {
+            $0.dataLocations = ["US-EAST4", "US-CENTRAL1"]
+          }
+        }
+      }, options: .init())
+  print("successfully created bucket \(bucket)")
+}
+// [END storage_create_bucket_dual_region]

--- a/Sources/StorageSamples/Buckets/CreateBucketHierarchicalNamespace.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucketHierarchicalNamespace.swift
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_create_bucket_hierarchical_namespace]
+import GoogleCloudStorage
+
+public func createBucketHierarchicalNamespace(
+  client: StorageControlClient, projectId: String, bucketId: String
+) async throws {
+  let bucket =
+    try await client
+    .createBucket(
+      request: .init().with {
+        $0.parent = "projects/_"
+        $0.bucketId = bucketId
+        $0.bucket = .init().with {
+          $0.project = "projects/\(projectId)"
+          $0.hierarchicalNamespace = .init().with {
+            $0.enabled = true
+          }
+          $0.iamConfig = .init().with {
+            $0.uniformBucketLevelAccess = .init().with {
+              $0.enabled = true
+            }
+          }
+        }
+      }, options: .init())
+  print("successfully created bucket \(bucket)")
+}
+// [END storage_create_bucket_hierarchical_namespace]

--- a/Sources/StorageSamples/Buckets/CreateBucketHierarchicalNamespace.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucketHierarchicalNamespace.swift
@@ -24,14 +24,14 @@ public func createBucketHierarchicalNamespace(
       request: .init().with {
         $0.parent = "projects/_"
         $0.bucketId = bucketId
-        $0.bucket = .init().with {
-          $0.project = "projects/\(projectId)"
-          $0.hierarchicalNamespace = .init().with {
-            $0.enabled = true
+        $0.bucket = .init().with { bucket in
+          bucket.project = "projects/\(projectId)"
+          bucket.hierarchicalNamespace = .init().with { hns in
+            hns.enabled = true
           }
-          $0.iamConfig = .init().with {
-            $0.uniformBucketLevelAccess = .init().with {
-              $0.enabled = true
+          bucket.iamConfig = .init().with { iamc in
+            iamc.uniformBucketLevelAccess = .init().with { ubla in
+              ubla.enabled = true
             }
           }
         }

--- a/Sources/StorageSamples/Buckets/CreateBucketTurboReplication.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucketTurboReplication.swift
@@ -24,10 +24,10 @@ public func createBucketTurboReplication(
       request: .init().with {
         $0.parent = "projects/_"
         $0.bucketId = bucketId
-        $0.bucket = .init().with {
-          $0.project = "projects/\(projectId)"
-          $0.location = "NAM4"
-          $0.rpo = "ASYNC_TURBO"
+        $0.bucket = .init().with { bucket in
+          bucket.project = "projects/\(projectId)"
+          bucket.location = "NAM4"
+          bucket.rpo = "ASYNC_TURBO"
         }
       }, options: .init())
   print("successfully created bucket \(bucket)")

--- a/Sources/StorageSamples/Buckets/CreateBucketTurboReplication.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucketTurboReplication.swift
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_create_bucket_turbo_replication]
+import GoogleCloudStorage
+
+public func createBucketTurboReplication(
+  client: StorageControlClient, projectId: String, bucketId: String
+) async throws {
+  let bucket =
+    try await client
+    .createBucket(
+      request: .init().with {
+        $0.parent = "projects/_"
+        $0.bucketId = bucketId
+        $0.bucket = .init().with {
+          $0.project = "projects/\(projectId)"
+          $0.location = "NAM4"
+          $0.rpo = "ASYNC_TURBO"
+        }
+      }, options: .init())
+  print("successfully created bucket \(bucket)")
+}
+// [END storage_create_bucket_turbo_replication]

--- a/Sources/StorageSamples/Buckets/CreateBucketWithEncryptionEnforcement.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucketWithEncryptionEnforcement.swift
@@ -1,0 +1,40 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_create_bucket_with_encryption_enforcement]
+import GoogleCloudStorage
+
+public func createBucketWithEncryptionEnforcement(
+  client: StorageControlClient, projectId: String, bucketId: String
+) async throws {
+  // Note that this example uses Google-managed encryption keys (GMEK) with FullyRestricted.
+  // More options are available, please consult the documentation.
+  let bucket =
+    try await client
+    .createBucket(
+      request: .init().with {
+        $0.parent = "projects/_"
+        $0.bucketId = bucketId
+        $0.bucket = .init().with {
+          $0.project = "projects/\(projectId)"
+          $0.encryption = .init().with {
+            $0.googleManagedEncryptionEnforcementConfig = .init().with {
+              $0.restrictionMode = "FullyRestricted"
+            }
+          }
+        }
+      }, options: .init())
+  print("successfully created bucket \(bucket)")
+}
+// [END storage_create_bucket_with_encryption_enforcement]

--- a/Sources/StorageSamples/Buckets/CreateBucketWithEncryptionEnforcement.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucketWithEncryptionEnforcement.swift
@@ -26,11 +26,11 @@ public func createBucketWithEncryptionEnforcement(
       request: .init().with {
         $0.parent = "projects/_"
         $0.bucketId = bucketId
-        $0.bucket = .init().with {
-          $0.project = "projects/\(projectId)"
-          $0.encryption = .init().with {
-            $0.googleManagedEncryptionEnforcementConfig = .init().with {
-              $0.restrictionMode = "FullyRestricted"
+        $0.bucket = .init().with { bucket in
+          bucket.project = "projects/\(projectId)"
+          bucket.encryption = .init().with { e in
+            e.googleManagedEncryptionEnforcementConfig = .init().with { ec in
+              ec.restrictionMode = "FullyRestricted"
             }
           }
         }

--- a/Sources/StorageSamples/Buckets/CreateBucketWithObjectRetention.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucketWithObjectRetention.swift
@@ -24,10 +24,10 @@ public func createBucketWithObjectRetention(
       request: .init().with {
         $0.parent = "projects/_"
         $0.bucketId = bucketId
-        $0.bucket = .init().with {
-          $0.project = "projects/\(projectId)"
-          $0.objectRetention = .init().with {
-            $0.enabled = true
+        $0.bucket = .init().with { bucket in
+          bucket.project = "projects/\(projectId)"
+          bucket.objectRetention = .init().with { or in
+            or.enabled = true
           }
         }
       }, options: .init())

--- a/Sources/StorageSamples/Buckets/CreateBucketWithObjectRetention.swift
+++ b/Sources/StorageSamples/Buckets/CreateBucketWithObjectRetention.swift
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_create_bucket_with_object_retention]
+import GoogleCloudStorage
+
+public func createBucketWithObjectRetention(
+  client: StorageControlClient, projectId: String, bucketId: String
+) async throws {
+  let bucket =
+    try await client
+    .createBucket(
+      request: .init().with {
+        $0.parent = "projects/_"
+        $0.bucketId = bucketId
+        $0.bucket = .init().with {
+          $0.project = "projects/\(projectId)"
+          $0.objectRetention = .init().with {
+            $0.enabled = true
+          }
+        }
+      }, options: .init())
+  print("successfully created bucket \(bucket)")
+}
+// [END storage_create_bucket_with_object_retention]

--- a/Sources/StorageSamples/RunBucketSamples.swift
+++ b/Sources/StorageSamples/RunBucketSamples.swift
@@ -36,6 +36,41 @@ public func runBucketSamples(
   try await listBuckets(client: client, projectId: projectId)
   print("running deleteBucket() sample")
   try await deleteBucket(client: client, projectId: projectId, bucketId: id)
+
+  let classLocationId = randomBucketId()
+  bucketNames.append("projects/_/buckets/\(classLocationId)")
+  print("running createBucketClassLocation() sample")
+  try await createBucketClassLocation(
+    client: client, projectId: projectId, bucketId: classLocationId)
+
+  let dualRegionId = randomBucketId()
+  bucketNames.append("projects/_/buckets/\(dualRegionId)")
+  print("running createBucketDualRegion() sample")
+  try await createBucketDualRegion(client: client, projectId: projectId, bucketId: dualRegionId)
+
+  let turboReplicationId = randomBucketId()
+  bucketNames.append("projects/_/buckets/\(turboReplicationId)")
+  print("running createBucketTurboReplication() sample")
+  try await createBucketTurboReplication(
+    client: client, projectId: projectId, bucketId: turboReplicationId)
+
+  let hierarchicalNamespaceId = randomBucketId()
+  bucketNames.append("projects/_/buckets/\(hierarchicalNamespaceId)")
+  print("running createBucketHierarchicalNamespace() sample")
+  try await createBucketHierarchicalNamespace(
+    client: client, projectId: projectId, bucketId: hierarchicalNamespaceId)
+
+  let encryptionEnforcementId = randomBucketId()
+  bucketNames.append("projects/_/buckets/\(encryptionEnforcementId)")
+  print("running createBucketWithEncryptionEnforcement() sample")
+  try await createBucketWithEncryptionEnforcement(
+    client: client, projectId: projectId, bucketId: encryptionEnforcementId)
+
+  let objectRetentionId = randomBucketId()
+  bucketNames.append("projects/_/buckets/\(objectRetentionId)")
+  print("running createBucketWithObjectRetention() sample")
+  try await createBucketWithObjectRetention(
+    client: client, projectId: projectId, bucketId: objectRetentionId)
 }
 
 /// Generates a random bucket ID.


### PR DESCRIPTION
Implement multiple samples for `createBucket()`. The service offers several configuration options, and they like to write a sample for (almost) each option.

In general, I chose to hard-code things like the location, or the storage class. That makes the samples far easier to grok, and the cost for us (fixing the strings) is almost zero as the key locations have not changed in a decade or more.

Fixes #590 