### PR TITLE
feat(gax): support explicit client shutdown

### DIFF
--- a/packages/swift-google-gax/Sources/GoogleCloudGax/HTTPClient.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/HTTPClient.swift
@@ -107,4 +107,8 @@ import struct Logging.Logger
     }
     return try await newRequest(urlComponents: components)
   }
+
+  public func shutdown() async throws {
+    try await self.inner.shutdown()
+  }
 }

--- a/packages/swift-google-gax/Sources/GoogleCloudGax/HTTPClientHolder.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/HTTPClientHolder.swift
@@ -13,38 +13,67 @@
 // limitations under the License.
 
 import class AsyncHTTPClient.HTTPClient
+import struct AsyncHTTPClient.HTTPClientError
 import struct AsyncHTTPClient.HTTPClientRequest
 import struct AsyncHTTPClient.HTTPClientResponse
 import struct Logging.Logger
+import Synchronization
 
 /// Automatically call shutdown() on a HTTPClient.
 ///
 /// HTTPClient requires an (asynchronous) call to `shutdown()` or it leaks resources.
-/// This class automates the call.
+/// This class automates the call via `deinit`, while also offering an explicit `shutdown()`
+/// method for deterministic cleanup (e.g. before application or benchmark termination).
 ///
 /// SAFETY: calling `shutdown()` requires all requests to be finished. In the AuthHTTPClient struct
 /// each HTTP request is executed within a function, therefore the object is live while the HTTP
-/// request is in progress. By the time deinit starts, all starting a call requires having a
-/// reference to the object, so shutdown
+/// request is in progress. By the time deinit starts, starting a call requires having a
+/// reference to the object.
 final class HTTPClientHolder: _HTTPClientProtocol {
-  let inner = AsyncHTTPClient.HTTPClient()
+  private let state: Mutex<AsyncHTTPClient.HTTPClient?>
+
+  init() {
+    self.state = Mutex(AsyncHTTPClient.HTTPClient())
+  }
+
   deinit {
-    // Use a background task to shutdown the inner client. In most cases, the application will
-    // continue running and the HTTPClient is shutdown "eventually". Except for (maybe) some false
-    // positives in leak detectors, there is no harm if the application terminates before this gets
-    // to run.
-    let copy = inner
-    Task {
-      // Note how we make a copy of `inner` to avoid capturing `self`.
-      do {
-        try await copy.shutdown()
-      } catch {
-        // Ignore any exceptions. If `shutdown()` failed there is nothing the application can do.
+    let copy = self.state.withLock { state -> AsyncHTTPClient.HTTPClient? in
+      let client = state
+      state = nil
+      return client
+    }
+    if let copy {
+      // Use a background task to shutdown the inner client. In most cases, the application will
+      // continue running and the HTTPClient is shutdown "eventually". Except for (maybe) some false
+      // positives in leak detectors, there is no harm if the application terminates before this gets
+      // to run.
+      Task {
+        // Note how we make a copy of `inner` to avoid capturing `self`.
+        do {
+          try await copy.shutdown()
+        } catch {
+          // Ignore any exceptions. If `shutdown()` failed there is nothing the application can do.
+        }
       }
     }
   }
 
+  func shutdown() async throws {
+    let client = self.state.withLock { state -> AsyncHTTPClient.HTTPClient? in
+      let client = state
+      state = nil
+      return client
+    }
+    if let client {
+      try await client.shutdown()
+    }
+  }
+
   func execute(request: HTTPClientRequest, timeout: Duration) async throws -> HTTPClientResponse {
-    try await self.inner.execute(request, timeout: .init(timeout), logger: nil)
+    let client = self.state.withLock { $0 }
+    guard let client else {
+      throw HTTPClientError.alreadyShutdown
+    }
+    return try await client.execute(request, timeout: .init(timeout), logger: nil)
   }
 }

--- a/packages/swift-google-gax/Sources/GoogleCloudGax/HTTPClientProtocol.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/HTTPClientProtocol.swift
@@ -21,4 +21,9 @@ import struct Logging.Logger
 /// The tests for `GoogleCloudGax.HttpClient`
 @_spi(GoogleCloudInternal) public protocol _HTTPClientProtocol: Sendable {
   func execute(request: HTTPClientRequest, timeout: Duration) async throws -> HTTPClientResponse
+  func shutdown() async throws
+}
+
+extension _HTTPClientProtocol {
+  public func shutdown() async throws {}
 }

--- a/packages/swift-google-gax/Tests/HTTPClientTests.swift
+++ b/packages/swift-google-gax/Tests/HTTPClientTests.swift
@@ -608,6 +608,16 @@ import NIOHTTP1
     #expect(response.status == .ok)
   }
 
+  @Test func shutdownIsIdempotent() async throws {
+    let endpoint = "http://localhost:1234"
+    let credentials = try Credentials(configuration: .anonymous)
+    let options = ClientOptions().with { $0.credentials = credentials }
+    let client = try _HTTPClient(from: options, withDefaultEndpoint: endpoint)
+    try await client.shutdown()
+    // Second shutdown must be a safe idempotent no-op
+    try await client.shutdown()
+  }
+
   /// A test response type.
   struct ResponseType: Codable, Equatable, Sendable {
     public let name: String


### PR DESCRIPTION
Add explicit shutdown() to _HTTPClientProtocol, HTTPClientHolder, and _HTTPClient for deterministic resource cleanup.

Motived by #647 