### PR TITLE
feat(StorageW1R3): shared control client

### DIFF
--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -101,7 +101,7 @@ extension StorageW1R3 {
         await self.deleteBatch(
           iterationId: iterationId,
           counters: counters,
-          credentials: credentials,
+          client: controlClient,
           batch: currentBatch
         )
       }
@@ -115,7 +115,7 @@ extension StorageW1R3 {
       iterationId: IterationId(
         task: taskIndex, taskStartInstant: taskStartInstant, iteration: iterations),
       counters: counters,
-      credentials: credentials,
+      client: controlClient,
       batch: deletes
     )
   }
@@ -204,7 +204,7 @@ extension StorageW1R3 {
   private func deleteBatch(
     iterationId: IterationId,
     counters: BenchmarkCounters,
-    credentials: GoogleCloudAuth.Credentials,
+    client: StorageControlClient,
     batch: [GoogleCloudStorage.Object],
   ) async {
     if batch.isEmpty {
@@ -219,7 +219,7 @@ extension StorageW1R3 {
 
     do {
       try await StorageOperations.batchDelete(
-        credentials: credentials, batch: batch
+        client: client, batch: batch
       )
       let sample = deleteBuilder.success()
       self.emitSample(sample)

--- a/Tests/StorageW1R3/StorageOperations.swift
+++ b/Tests/StorageW1R3/StorageOperations.swift
@@ -80,7 +80,7 @@ enum StorageOperations {
 
   /// Deletes a batch of objects in parallel using StorageControlClient.
   static func batchDelete(
-    credentials: Credentials,
+    client: StorageControlClient,
     batch: [GoogleCloudStorage.Object]
   ) async throws {
     guard !batch.isEmpty else { return }
@@ -88,8 +88,6 @@ enum StorageOperations {
     try await withThrowingTaskGroup(of: Void.self) { group in
       for object in batch {
         group.addTask {
-          let client = try StorageControlClient(
-            ClientOptions().with { $0.credentials = credentials })
           let deleteReq = DeleteObjectRequest().with {
             $0.bucket = object.bucket
             $0.object = object.name


### PR DESCRIPTION
Use a shared control client to delete objects. That is more interesting than using different clients, and also should be more efficient as the client does not need to reconnect on each request.