### PR TITLE
perf(storage): maintain file descriptor to avoid multiple file opens

### DIFF
--- a/packages/swift-google-cloud-storage/Package.swift
+++ b/packages/swift-google-cloud-storage/Package.swift
@@ -58,6 +58,7 @@ let package = Package(
         .product(name: "Crypto", package: "swift-crypto"),
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "_NIOFileSystem", package: "swift-nio"),
         .product(name: "NIOHTTP1", package: "swift-nio"),
       ],
       path: "Sources/GoogleCloudStorage"

--- a/packages/swift-google-cloud-storage/Package.swift
+++ b/packages/swift-google-cloud-storage/Package.swift
@@ -58,6 +58,7 @@ let package = Package(
         .product(name: "Crypto", package: "swift-crypto"),
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "NIOCore", package: "swift-nio"),
+        .product(name: "NIOPosix", package: "swift-nio"),
         .product(name: "NIOHTTP1", package: "swift-nio"),
       ],
       path: "Sources/GoogleCloudStorage"

--- a/packages/swift-google-cloud-storage/Package.swift
+++ b/packages/swift-google-cloud-storage/Package.swift
@@ -58,7 +58,6 @@ let package = Package(
         .product(name: "Crypto", package: "swift-crypto"),
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "NIOCore", package: "swift-nio"),
-        .product(name: "NIOPosix", package: "swift-nio"),
         .product(name: "NIOHTTP1", package: "swift-nio"),
       ],
       path: "Sources/GoogleCloudStorage"

--- a/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/FileSource.swift
+++ b/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/FileSource.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import NIOCore
+// We expect the API is stable, see https://github.com/apple/swift-nio/issues/3052 for details
 import _NIOFileSystem
 
 private final class FileHandleBox: @unchecked Sendable {

--- a/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/FileSource.swift
+++ b/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/FileSource.swift
@@ -14,7 +14,6 @@
 
 import Foundation
 import NIOCore
-import NIOPosix
 
 private final class FileHandleBox: @unchecked Sendable {
   let fileHandle: NIOFileHandle

--- a/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/FileSource.swift
+++ b/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/FileSource.swift
@@ -14,95 +14,36 @@
 
 import Foundation
 import NIOCore
-
-#if canImport(Darwin)
-  import Darwin
-#elseif canImport(Glibc)
-  import Glibc
-#elseif canImport(Musl)
-  import Musl
-#endif
+import NIOPosix
 
 private final class FileHandleBox: @unchecked Sendable {
-  let fd: CInt
+  let fileHandle: NIOFileHandle
 
-  init(fd: CInt) {
-    self.fd = fd
+  init(fileHandle: NIOFileHandle) {
+    self.fileHandle = fileHandle
   }
 
   deinit {
-    #if canImport(Darwin)
-      _ = Darwin.close(fd)
-    #elseif canImport(Glibc)
-      _ = Glibc.close(fd)
-    #elseif canImport(Musl)
-      _ = Musl.close(fd)
-    #else
-      _ = close(fd)
-    #endif
+    try? fileHandle.close()
   }
 
   static func open(fileURL: URL) throws -> FileHandleBox {
-    let fd = try fileURL.withUnsafeFileSystemRepresentation { cPath in
-      guard let cPath = cPath else {
-        throw UploadError.internalError("Unable to resolve file path for URL: \(fileURL)")
-      }
-      #if canImport(Darwin)
-        let fd = Darwin.open(cPath, O_RDONLY)
-      #elseif canImport(Glibc)
-        let fd = Glibc.open(cPath, O_RDONLY | O_CLOEXEC)
-      #elseif canImport(Musl)
-        let fd = Musl.open(cPath, O_RDONLY | O_CLOEXEC)
-      #else
-        let fd = open(cPath, O_RDONLY)
-      #endif
-      guard fd >= 0 else {
-        let code = errno
-        if code == ENOENT {
-          throw CocoaError(.fileNoSuchFile)
-        } else if code == EACCES {
-          throw CocoaError(.fileReadNoPermission)
-        } else {
-          throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
-        }
-      }
-      return fd
-    }
-    return FileHandleBox(fd: fd)
+    let handle = try NIOFileHandle(_deprecatedPath: fileURL.path)
+    return FileHandleBox(fileHandle: handle)
   }
 
-  var totalSize: UInt64? {
-    var st = stat()
-    #if canImport(Darwin)
-      guard Darwin.fstat(fd, &st) == 0 else { return nil }
-    #elseif canImport(Glibc)
-      guard Glibc.fstat(fd, &st) == 0 else { return nil }
-    #elseif canImport(Musl)
-      guard Musl.fstat(fd, &st) == 0 else { return nil }
-    #else
-      guard fstat(fd, &st) == 0 else { return nil }
-    #endif
-    return st.st_size >= 0 ? UInt64(st.st_size) : nil
-  }
-
-  func pread(into base: UnsafeMutableRawPointer, maxBytes: Int, offset: UInt64) throws -> Int {
+  func readBytes(into base: UnsafeMutableRawPointer, maxBytes: Int, offset: UInt64) throws -> Int {
     guard let off = off_t(exactly: offset) else {
       throw UploadError.internalError("Offset exceeds maximum file offset: \(offset)")
     }
-    #if canImport(Darwin)
-      let n = Darwin.pread(fd, base, maxBytes, off)
-    #elseif canImport(Glibc)
-      let n = Glibc.pread(fd, base, maxBytes, off)
-    #elseif canImport(Musl)
-      let n = Musl.pread(fd, base, maxBytes, off)
-    #else
+    return try fileHandle.withUnsafeFileDescriptor { fd in
       let n = pread(fd, base, maxBytes, off)
-    #endif
-    guard n >= 0 else {
-      let code = errno
-      throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+      guard n >= 0 else {
+        let code = errno
+        throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+      }
+      return n
     }
-    return n
   }
 }
 
@@ -113,9 +54,6 @@ public struct FileSource: SeekableUploadSource {
   private var handleBox: FileHandleBox?
 
   public var totalSize: UInt64? {
-    if let size = handleBox?.totalSize {
-      return size
-    }
     do {
       let values = try fileURL.resourceValues(forKeys: [.fileSizeKey])
       return values.fileSize.flatMap { $0 >= 0 ? UInt64($0) : nil }
@@ -149,7 +87,7 @@ public struct FileSource: SeekableUploadSource {
     let bytesRead = try nioBuffer.writeWithUnsafeMutableBytes(minimumWritableBytes: maxBytes) {
       ptr in
       guard let base = ptr.baseAddress else { return 0 }
-      return try box.pread(into: base, maxBytes: maxBytes, offset: currentOffset)
+      return try box.readBytes(into: base, maxBytes: maxBytes, offset: currentOffset)
     }
 
     guard bytesRead > 0 else {

--- a/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/FileSource.swift
+++ b/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/FileSource.swift
@@ -14,41 +14,42 @@
 
 import Foundation
 import NIOCore
+import _NIOFileSystem
 
 private final class FileHandleBox: @unchecked Sendable {
-  let fileHandle: NIOFileHandle
+  let handle: ReadFileHandle
 
-  init(fileHandle: NIOFileHandle) {
-    self.fileHandle = fileHandle
+  init(handle: ReadFileHandle) {
+    self.handle = handle
   }
 
   deinit {
-    try? fileHandle.close()
+    if let descriptor = try? handle.detachUnsafeFileDescriptor() {
+      try? descriptor.close()
+    }
   }
 
-  static func open(fileURL: URL) throws -> FileHandleBox {
-    let handle = try NIOFileHandle(_deprecatedPath: fileURL.path)
-    return FileHandleBox(fileHandle: handle)
+  static func open(fileURL: URL) async throws -> FileHandleBox {
+    let handle = try await FileSystem.shared.openFile(
+      forReadingAt: FilePath(fileURL.path)
+    )
+    return FileHandleBox(handle: handle)
   }
 
-  func read(maxBytes: Int, offset: UInt64) throws -> NIOCore.ByteBuffer? {
-    guard let off = off_t(exactly: offset) else {
+  func read(maxBytes: Int, offset: UInt64) async throws -> NIOCore.ByteBuffer? {
+    guard let off = Int64(exactly: offset) else {
       throw UploadError.internalError("Offset exceeds maximum file offset: \(offset)")
     }
-    var buffer = ByteBufferAllocator().buffer(capacity: maxBytes)
-    let bytesRead = try buffer.writeWithUnsafeMutableBytes(minimumWritableBytes: maxBytes) { ptr in
-      guard let base = ptr.baseAddress else { return 0 }
-      return try fileHandle.withUnsafeFileDescriptor { fd in
-        let n = pread(fd, base, maxBytes, off)
-        guard n >= 0 else {
-          let code = errno
-          throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
-        }
-        return n
-      }
-    }
-    guard bytesRead > 0 else { return nil }
+    let buffer = try await handle.readChunk(
+      fromAbsoluteOffset: off,
+      length: .bytes(Int64(maxBytes))
+    )
+    guard buffer.readableBytes > 0 else { return nil }
     return buffer
+  }
+
+  func close() async throws {
+    try await handle.close()
   }
 }
 
@@ -74,7 +75,10 @@ public struct FileSource: SeekableUploadSource {
   public mutating func read(maxBytes: Int) async throws -> ByteBuffer? {
     guard maxBytes > 0 else { return nil }
     if let size = totalSize, offset >= size {
-      handleBox = nil
+      if let box = handleBox {
+        try? await box.close()
+        handleBox = nil
+      }
       return nil
     }
 
@@ -82,12 +86,13 @@ public struct FileSource: SeekableUploadSource {
     if let existing = handleBox {
       box = existing
     } else {
-      let newBox = try FileHandleBox.open(fileURL: fileURL)
+      let newBox = try await FileHandleBox.open(fileURL: fileURL)
       self.handleBox = newBox
       box = newBox
     }
 
-    guard let nioBuffer = try box.read(maxBytes: maxBytes, offset: offset) else {
+    guard let nioBuffer = try await box.read(maxBytes: maxBytes, offset: offset) else {
+      try? await box.close()
       handleBox = nil
       return nil
     }

--- a/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/FileSource.swift
+++ b/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/FileSource.swift
@@ -13,13 +13,109 @@
 // limitations under the License.
 
 import Foundation
+import NIOCore
+
+#if canImport(Darwin)
+  import Darwin
+#elseif canImport(Glibc)
+  import Glibc
+#elseif canImport(Musl)
+  import Musl
+#endif
+
+private final class FileHandleBox: @unchecked Sendable {
+  let fd: CInt
+
+  init(fd: CInt) {
+    self.fd = fd
+  }
+
+  deinit {
+    #if canImport(Darwin)
+      _ = Darwin.close(fd)
+    #elseif canImport(Glibc)
+      _ = Glibc.close(fd)
+    #elseif canImport(Musl)
+      _ = Musl.close(fd)
+    #else
+      _ = close(fd)
+    #endif
+  }
+
+  static func open(fileURL: URL) throws -> FileHandleBox {
+    let fd = try fileURL.withUnsafeFileSystemRepresentation { cPath in
+      guard let cPath = cPath else {
+        throw UploadError.internalError("Unable to resolve file path for URL: \(fileURL)")
+      }
+      #if canImport(Darwin)
+        let fd = Darwin.open(cPath, O_RDONLY)
+      #elseif canImport(Glibc)
+        let fd = Glibc.open(cPath, O_RDONLY | O_CLOEXEC)
+      #elseif canImport(Musl)
+        let fd = Musl.open(cPath, O_RDONLY | O_CLOEXEC)
+      #else
+        let fd = open(cPath, O_RDONLY)
+      #endif
+      guard fd >= 0 else {
+        let code = errno
+        if code == ENOENT {
+          throw CocoaError(.fileNoSuchFile)
+        } else if code == EACCES {
+          throw CocoaError(.fileReadNoPermission)
+        } else {
+          throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+        }
+      }
+      return fd
+    }
+    return FileHandleBox(fd: fd)
+  }
+
+  var totalSize: UInt64? {
+    var st = stat()
+    #if canImport(Darwin)
+      guard Darwin.fstat(fd, &st) == 0 else { return nil }
+    #elseif canImport(Glibc)
+      guard Glibc.fstat(fd, &st) == 0 else { return nil }
+    #elseif canImport(Musl)
+      guard Musl.fstat(fd, &st) == 0 else { return nil }
+    #else
+      guard fstat(fd, &st) == 0 else { return nil }
+    #endif
+    return st.st_size >= 0 ? UInt64(st.st_size) : nil
+  }
+
+  func pread(into base: UnsafeMutableRawPointer, maxBytes: Int, offset: UInt64) throws -> Int {
+    guard let off = off_t(exactly: offset) else {
+      throw UploadError.internalError("Offset exceeds maximum file offset: \(offset)")
+    }
+    #if canImport(Darwin)
+      let n = Darwin.pread(fd, base, maxBytes, off)
+    #elseif canImport(Glibc)
+      let n = Glibc.pread(fd, base, maxBytes, off)
+    #elseif canImport(Musl)
+      let n = Musl.pread(fd, base, maxBytes, off)
+    #else
+      let n = pread(fd, base, maxBytes, off)
+    #endif
+    guard n >= 0 else {
+      let code = errno
+      throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+    }
+    return n
+  }
+}
 
 /// An upload source that reads from a local file.
 public struct FileSource: SeekableUploadSource {
   public let fileURL: URL
   private var offset: UInt64 = 0
+  private var handleBox: FileHandleBox?
 
   public var totalSize: UInt64? {
+    if let size = handleBox?.totalSize {
+      return size
+    }
     do {
       let values = try fileURL.resourceValues(forKeys: [.fileSizeKey])
       return values.fileSize.flatMap { $0 >= 0 ? UInt64($0) : nil }
@@ -33,16 +129,36 @@ public struct FileSource: SeekableUploadSource {
   }
 
   public mutating func read(maxBytes: Int) async throws -> ByteBuffer? {
-    let handle = try FileHandle(forReadingFrom: fileURL)
-    defer {
-      try? handle.close()
-    }
-    try handle.seek(toOffset: offset)
-    guard let data = try handle.read(upToCount: maxBytes), !data.isEmpty else {
+    guard maxBytes > 0 else { return nil }
+    if let size = totalSize, offset >= size {
+      handleBox = nil
       return nil
     }
-    offset += UInt64(data.count)
-    return ByteBuffer(data)
+
+    let box: FileHandleBox
+    if let existing = handleBox {
+      box = existing
+    } else {
+      let newBox = try FileHandleBox.open(fileURL: fileURL)
+      self.handleBox = newBox
+      box = newBox
+    }
+
+    var nioBuffer = ByteBufferAllocator().buffer(capacity: maxBytes)
+    let currentOffset = offset
+    let bytesRead = try nioBuffer.writeWithUnsafeMutableBytes(minimumWritableBytes: maxBytes) {
+      ptr in
+      guard let base = ptr.baseAddress else { return 0 }
+      return try box.pread(into: base, maxBytes: maxBytes, offset: currentOffset)
+    }
+
+    guard bytesRead > 0 else {
+      handleBox = nil
+      return nil
+    }
+
+    offset += UInt64(bytesRead)
+    return ByteBuffer(nioBuffer)
   }
 
   public mutating func seek(to offset: UInt64) async throws {

--- a/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/FileSource.swift
+++ b/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/FileSource.swift
@@ -32,18 +32,24 @@ private final class FileHandleBox: @unchecked Sendable {
     return FileHandleBox(fileHandle: handle)
   }
 
-  func readBytes(into base: UnsafeMutableRawPointer, maxBytes: Int, offset: UInt64) throws -> Int {
+  func read(maxBytes: Int, offset: UInt64) throws -> NIOCore.ByteBuffer? {
     guard let off = off_t(exactly: offset) else {
       throw UploadError.internalError("Offset exceeds maximum file offset: \(offset)")
     }
-    return try fileHandle.withUnsafeFileDescriptor { fd in
-      let n = pread(fd, base, maxBytes, off)
-      guard n >= 0 else {
-        let code = errno
-        throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+    var buffer = ByteBufferAllocator().buffer(capacity: maxBytes)
+    let bytesRead = try buffer.writeWithUnsafeMutableBytes(minimumWritableBytes: maxBytes) { ptr in
+      guard let base = ptr.baseAddress else { return 0 }
+      return try fileHandle.withUnsafeFileDescriptor { fd in
+        let n = pread(fd, base, maxBytes, off)
+        guard n >= 0 else {
+          let code = errno
+          throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+        }
+        return n
       }
-      return n
     }
+    guard bytesRead > 0 else { return nil }
+    return buffer
   }
 }
 
@@ -82,20 +88,12 @@ public struct FileSource: SeekableUploadSource {
       box = newBox
     }
 
-    var nioBuffer = ByteBufferAllocator().buffer(capacity: maxBytes)
-    let currentOffset = offset
-    let bytesRead = try nioBuffer.writeWithUnsafeMutableBytes(minimumWritableBytes: maxBytes) {
-      ptr in
-      guard let base = ptr.baseAddress else { return 0 }
-      return try box.readBytes(into: base, maxBytes: maxBytes, offset: currentOffset)
-    }
-
-    guard bytesRead > 0 else {
+    guard let nioBuffer = try box.read(maxBytes: maxBytes, offset: offset) else {
       handleBox = nil
       return nil
     }
 
-    offset += UInt64(bytesRead)
+    offset += UInt64(nioBuffer.readableBytes)
     return ByteBuffer(nioBuffer)
   }
 


### PR DESCRIPTION
Fixes #606 

We use a box implementation to manage the lifecycle of the file descriptor (close on deinit if it was opened)