### PR TITLE
fix(StorageW1R3): share the random data

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,6 +54,7 @@ let package = Package(
     .package(path: "./guide"),
     .package(url: "https://github.com/apple/swift-log", from: "1.12.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
+    .package(url: "https://github.com/apple/swift-nio", from: "2.101.0"),
     // Only used for development.
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
   ] + generatedDependencies,
@@ -144,6 +145,7 @@ let package = Package(
         .product(name: "GoogleCloudAuth", package: "swift-google-auth"),
         .product(name: "GoogleCloudGax", package: "swift-google-gax"),
         .product(name: "Logging", package: "swift-log"),
+        .product(name: "NIOCore", package: "swift-nio"),
       ],
       path: "Tests/StorageW1R3",
       exclude: ["README.md"]

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import NIOCore
 import GoogleCloudAuth
 import GoogleCloudGax
 import GoogleCloudStorage
@@ -22,7 +23,7 @@ extension StorageW1R3 {
   func runWorker(
     taskIndex: Int,
     counters: BenchmarkCounters,
-    buffer: Data
+    buffer: NIOCore.ByteBuffer
   ) async {
     let clock = ContinuousClock()
     // Apply rampup delay
@@ -61,7 +62,7 @@ extension StorageW1R3 {
       let size = pickObjectSize()
       let objectName = Self.randomObjectName()
       let isResumable = Bool.random()
-      let uploadSlice = size > 0 ? buffer.prefix(size) : Data()
+      let uploadSlice = buffer.getSlice(at: 0, length: size) ?? buffer.slice()
       let iterationId = IterationId(
         task: taskIndex, taskStartInstant: taskStartInstant, iteration: iteration)
 
@@ -73,7 +74,7 @@ extension StorageW1R3 {
           controlClient: controlClient,
           bucketName: bucketName,
           objectName: objectName,
-          data: uploadSlice,
+          buffer: uploadSlice,
           isResumable: isResumable)
       else {
         continue
@@ -127,7 +128,7 @@ extension StorageW1R3 {
     controlClient: StorageControlClient,
     bucketName: String,
     objectName: String,
-    data: Data,
+    buffer: NIOCore.ByteBuffer,
     isResumable: Bool
   ) async -> GoogleCloudStorage.Object? {
     let uploadOp: Operation = isResumable ? .resumable : .singleShot
@@ -135,7 +136,7 @@ extension StorageW1R3 {
     let uploadBuilder = SampleBuilder(
       iterationId: iterationId,
       op: uploadOp,
-      targetSize: data.count,
+      targetSize: buffer.readableBytes,
       object: objectName
     )
     do {
@@ -144,7 +145,7 @@ extension StorageW1R3 {
         controlClient: controlClient,
         bucketName: bucketName,
         objectName: objectName,
-        data: data,
+        buffer: buffer,
         isResumable: isResumable
       )
       let sample = uploadBuilder.success()
@@ -242,9 +243,10 @@ extension StorageW1R3 {
     print(sample.toRow())
   }
 
-  func generateRandomBuffer() -> Data {
+  func generateRandomBuffer() -> NIOCore.ByteBuffer {
     let size = self.maxObjectSize
-    guard size > 0 else { return Data() }
+    var buffer = ByteBufferAllocator().buffer(capacity: size)
+    guard size > 0 else { return buffer }
     // There is a lot going on here. Sometimes the benchmark is used with really large buffers,
     // 256MiB and 2GiB are not uncommon. To efficiently initialized the buffer with random data
     // we create an array of the desired size.
@@ -263,7 +265,8 @@ extension StorageW1R3 {
       }
       initializedCount = size
     }
-    return Data(bytes)
+    buffer.writeBytes(bytes)
+    return buffer
   }
 
   private static func randomObjectName() -> String {

--- a/Tests/StorageW1R3/StorageOperations.swift
+++ b/Tests/StorageW1R3/StorageOperations.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import NIOCore
 import GoogleCloudAuth
 import GoogleCloudGax
 import GoogleCloudStorage
@@ -24,7 +25,7 @@ enum StorageOperations {
     controlClient: StorageControlClient,
     bucketName: String,
     objectName: String,
-    data: Data,
+    buffer: NIOCore.ByteBuffer,
     isResumable: Bool
   ) async throws -> GoogleCloudStorage.Object {
     let options = UploadOptions().with {
@@ -34,14 +35,15 @@ enum StorageOperations {
       // If resumable, chunk size is set to 32MiB; if simple, threshold handles it
       if isResumable {
         $0.chunkSize = 32 * 1024 * 1024
-        $0.resumableUploadThreshold = data.count
+        $0.resumableUploadThreshold = buffer.readableBytes
       } else {
-        $0.resumableUploadThreshold = data.count + 256 * 1024
+        $0.resumableUploadThreshold = buffer.readableBytes + 256 * 1024
       }
     }
 
     do {
-      return try await client.upload(data, to: bucketName, as: objectName, options: options)
+      return try await client.upload(
+        BytesSource(buffer: .init(buffer)), to: bucketName, as: objectName, options: options)
     } catch {
       // If precondition failed (412), check if object already exists
       if let reqError = error as? RequestError,


### PR DESCRIPTION
Evidently `Foundation.Data()` does not share the underlying data. Which means each task was getting a copy of the random data, and each upload a copy of the slice to be uploaded, and a freshly allocated buffer for it too!

Better to use `NIOCore.ByteBuffer` which (I read) does share data when the common buffer is not modified.