### PR TITLE
fix(storage): channel leaks during uploads

### DIFF
--- a/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -265,6 +265,9 @@ extension StorageClient {
         statusCode: statusCode,
         message: String(data: startData, encoding: .utf8) ?? "")
     }
+    // We need to drain the data in the response to release the underlying resources. We can ignore
+    // any errors because the the information we wanted is already captured.
+    await startResponse.drain()
     return location
   }
 
@@ -291,6 +294,9 @@ extension StorageClient {
       return (.done(object), nil)
     } else if statusCode == 308 {
       let queryStatus = try parseResumableUploadQueryStatus(from: queryResponse.headers)
+      // We need to drain the data in the response to release the underlying resources. We can ignore
+      // any errors because the the information we wanted is already captured.
+      await queryResponse.drain()
       return (.inprogress(queryStatus.nextOffset), queryStatus.crc32cSeed)
     } else if queryResponse.isError() {
       throw await queryResponse.decodeError()
@@ -363,6 +369,9 @@ extension StorageClient {
       if let runningHashHeader = uploadResponse.headers.first(name: "x-goog-running-hash") {
         crc32cSeed = parseCRC32CFromRunningHash(runningHashHeader)
       }
+      // We need to drain the data in the response to release the underlying resources. We can ignore
+      // any errors because the the information we wanted is already captured.
+      await uploadResponse.drain()
       return (.inprogress(nextOffset), crc32cSeed)
     } else if uploadResponse.isError() {
       throw await uploadResponse.decodeError()

--- a/packages/swift-google-gax/Sources/GoogleCloudGax/HTTPClientResponse.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/HTTPClientResponse.swift
@@ -56,6 +56,12 @@ import struct NIOCore.ByteBuffer
     try await data(upTo: Self.defaultMaximumResponseSize)
   }
 
+  public consuming func drain() async {
+    do {
+      for try await _ in self.response.body {}
+    } catch {}
+  }
+
   public func isError() -> Bool {
     !(200...300).contains(self.response.status.code)
   }


### PR DESCRIPTION
When using AsyncHTTPClient one must drain any response. I cannot find an authoritative source, but my friend Gemini read the code in AsyncHTTPClient. It also makes sense, because the underlying transfer stops us from reusing the socket under HTTP/1.x and may block other streams with HTTP/2.