### PR TITLE
fix(Endurance): log errors immediately

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "5c64860ba382ee9718763d43cb5694857a966e03d4ade7994047068b97054d1b",
+  "originHash" : "ac507a2e1b3a29cefbdc5da88f9835603ecd9329f150f43f140bc6841d3d4b94",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "9544287b9416c0bc71e58b9f3aead8dd14b16103",
-        "version" : "1.36.0"
+        "revision" : "f95c908967e98c68c5ce3fd61a7974e7e869e303",
+        "version" : "1.36.1"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
-        "version" : "1.7.1"
+        "revision" : "d9a5b37470adc940d22c3bcd5ca6953a516b727f",
+        "version" : "1.7.2"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "449dbbecd0f31e82b510ada227ca152caa8b5e98",
-        "version" : "1.19.4"
+        "revision" : "c8aece90ea05f9866bd392a5bf13b5cae56c0e03",
+        "version" : "1.20.0"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
-        "version" : "2.101.3"
+        "revision" : "a931f2c1de8dd49381ce3bf2e279d033f68d8865",
+        "version" : "2.102.0"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
-        "version" : "1.34.3"
+        "revision" : "3078359149adac3dd1255621a041e361e3f0edd1",
+        "version" : "1.35.0"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "45bdf670248be5f16ec0340e125dca285536f0fb",
-        "version" : "1.45.0"
+        "revision" : "0f3e54e29c944c2e835ad52159da7d9e1c94ac69",
+        "version" : "1.46.0"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "d930168b86f46ca51a4bc09c5ca45c1833db8067",
-        "version" : "2.37.2"
+        "revision" : "dea6ebb773fb4b140753d48f93c8d0084531fbd5",
+        "version" : "2.37.3"
       }
     },
     {

--- a/Tests/Endurance/main.swift
+++ b/Tests/Endurance/main.swift
@@ -118,9 +118,17 @@ private func worker(
   while true {
     let now = ContinuousClock.now
     if now >= lastAddVersion + addVersionPeriod {
-      version = try await updateSecret(client: client, secret: secret)
-      lastAddVersion = ContinuousClock.now
-      updateCount += 1
+      do {
+        version = try await updateSecret(client: client, secret: secret)
+        lastAddVersion = ContinuousClock.now
+        updateCount += 1
+      } catch {
+        errorCount += 1
+        if errorCount > tooManyErrors && successCount == 0 {
+          throw error
+        }
+        reportError(error, task: "task[\(taskId)]")
+      }
     }
 
     if now >= lastReport + reportPeriod {
@@ -162,6 +170,7 @@ private func worker(
       if errorCount > tooManyErrors && successCount == 0 {
         throw error
       }
+      reportError(error, task: "task[\(taskId)]")
     }
 
     if ContinuousClock.now < nextTargetTime {
@@ -181,17 +190,20 @@ private func updateSecret(
     if version.state == .destroyed {
       continue
     }
-    _ = try await client.destroySecretVersion(request: .init().with { $0.name = version.name })
+    _ = try await client.destroySecretVersion(
+      request: .init().with { $0.name = version.name },
+      options: .init().with { $0.idempotency = true })
   }
 
   let version = try await client.addSecretVersion(
     request: .init().with {
       $0.parent = secret
-      $0.payload = SecretPayload().with {
-        $0.data = payloadData
-        $0.dataCrc32C = payloadCrc32c
+      $0.payload = SecretPayload().with { payload in
+        payload.data = payloadData
+        payload.dataCrc32C = payloadCrc32c
       }
-    })
+    },
+    options: .init().with { $0.idempotency = true })
   return version
 }
 


### PR DESCRIPTION
The test should log errors that escape the retry loop immediately, even if they don't stop testing.

Towards #16 