### PR TITLE
docs(storage): add bucket metadata samples

### DIFF
--- a/Sources/StorageSamples/Buckets/AddBucketLabel.swift
+++ b/Sources/StorageSamples/Buckets/AddBucketLabel.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_add_bucket_label]
+import GoogleCloudStorage
+
+public func addBucketLabel(
+  client: StorageControlClient, bucketId: String, labelKey: String, labelValue: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.labels[labelKey] = labelValue
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["labels"])
+    },
+    options: .init()
+  )
+  print("Successfully added label \(labelKey)=\(labelValue) to bucket \(bucketId)")
+}
+// [END storage_add_bucket_label]

--- a/Sources/StorageSamples/Buckets/AddLifecycleRule.swift
+++ b/Sources/StorageSamples/Buckets/AddLifecycleRule.swift
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_add_lifecycle_rule]
+import GoogleCloudStorage
+
+public func addLifecycleRule(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.lifecycle = (bucket.lifecycle ?? .init()).with { lifecycle in
+          lifecycle.rule.append(
+            .init().with { rule in
+              rule.action = .init().with { action in
+                action.type = "AbortIncompleteMultipartUpload"
+              }
+              rule.condition = .init().with { condition in
+                condition.ageDays = 7
+              }
+            }
+          )
+        }
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["lifecycle"])
+    },
+    options: .init()
+  )
+  print("Lifecycle rule added for bucket \(bucketId)")
+}
+// [END storage_add_lifecycle_rule]

--- a/Sources/StorageSamples/Buckets/ChangeDefaultStorageClass.swift
+++ b/Sources/StorageSamples/Buckets/ChangeDefaultStorageClass.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_change_default_storage_class]
+import GoogleCloudStorage
+
+public func changeDefaultStorageClass(
+  client: StorageControlClient, bucketId: String, storageClass: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.storageClass = storageClass
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["storage_class"])
+    },
+    options: .init()
+  )
+  print("Default storage class for bucket \(bucketId) set to \(storageClass)")
+}
+// [END storage_change_default_storage_class]

--- a/Sources/StorageSamples/Buckets/CorsConfiguration.swift
+++ b/Sources/StorageSamples/Buckets/CorsConfiguration.swift
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_cors_configuration]
+import GoogleCloudStorage
+
+public func corsConfiguration(
+  client: StorageControlClient, bucketId: String, maxAgeSeconds: Int32,
+  method: [String], origin: [String], responseHeader: [String]
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.cors.append(
+          .init().with { cors in
+            cors.maxAgeSeconds = maxAgeSeconds
+            cors.method = method
+            cors.origin = origin
+            cors.responseHeader = responseHeader
+          }
+        )
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["cors"])
+    },
+    options: .init()
+  )
+  print("Set CORS configuration on bucket \(bucketId)")
+}
+// [END storage_cors_configuration]

--- a/Sources/StorageSamples/Buckets/DefineBucketWebsiteConfiguration.swift
+++ b/Sources/StorageSamples/Buckets/DefineBucketWebsiteConfiguration.swift
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_define_bucket_website_configuration]
+import GoogleCloudStorage
+
+public func defineBucketWebsiteConfiguration(
+  client: StorageControlClient, bucketId: String, mainPageSuffix: String, notFoundPage: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.website = .init().with { website in
+          website.mainPageSuffix = mainPageSuffix
+          website.notFoundPage = notFoundPage
+        }
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["website"])
+    },
+    options: .init()
+  )
+  print("Static website configuration set for bucket \(bucketId)")
+}
+// [END storage_define_bucket_website_configuration]

--- a/Sources/StorageSamples/Buckets/DisableBucketLifecycleManagement.swift
+++ b/Sources/StorageSamples/Buckets/DisableBucketLifecycleManagement.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_disable_bucket_lifecycle_management]
+import GoogleCloudStorage
+
+public func disableBucketLifecycleManagement(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.lifecycle = .init()
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["lifecycle"])
+    },
+    options: .init()
+  )
+  print("Lifecycle management disabled for bucket \(bucketId)")
+}
+// [END storage_disable_bucket_lifecycle_management]

--- a/Sources/StorageSamples/Buckets/DisableDefaultEventBasedHold.swift
+++ b/Sources/StorageSamples/Buckets/DisableDefaultEventBasedHold.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_disable_default_event_based_hold]
+import GoogleCloudStorage
+
+public func disableDefaultEventBasedHold(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.defaultEventBasedHold = false
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["default_event_based_hold"])
+    },
+    options: .init()
+  )
+  print("Default event-based hold was disabled for \(bucketId)")
+}
+// [END storage_disable_default_event_based_hold]

--- a/Sources/StorageSamples/Buckets/DisableRequesterPays.swift
+++ b/Sources/StorageSamples/Buckets/DisableRequesterPays.swift
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_disable_requester_pays]
+import GoogleCloudStorage
+
+public func disableRequesterPays(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.billing = .init().with { billing in
+          billing.requesterPays = false
+        }
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["billing.requester_pays"])
+    },
+    options: .init()
+  )
+  print("Requester pays was disabled for \(bucketId)")
+}
+// [END storage_disable_requester_pays]

--- a/Sources/StorageSamples/Buckets/DisableVersioning.swift
+++ b/Sources/StorageSamples/Buckets/DisableVersioning.swift
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_disable_versioning]
+import GoogleCloudStorage
+
+public func disableVersioning(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.versioning = .init().with { versioning in
+          versioning.enabled = false
+        }
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["versioning"])
+    },
+    options: .init()
+  )
+  print("Versioning disabled for bucket \(bucketId)")
+}
+// [END storage_disable_versioning]

--- a/Sources/StorageSamples/Buckets/EnableBucketLifecycleManagement.swift
+++ b/Sources/StorageSamples/Buckets/EnableBucketLifecycleManagement.swift
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_enable_bucket_lifecycle_management]
+import GoogleCloudStorage
+
+public func enableBucketLifecycleManagement(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.lifecycle = .init().with { lifecycle in
+          lifecycle.rule = [
+            .init().with { rule in
+              rule.action = .init().with { action in
+                action.type = "Delete"
+              }
+              rule.condition = .init().with { condition in
+                condition.ageDays = 30
+              }
+            }
+          ]
+        }
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["lifecycle"])
+    },
+    options: .init()
+  )
+  print("Lifecycle management enabled for bucket \(bucketId)")
+}
+// [END storage_enable_bucket_lifecycle_management]

--- a/Sources/StorageSamples/Buckets/EnableDefaultEventBasedHold.swift
+++ b/Sources/StorageSamples/Buckets/EnableDefaultEventBasedHold.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_enable_default_event_based_hold]
+import GoogleCloudStorage
+
+public func enableDefaultEventBasedHold(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.defaultEventBasedHold = true
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["default_event_based_hold"])
+    },
+    options: .init()
+  )
+  print("Default event-based hold was enabled for \(bucketId)")
+}
+// [END storage_enable_default_event_based_hold]

--- a/Sources/StorageSamples/Buckets/EnableRequesterPays.swift
+++ b/Sources/StorageSamples/Buckets/EnableRequesterPays.swift
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_enable_requester_pays]
+import GoogleCloudStorage
+
+public func enableRequesterPays(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.billing = .init().with { billing in
+          billing.requesterPays = true
+        }
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["billing.requester_pays"])
+    },
+    options: .init()
+  )
+  print("Requester pays was enabled for \(bucketId)")
+}
+// [END storage_enable_requester_pays]

--- a/Sources/StorageSamples/Buckets/EnableVersioning.swift
+++ b/Sources/StorageSamples/Buckets/EnableVersioning.swift
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_enable_versioning]
+import GoogleCloudStorage
+
+public func enableVersioning(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.versioning = .init().with { versioning in
+          versioning.enabled = true
+        }
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["versioning"])
+    },
+    options: .init()
+  )
+  print("Versioning enabled for bucket \(bucketId)")
+}
+// [END storage_enable_versioning]

--- a/Sources/StorageSamples/Buckets/GetAutoclass.swift
+++ b/Sources/StorageSamples/Buckets/GetAutoclass.swift
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_get_autoclass]
+import GoogleCloudStorage
+
+public func getAutoclass(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  print("Autoclass for bucket \(bucketId): \(String(describing: bucket.autoclass))")
+}
+// [END storage_get_autoclass]

--- a/Sources/StorageSamples/Buckets/GetBucketClassAndLocation.swift
+++ b/Sources/StorageSamples/Buckets/GetBucketClassAndLocation.swift
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_get_bucket_class_and_location]
+import GoogleCloudStorage
+
+public func getBucketClassAndLocation(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  print(
+    "Bucket \(bucketId) has default storage class \(bucket.storageClass) and is located in \(bucket.location)"
+  )
+}
+// [END storage_get_bucket_class_and_location]

--- a/Sources/StorageSamples/Buckets/GetBucketLabels.swift
+++ b/Sources/StorageSamples/Buckets/GetBucketLabels.swift
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_get_bucket_labels]
+import GoogleCloudStorage
+
+public func getBucketLabels(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  print("Labels for bucket \(bucketId): \(bucket.labels)")
+}
+// [END storage_get_bucket_labels]

--- a/Sources/StorageSamples/Buckets/GetBucketMetadata.swift
+++ b/Sources/StorageSamples/Buckets/GetBucketMetadata.swift
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_get_bucket_metadata]
+import GoogleCloudStorage
+
+public func getBucketMetadata(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  print("Bucket \(bucketId) metadata: \(bucket)")
+}
+// [END storage_get_bucket_metadata]

--- a/Sources/StorageSamples/Buckets/GetDefaultEventBasedHold.swift
+++ b/Sources/StorageSamples/Buckets/GetDefaultEventBasedHold.swift
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_get_default_event_based_hold]
+import GoogleCloudStorage
+
+public func getDefaultEventBasedHold(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let status = bucket.defaultEventBasedHold ? "enabled" : "disabled"
+  print("The default event-based hold for bucket \"\(bucketId)\" is \(status).")
+}
+// [END storage_get_default_event_based_hold]

--- a/Sources/StorageSamples/Buckets/GetPublicAccessPrevention.swift
+++ b/Sources/StorageSamples/Buckets/GetPublicAccessPrevention.swift
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_get_public_access_prevention]
+import GoogleCloudStorage
+
+public func getPublicAccessPrevention(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  print(
+    "Public access prevention is \(bucket.iamConfig?.publicAccessPrevention ?? "unspecified") for bucket \(bucketId)"
+  )
+}
+// [END storage_get_public_access_prevention]

--- a/Sources/StorageSamples/Buckets/GetRequesterPaysStatus.swift
+++ b/Sources/StorageSamples/Buckets/GetRequesterPaysStatus.swift
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_get_requester_pays_status]
+import GoogleCloudStorage
+
+public func getRequesterPaysStatus(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  print("Bucket \(bucketId) has billing status: \(String(describing: bucket.billing))")
+}
+// [END storage_get_requester_pays_status]

--- a/Sources/StorageSamples/Buckets/GetRetentionPolicy.swift
+++ b/Sources/StorageSamples/Buckets/GetRetentionPolicy.swift
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_get_retention_policy]
+import GoogleCloudStorage
+
+public func getRetentionPolicy(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  print("Retention policy for bucket \(bucketId): \(String(describing: bucket.retentionPolicy))")
+}
+// [END storage_get_retention_policy]

--- a/Sources/StorageSamples/Buckets/GetRpo.swift
+++ b/Sources/StorageSamples/Buckets/GetRpo.swift
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_get_rpo]
+import GoogleCloudStorage
+
+public func getRpo(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  print("RPO for bucket \(bucketId) is \(bucket.rpo)")
+}
+// [END storage_get_rpo]

--- a/Sources/StorageSamples/Buckets/PrintBucketWebsiteConfiguration.swift
+++ b/Sources/StorageSamples/Buckets/PrintBucketWebsiteConfiguration.swift
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_print_bucket_website_configuration]
+import GoogleCloudStorage
+
+public func printBucketWebsiteConfiguration(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  print("Website configuration for bucket \(bucketId): \(String(describing: bucket.website))")
+}
+// [END storage_print_bucket_website_configuration]

--- a/Sources/StorageSamples/Buckets/RemoveBucketLabel.swift
+++ b/Sources/StorageSamples/Buckets/RemoveBucketLabel.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_remove_bucket_label]
+import GoogleCloudStorage
+
+public func removeBucketLabel(
+  client: StorageControlClient, bucketId: String, labelKey: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.labels.removeValue(forKey: labelKey)
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["labels"])
+    },
+    options: .init()
+  )
+  print("Successfully removed label \(labelKey) from bucket \(bucketId)")
+}
+// [END storage_remove_bucket_label]

--- a/Sources/StorageSamples/Buckets/RemoveCorsConfiguration.swift
+++ b/Sources/StorageSamples/Buckets/RemoveCorsConfiguration.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_remove_cors_configuration]
+import GoogleCloudStorage
+
+public func removeCorsConfiguration(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.cors = []
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["cors"])
+    },
+    options: .init()
+  )
+  print("Successfully removed CORS configuration for bucket \(bucketId)")
+}
+// [END storage_remove_cors_configuration]

--- a/Sources/StorageSamples/Buckets/RemoveRetentionPolicy.swift
+++ b/Sources/StorageSamples/Buckets/RemoveRetentionPolicy.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_remove_retention_policy]
+import GoogleCloudStorage
+
+public func removeRetentionPolicy(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.retentionPolicy = .init()
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["retention_policy"])
+    },
+    options: .init()
+  )
+  print("Retention policy for bucket \(bucketId) removed")
+}
+// [END storage_remove_retention_policy]

--- a/Sources/StorageSamples/Buckets/SetAutoclass.swift
+++ b/Sources/StorageSamples/Buckets/SetAutoclass.swift
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_set_autoclass]
+import GoogleCloudStorage
+
+public func setAutoclass(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let updated = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.autoclass = .init().with { autoclass in
+          autoclass.enabled = true
+        }
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["autoclass"])
+    },
+    options: .init()
+  )
+  print(
+    "Successfully updated autoclass for bucket \(bucketId): \(String(describing: updated.autoclass))"
+  )
+}
+// [END storage_set_autoclass]

--- a/Sources/StorageSamples/Buckets/SetBucketEncryptionEnforcement.swift
+++ b/Sources/StorageSamples/Buckets/SetBucketEncryptionEnforcement.swift
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_set_bucket_encryption_enforcement]
+import GoogleCloudStorage
+
+public func setBucketEncryptionEnforcement(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let updated = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.encryption = .init().with { encryption in
+          encryption.googleManagedEncryptionEnforcementConfig = .init().with { config in
+            config.restrictionMode = "FullyRestricted"
+          }
+        }
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["encryption.google_managed_encryption_enforcement_config"])
+    },
+    options: .init()
+  )
+  print(
+    "Updated encryption enforcement on bucket \(bucketId): \(String(describing: updated.encryption))"
+  )
+}
+// [END storage_set_bucket_encryption_enforcement]

--- a/Sources/StorageSamples/Buckets/SetPublicAccessPreventionEnforced.swift
+++ b/Sources/StorageSamples/Buckets/SetPublicAccessPreventionEnforced.swift
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_set_public_access_prevention_enforced]
+import GoogleCloudStorage
+
+public func setPublicAccessPreventionEnforced(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.iamConfig = .init().with { iamConfig in
+          iamConfig.publicAccessPrevention = "enforced"
+        }
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["iam_config.public_access_prevention"])
+    },
+    options: .init()
+  )
+  print("Public access prevention is enforced for bucket \(bucketId)")
+}
+// [END storage_set_public_access_prevention_enforced]

--- a/Sources/StorageSamples/Buckets/SetPublicAccessPreventionInherited.swift
+++ b/Sources/StorageSamples/Buckets/SetPublicAccessPreventionInherited.swift
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_set_public_access_prevention_inherited]
+import GoogleCloudStorage
+
+public func setPublicAccessPreventionInherited(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.iamConfig = .init().with { iamConfig in
+          iamConfig.publicAccessPrevention = "inherited"
+        }
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["iam_config.public_access_prevention"])
+    },
+    options: .init()
+  )
+  print("Public access prevention is inherited for bucket \(bucketId)")
+}
+// [END storage_set_public_access_prevention_inherited]

--- a/Sources/StorageSamples/Buckets/SetPublicAccessPreventionUnspecified.swift
+++ b/Sources/StorageSamples/Buckets/SetPublicAccessPreventionUnspecified.swift
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_set_public_access_prevention_unspecified]
+import GoogleCloudStorage
+
+public func setPublicAccessPreventionUnspecified(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.iamConfig = .init().with { iamConfig in
+          iamConfig.publicAccessPrevention = ""
+        }
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["iam_config.public_access_prevention"])
+    },
+    options: .init()
+  )
+  print("Public access prevention is unspecified for bucket \(bucketId)")
+}
+// [END storage_set_public_access_prevention_unspecified]

--- a/Sources/StorageSamples/Buckets/SetRpoAsyncTurbo.swift
+++ b/Sources/StorageSamples/Buckets/SetRpoAsyncTurbo.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_set_rpo_async_turbo]
+import GoogleCloudStorage
+
+public func setRpoAsyncTurbo(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.rpo = "ASYNC_TURBO"
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["rpo"])
+    },
+    options: .init()
+  )
+  print("Successfully updated bucket RPO to ASYNC_TURBO for bucket \(bucketId)")
+}
+// [END storage_set_rpo_async_turbo]

--- a/Sources/StorageSamples/Buckets/SetRpoDefault.swift
+++ b/Sources/StorageSamples/Buckets/SetRpoDefault.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_set_rpo_default]
+import GoogleCloudStorage
+
+public func setRpoDefault(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  let _ = try await client.updateBucket(
+    request: .init().with {
+      $0.bucket = bucket.with { bucket in
+        bucket.rpo = "DEFAULT"
+      }
+      $0.ifMetagenerationMatch = bucket.metageneration
+      $0.updateMask = .init(paths: ["rpo"])
+    },
+    options: .init()
+  )
+  print("Successfully updated bucket RPO to DEFAULT for bucket \(bucketId)")
+}
+// [END storage_set_rpo_default]

--- a/Sources/StorageSamples/Buckets/ViewLifecycleManagementConfiguration.swift
+++ b/Sources/StorageSamples/Buckets/ViewLifecycleManagementConfiguration.swift
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_view_lifecycle_management_configuration]
+import GoogleCloudStorage
+
+public func viewLifecycleManagementConfiguration(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  print("Lifecycle rules for bucket \(bucketId): \(String(describing: bucket.lifecycle))")
+}
+// [END storage_view_lifecycle_management_configuration]

--- a/Sources/StorageSamples/Buckets/ViewVersioningStatus.swift
+++ b/Sources/StorageSamples/Buckets/ViewVersioningStatus.swift
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_view_versioning_status]
+import GoogleCloudStorage
+
+public func viewVersioningStatus(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let bucket = try await client.getBucket(
+    request: .init().with {
+      $0.name = "projects/_/buckets/\(bucketId)"
+    },
+    options: .init()
+  )
+  print("Versioning for bucket \(bucketId): \(String(describing: bucket.versioning))")
+}
+// [END storage_view_versioning_status]

--- a/Sources/StorageSamples/RunBucketSamples.swift
+++ b/Sources/StorageSamples/RunBucketSamples.swift
@@ -24,6 +24,12 @@ fileprivate let bucketIdLength = 63
 fileprivate let prefix = "swift-sdk-testing-"
 fileprivate let lowerCaseAlphanumeric = "abcdefghijklmnopqrstuvwxyz0123456789"
 
+/// Cloud Storage rate limits bucket metadata updates to approximately 1 update per second per bucket.
+/// Pacing consecutive update operations on the same bucket avoids `resourceExhausted` rate limit errors.
+fileprivate func paceBucketUpdates() async throws {
+  try await Task.sleep(nanoseconds: 1_200_000_000)
+}
+
 public func runBucketSamples(
   client: StorageControlClient, projectId: String, serviceAccount: String,
   bucketNames: inout [String]
@@ -44,11 +50,23 @@ public func runBucketSamples(
   print("running createBucketClassLocation() sample")
   try await createBucketClassLocation(
     client: client, projectId: projectId, bucketId: classLocationId)
+  print("running getBucketClassAndLocation() sample")
+  try await getBucketClassAndLocation(client: client, bucketId: classLocationId)
+  print("running getBucketMetadata() sample")
+  try await getBucketMetadata(client: client, bucketId: classLocationId)
 
   let dualRegionId = randomBucketId()
   bucketNames.append("projects/_/buckets/\(dualRegionId)")
   print("running createBucketDualRegion() sample")
   try await createBucketDualRegion(client: client, projectId: projectId, bucketId: dualRegionId)
+  print("running getRpo() sample")
+  try await getRpo(client: client, bucketId: dualRegionId)
+  print("running setRpoDefault() sample")
+  try await setRpoDefault(client: client, bucketId: dualRegionId)
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running setRpoAsyncTurbo() sample")
+  try await setRpoAsyncTurbo(client: client, bucketId: dualRegionId)
 
   let turboReplicationId = randomBucketId()
   bucketNames.append("projects/_/buckets/\(turboReplicationId)")
@@ -67,12 +85,183 @@ public func runBucketSamples(
   print("running createBucketWithEncryptionEnforcement() sample")
   try await createBucketWithEncryptionEnforcement(
     client: client, projectId: projectId, bucketId: encryptionEnforcementId)
+  print("running setBucketEncryptionEnforcement() sample")
+  try await setBucketEncryptionEnforcement(
+    client: client, bucketId: encryptionEnforcementId)
 
   let objectRetentionId = randomBucketId()
   bucketNames.append("projects/_/buckets/\(objectRetentionId)")
   print("running createBucketWithObjectRetention() sample")
   try await createBucketWithObjectRetention(
     client: client, projectId: projectId, bucketId: objectRetentionId)
+
+  let labelBucketId = randomBucketId()
+  bucketNames.append("projects/_/buckets/\(labelBucketId)")
+  print("creating bucket for label samples")
+  let _ = try await client.createBucket(
+    request: .init().with {
+      $0.parent = "projects/_"
+      $0.bucketId = labelBucketId
+      $0.bucket = .init().with { bucket in
+        bucket.project = "projects/\(projectId)"
+      }
+    },
+    options: .init()
+  )
+  print("running changeDefaultStorageClass() sample")
+  try await changeDefaultStorageClass(
+    client: client, bucketId: labelBucketId, storageClass: "NEARLINE")
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running addBucketLabel() sample")
+  try await addBucketLabel(
+    client: client, bucketId: labelBucketId, labelKey: "test-label", labelValue: "test-value")
+  print("running getBucketLabels() sample")
+  try await getBucketLabels(client: client, bucketId: labelBucketId)
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running removeBucketLabel() sample")
+  try await removeBucketLabel(
+    client: client, bucketId: labelBucketId, labelKey: "test-label")
+
+  let holdPapBucketId = randomBucketId()
+  bucketNames.append("projects/_/buckets/\(holdPapBucketId)")
+  print("creating bucket for hold and pap samples")
+  let _ = try await client.createBucket(
+    request: .init().with {
+      $0.parent = "projects/_"
+      $0.bucketId = holdPapBucketId
+      $0.bucket = .init().with { bucket in
+        bucket.project = "projects/\(projectId)"
+      }
+    },
+    options: .init()
+  )
+  print("running getDefaultEventBasedHold() sample")
+  try await getDefaultEventBasedHold(client: client, bucketId: holdPapBucketId)
+  print("running enableDefaultEventBasedHold() sample")
+  try await enableDefaultEventBasedHold(client: client, bucketId: holdPapBucketId)
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running disableDefaultEventBasedHold() sample")
+  try await disableDefaultEventBasedHold(client: client, bucketId: holdPapBucketId)
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running setPublicAccessPreventionUnspecified() sample")
+  try await setPublicAccessPreventionUnspecified(client: client, bucketId: holdPapBucketId)
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running setPublicAccessPreventionInherited() sample")
+  try await setPublicAccessPreventionInherited(client: client, bucketId: holdPapBucketId)
+  print("running getPublicAccessPrevention() sample")
+  try await getPublicAccessPrevention(client: client, bucketId: holdPapBucketId)
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running setPublicAccessPreventionEnforced() sample")
+  try await setPublicAccessPreventionEnforced(client: client, bucketId: holdPapBucketId)
+
+  let lifecycleBucketId = randomBucketId()
+  bucketNames.append("projects/_/buckets/\(lifecycleBucketId)")
+  print("creating bucket for versioning and lifecycle samples")
+  let _ = try await client.createBucket(
+    request: .init().with {
+      $0.parent = "projects/_"
+      $0.bucketId = lifecycleBucketId
+      $0.bucket = .init().with { bucket in
+        bucket.project = "projects/\(projectId)"
+      }
+    },
+    options: .init()
+  )
+  print("running viewVersioningStatus() sample")
+  try await viewVersioningStatus(client: client, bucketId: lifecycleBucketId)
+  print("running enableVersioning() sample")
+  try await enableVersioning(client: client, bucketId: lifecycleBucketId)
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running disableVersioning() sample")
+  try await disableVersioning(client: client, bucketId: lifecycleBucketId)
+  print("running viewLifecycleManagementConfiguration() sample")
+  try await viewLifecycleManagementConfiguration(client: client, bucketId: lifecycleBucketId)
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running enableBucketLifecycleManagement() sample")
+  try await enableBucketLifecycleManagement(client: client, bucketId: lifecycleBucketId)
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running addLifecycleRule() sample")
+  try await addLifecycleRule(client: client, bucketId: lifecycleBucketId)
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running disableBucketLifecycleManagement() sample")
+  try await disableBucketLifecycleManagement(client: client, bucketId: lifecycleBucketId)
+
+  let websiteCorsBucketId = randomBucketId()
+  bucketNames.append("projects/_/buckets/\(websiteCorsBucketId)")
+  print("creating bucket for website and cors samples")
+  let _ = try await client.createBucket(
+    request: .init().with {
+      $0.parent = "projects/_"
+      $0.bucketId = websiteCorsBucketId
+      $0.bucket = .init().with { bucket in
+        bucket.project = "projects/\(projectId)"
+      }
+    },
+    options: .init()
+  )
+  print("running printBucketWebsiteConfiguration() sample")
+  try await printBucketWebsiteConfiguration(client: client, bucketId: websiteCorsBucketId)
+  print("running defineBucketWebsiteConfiguration() sample")
+  try await defineBucketWebsiteConfiguration(
+    client: client, bucketId: websiteCorsBucketId, mainPageSuffix: "index.html",
+    notFoundPage: "404.html")
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running corsConfiguration() sample")
+  try await corsConfiguration(
+    client: client, bucketId: websiteCorsBucketId, maxAgeSeconds: 3600,
+    method: ["GET", "HEAD"], origin: ["http://example.com"],
+    responseHeader: ["Content-Type"])
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running removeCorsConfiguration() sample")
+  try await removeCorsConfiguration(client: client, bucketId: websiteCorsBucketId)
+  print("running getRetentionPolicy() sample")
+  try await getRetentionPolicy(client: client, bucketId: websiteCorsBucketId)
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running removeRetentionPolicy() sample")
+  try await removeRetentionPolicy(client: client, bucketId: websiteCorsBucketId)
+
+  let autoclassBucketId = randomBucketId()
+  bucketNames.append("projects/_/buckets/\(autoclassBucketId)")
+  print("creating bucket for autoclass and requester pays samples")
+  let _ = try await client.createBucket(
+    request: .init().with {
+      $0.parent = "projects/_"
+      $0.bucketId = autoclassBucketId
+      $0.bucket = .init().with { bucket in
+        bucket.project = "projects/\(projectId)"
+      }
+    },
+    options: .init()
+  )
+  print("running setAutoclass() sample")
+  try await setAutoclass(client: client, bucketId: autoclassBucketId)
+  print("running getAutoclass() sample")
+  try await getAutoclass(client: client, bucketId: autoclassBucketId)
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running enableRequesterPays() sample")
+  try await enableRequesterPays(client: client, bucketId: autoclassBucketId)
+  print("running getRequesterPaysStatus() sample")
+  try await getRequesterPaysStatus(client: client, bucketId: autoclassBucketId)
+  // Pause to respect Cloud Storage rate limits (roughly 1 update per second per bucket).
+  try await paceBucketUpdates()
+  print("running disableRequesterPays() sample")
+  try await disableRequesterPays(client: client, bucketId: autoclassBucketId)
+  print("running getRequesterPaysStatus() sample")
+  try await getRequesterPaysStatus(client: client, bucketId: autoclassBucketId)
 
   let ublaBucketId = randomBucketId()
   bucketNames.append("projects/_/buckets/\(ublaBucketId)")


### PR DESCRIPTION
Implement Cloud Storage bucket metadata samples corresponding to issues:
- Fixes #656: storage_add_bucket_label
- Fixes #657: storage_change_default_storage_class
- Fixes #658: storage_cors_configuration
- Fixes #659: storage_define_bucket_website_configuration
- Fixes #660: storage_disable_bucket_lifecycle_management
- Fixes #661: storage_disable_default_event_based_hold
- Fixes #662: storage_disable_versioning
- Fixes #663: storage_enable_bucket_lifecycle_management
- Fixes #664: storage_enable_default_event_based_hold
- Fixes #665: storage_enable_requester_pays
- Fixes #666: storage_enable_versioning
- Fixes #667: storage_get_autoclass
- Fixes #668: storage_get_bucket_class_and_location
- Fixes #669: storage_get_bucket_labels
- Fixes #670: storage_get_bucket_metadata
- Fixes #671: storage_get_public_access_prevention
- Fixes #672: storage_get_rpo
- Fixes #673: storage_get_default_event_based_hold
- Fixes #674: storage_get_public_access_prevention
- Fixes #675: storage_get_requester_pays_status
- Fixes #676: storage_get_retention_policy
- Fixes #677: storage_print_bucket_website_configuration
- Fixes #678: storage_remove_bucket_label
- Fixes #679: storage_remove_cors_configuration
- Fixes #680: storage_remove_retention_policy
- Fixes #681: storage_set_autoclass
- Fixes #682: storage_set_bucket_encryption_enforcement
- Fixes #683: storage_add_lifecycle_rule
- Fixes #684: storage_set_public_access_prevention_enforced
- Fixes #685: storage_set_public_access_prevention_inherited
- Fixes #686: storage_set_public_access_prevention_unspecified
- Fixes #687: storage_set_rpo_async_turbo
- Fixes #688: storage_set_rpo_default
- Fixes #689: storage_view_lifecycle_management_configuration
- Fixes #690: storage_view_versioning_status
- Fixes #693: storage_disable_requester_pays

Also wire all 35 samples into RunBucketSamples.swift with pacing sleeps to respect Cloud Storage's 1-update/second per bucket rate limits, and validate with integration tests.