### PR TITLE
perf(storage): ByteBuffer.subdata returns a zero-copy sub-buffer

### DIFF
--- a/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/ByteBuffer.swift
+++ b/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/ByteBuffer.swift
@@ -130,11 +130,13 @@ extension ByteBuffer {
     withUnsafeBytes { Array($0) }
   }
 
-  /// Returns a sub-buffer within the specified byte range.
+  /// Returns a zero-copy sub-buffer within the specified byte range.
   public func subdata(in range: Range<Int>) -> ByteBuffer {
     switch storage {
     case .data(let data):
-      return ByteBuffer(data.subdata(in: range))
+      let start = data.startIndex.advanced(by: range.lowerBound)
+      let end = data.startIndex.advanced(by: range.upperBound)
+      return ByteBuffer(data[start..<end])
     case .byteBuffer(let nioBuffer):
       var copy = nioBuffer
       copy.moveReaderIndex(to: nioBuffer.readerIndex + range.lowerBound)

--- a/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/BytesSource.swift
+++ b/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/BytesSource.swift
@@ -34,20 +34,7 @@ public struct BytesSource: SeekableUploadSource {
   public mutating func read(maxBytes: Int) async throws -> ByteBuffer? {
     guard maxBytes > 0, offset < buffer.count else { return nil }
     let end = min(offset + Int64(maxBytes), Int64(buffer.count))
-    let countToRead = Int(end - offset)
-    let chunk: ByteBuffer
-    switch buffer.storage {
-    case .data(let data):
-      chunk = ByteBuffer(data.subdata(in: Int(offset)..<Int(end)))
-    case .byteBuffer(let nioBuffer):
-      var slice = nioBuffer
-      slice.moveReaderIndex(to: nioBuffer.readerIndex + Int(offset))
-      if let subSlice = slice.readSlice(length: countToRead) {
-        chunk = ByteBuffer(subSlice)
-      } else {
-        chunk = ByteBuffer()
-      }
-    }
+    let chunk = buffer.subdata(in: Int(offset)..<Int(end))
     offset = end
     return chunk
   }


### PR DESCRIPTION
Fixes #604 

Foundation.Data can return the same heap bytes using slice/index rather than subdata.