### PR TITLE
feat(StorageW1R3): configurable client count

### DIFF
--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -23,7 +23,9 @@ extension StorageW1R3 {
   func runWorker(
     taskIndex: Int,
     counters: BenchmarkCounters,
-    buffer: NIOCore.ByteBuffer
+    buffer: NIOCore.ByteBuffer,
+    storageClient: StorageClient,
+    controlClient: StorageControlClient,
   ) async {
     let clock = ContinuousClock()
     // Apply rampup delay
@@ -31,19 +33,9 @@ extension StorageW1R3 {
       let delay = rampupPeriod * Double(taskIndex)
       try? await Task.sleep(for: delay)
     }
-
-    let credentials: Credentials
-    let storageClient: StorageClient
-    let controlClient: StorageControlClient
-    do {
-      credentials = try Credentials()
-      storageClient = try StorageClient(
-        StorageClientOptions().with { $0.client = .init().with { $0.credentials = credentials } })
-      controlClient = try StorageControlClient(
-        ClientOptions().with { $0.credentials = credentials })
-    } catch {
-      logToStderr("Failed to initialize Storage clients for task \(taskIndex): \(error)")
-      return
+    await counters.taskStarted()
+    defer {
+      Task { await counters.taskFinished() }
     }
 
     let taskStartInstant = clock.now
@@ -272,5 +264,23 @@ extension StorageW1R3 {
   private static func randomObjectName() -> String {
     let charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
     return String((0..<32).map { _ in charset.randomElement()! })
+  }
+
+  func makeClients(_ credentials: Credentials) throws -> [StorageClient] {
+    var clients: [StorageClient] = []
+    for _ in 0..<self.clientCount {
+      clients.append(try StorageClient(.init().with {
+        $0.client = .init().with { $0.credentials = credentials }
+      }))
+    }
+    return clients
+  }
+
+  func makeControlClients(_ credentials: Credentials) throws -> [StorageControlClient] {
+    var clients: [StorageControlClient] = []
+    for _ in 0..<self.controlClientCount {
+      clients.append(try StorageControlClient(.init().with { $0.credentials = credentials }))
+    }
+    return clients
   }
 }

--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -269,9 +269,11 @@ extension StorageW1R3 {
   func makeClients(_ credentials: Credentials) throws -> [StorageClient] {
     var clients: [StorageClient] = []
     for _ in 0..<self.clientCount {
-      clients.append(try StorageClient(.init().with {
-        $0.client = .init().with { $0.credentials = credentials }
-      }))
+      clients.append(
+        try StorageClient(
+          .init().with {
+            $0.client = .init().with { clientOptions in clientOptions.credentials = credentials }
+          }))
     }
     return clients
   }

--- a/Tests/StorageW1R3/Counters.swift
+++ b/Tests/StorageW1R3/Counters.swift
@@ -28,6 +28,7 @@ public actor BenchmarkCounters {
   public private(set) var deleteError: UInt64 = 0
   public private(set) var readError: UInt64 = 0
   public private(set) var writeError: UInt64 = 0
+  public private(set) var activeTasks: UInt64 = 0
 
   public init() {}
 
@@ -59,6 +60,14 @@ public actor BenchmarkCounters {
     writeError &+= 1
   }
 
+  public func taskStarted() {
+    activeTasks &+= 1
+  }
+
+  public func taskFinished() {
+    activeTasks &-= 1
+  }
+
   public func snapshot() -> [(key: String, value: UInt64)] {
     [
       ("DELETE_COUNT", deleteCount),
@@ -68,6 +77,7 @@ public actor BenchmarkCounters {
       ("SAMPLE_COUNT", sampleCount),
       ("WRITE_COUNT", writeCount),
       ("WRITE_ERROR", writeError),
+      ("TASK_COUNT", activeTasks),
     ]
   }
 

--- a/Tests/StorageW1R3/StorageW1R3.swift
+++ b/Tests/StorageW1R3/StorageW1R3.swift
@@ -14,6 +14,8 @@
 
 import ArgumentParser
 import Foundation
+import GoogleCloudAuth
+import GoogleCloudStorage
 
 @main
 struct StorageW1R3: AsyncParsableCommand, Sendable {
@@ -56,6 +58,11 @@ struct StorageW1R3: AsyncParsableCommand, Sendable {
     let randomBuffer = self.generateRandomBuffer()
     logToStderr("Random payload buffer ready.")
 
+    let credentials = try Credentials()
+    let storageClients = try self.makeClients(credentials)
+    let controlClients = try self.makeControlClients(credentials)
+    logToStderr("Clients initialzed ready.")
+
     // Print CSV header to stdout.
     print(Sample.header)
 
@@ -78,7 +85,9 @@ struct StorageW1R3: AsyncParsableCommand, Sendable {
           await self.runWorker(
             taskIndex: taskIndex,
             counters: counters,
-            buffer: randomBuffer
+            buffer: randomBuffer,
+            storageClient: storageClients[taskIndex % storageClients.count],
+            controlClient: controlClients[taskIndex % controlClients.count],
           )
         }
       }
@@ -158,6 +167,18 @@ struct StorageW1R3: AsyncParsableCommand, Sendable {
   )
   var skipOkSamples: Bool = false
 
+  @Option(
+    name: .customLong("client-count"),
+    help: "Number of storage clients."
+  )
+  var clientCount: Int = 1
+
+  @Option(
+    name: .customLong("control-client-count"),
+    help: "Number of storage control clients."
+  )
+  var controlClientCount: Int = 1
+
   func validate() throws {
     guard minObjectSize <= maxObjectSize else {
       throw ValidationError(
@@ -175,6 +196,12 @@ struct StorageW1R3: AsyncParsableCommand, Sendable {
     }
     guard readCount >= 0 else {
       throw ValidationError("read-count must be non-negative")
+    }
+    guard clientCount >= 1 else {
+      throw ValidationError("client-count must be at least 1")
+    }
+    guard controlClientCount >= 1 else {
+      throw ValidationError("control-client-count must be at least 1")
     }
   }
 }

--- a/Tests/StorageW1R3/StorageW1R3.swift
+++ b/Tests/StorageW1R3/StorageW1R3.swift
@@ -61,7 +61,7 @@ struct StorageW1R3: AsyncParsableCommand, Sendable {
     let credentials = try Credentials()
     let storageClients = try self.makeClients(credentials)
     let controlClients = try self.makeControlClients(credentials)
-    logToStderr("Clients initialzed ready.")
+    logToStderr("Clients initialized ready.")
 
     // Print CSV header to stdout.
     print(Sample.header)


### PR DESCRIPTION
Sometimes we want to test with a separate client on each task (to test with isolated resources), some times with a single client (to test client under contention), and some times with something in between.