### PR TITLE
docs(storage): add object metadata samples

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -163,6 +163,7 @@ let package = Package(
         .product(name: "GoogleCloudStorage", package: "swift-google-cloud-storage"),
         .product(name: "GoogleCloudAuth", package: "swift-google-auth"),
         .product(name: "GoogleCloudGax", package: "swift-google-gax"),
+        .product(name: "GoogleCloudWKT", package: "swift-google-wkt"),
         .product(name: "Logging", package: "swift-log"),
         .product(name: "GoogleIAMV1", package: "swift-google-iam-v1"),
         .product(name: "GoogleType", package: "swift-google-type"),

--- a/Sources/StorageSamples/Objects/AddFileOwner.swift
+++ b/Sources/StorageSamples/Objects/AddFileOwner.swift
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_add_file_owner]
+import GoogleCloudStorage
+
+public func addFileOwner(
+  client: StorageControlClient, bucketId: String, user: String
+) async throws {
+  let objectName = "object-to-update"
+  let object = try await client.getObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+      $0.readMask = .init(paths: ["*"])
+    },
+    options: .init()
+  )
+  let want = "user-\(user)"
+  var acl = object.acl
+  if let index = acl.firstIndex(where: { $0.entity == want }) {
+    acl[index].role = "OWNER"
+  } else {
+    acl.append(
+      ObjectAccessControl().with { entry in
+        entry.entity = want
+        entry.role = "OWNER"
+      }
+    )
+  }
+  let updated = try await client.updateObject(
+    request: .init().with {
+      $0.object = object.with { obj in
+        obj.acl = acl
+      }
+      $0.ifMetagenerationMatch = object.metageneration
+      $0.updateMask = .init(paths: ["acl"])
+    },
+    options: .init()
+  )
+  print("successfully updated object \(objectName) in bucket \(bucketId): \(updated)")
+}
+// [END storage_add_file_owner]

--- a/Sources/StorageSamples/Objects/ChangeFileStorageClass.swift
+++ b/Sources/StorageSamples/Objects/ChangeFileStorageClass.swift
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_change_file_storage_class]
+import GoogleCloudStorage
+
+public func changeFileStorageClass(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objectName = "update-storage-class"
+  var token = ""
+  var response: RewriteResponse
+  repeat {
+    response = try await client.rewriteObject(
+      request: .init().with {
+        $0.sourceBucket = "projects/_/buckets/\(bucketId)"
+        $0.sourceObject = objectName
+        $0.destinationBucket = "projects/_/buckets/\(bucketId)"
+        $0.destinationName = objectName
+        // For other valid storage classes, refer to the documentation:
+        // https://cloud.google.com/storage/docs/storage-classes
+        $0.destination = .init().with { dest in
+          dest.storageClass = "NEARLINE"
+        }
+        if !token.isEmpty {
+          $0.rewriteToken = token
+        }
+      },
+      options: .init()
+    )
+    token = response.rewriteToken
+  } while !response.done
+
+  print(
+    "successfully updated storage class for object \(objectName) in bucket \(bucketId): \(response)"
+  )
+}
+// [END storage_change_file_storage_class]

--- a/Sources/StorageSamples/Objects/GetMetadata.swift
+++ b/Sources/StorageSamples/Objects/GetMetadata.swift
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_get_metadata]
+import GoogleCloudStorage
+
+public func getMetadata(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objectName = "object-to-read"
+  let object = try await client.getObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+    },
+    options: .init()
+  )
+
+  let objectMetadata = object.metadata
+  print(
+    "successfully retrieved object \(objectName) metadata in bucket \(bucketId): \(objectMetadata)"
+  )
+}
+// [END storage_get_metadata]

--- a/Sources/StorageSamples/Objects/GetObjectContexts.swift
+++ b/Sources/StorageSamples/Objects/GetObjectContexts.swift
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_get_object_contexts]
+import GoogleCloudStorage
+
+public func getObjectContexts(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objectName = "object-with-contexts"
+  let object = try await client.getObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+    },
+    options: .init()
+  )
+  print(
+    "The contexts field for object \(objectName) in bucket \(bucketId) is: \(String(describing: object.contexts))"
+  )
+}
+// [END storage_get_object_contexts]

--- a/Sources/StorageSamples/Objects/PrintFileAcl.swift
+++ b/Sources/StorageSamples/Objects/PrintFileAcl.swift
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_print_file_acl]
+import GoogleCloudStorage
+
+public func printFileAcl(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objectName = "object-to-read"
+  let object = try await client.getObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+      $0.readMask = .init(paths: ["*"])
+    },
+    options: .init()
+  )
+
+  print("Object \(objectName) in bucket \(bucketId) has the following ACL: \(object.acl)")
+}
+// [END storage_print_file_acl]

--- a/Sources/StorageSamples/Objects/PrintFileAclForUser.swift
+++ b/Sources/StorageSamples/Objects/PrintFileAclForUser.swift
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_print_file_acl_for_user]
+import GoogleCloudStorage
+
+public func printFileAclForUser(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objectName = "object-to-read"
+  let object = try await client.getObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+      $0.readMask = .init(paths: ["*"])
+    },
+    options: .init()
+  )
+
+  // For other scopes see: https://cloud.google.com/storage/docs/access-control/lists#scopes
+  let user = "allAuthenticatedUsers"
+  if let acl = object.acl.first(where: { $0.entity == user }) {
+    print(
+      "Object \(objectName) in bucket \(bucketId) has the following ACL for user \(user): \(acl)"
+    )
+  } else {
+    print("Object \(objectName) in bucket \(bucketId) has no ACL entry for user \(user)")
+  }
+}
+// [END storage_print_file_acl_for_user]

--- a/Sources/StorageSamples/Objects/ReleaseEventBasedHold.swift
+++ b/Sources/StorageSamples/Objects/ReleaseEventBasedHold.swift
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_release_event_based_hold]
+import GoogleCloudStorage
+
+public func releaseEventBasedHold(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objectName = "object-to-update"
+  let object = try await client.getObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+    },
+    options: .init()
+  )
+
+  let updated = try await client.updateObject(
+    request: .init().with {
+      $0.object = object.with { obj in
+        obj.eventBasedHold = false
+      }
+      $0.ifMetagenerationMatch = object.metageneration
+      $0.updateMask = .init(paths: ["event_based_hold"])
+    },
+    options: .init()
+  )
+  print(
+    "successfully released event_based hold on object \(objectName) in bucket \(bucketId): \(updated)"
+  )
+}
+// [END storage_release_event_based_hold]

--- a/Sources/StorageSamples/Objects/ReleaseTemporaryHold.swift
+++ b/Sources/StorageSamples/Objects/ReleaseTemporaryHold.swift
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_release_temporary_hold]
+import GoogleCloudStorage
+
+public func releaseTemporaryHold(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objectName = "object-to-update"
+  let object = try await client.getObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+    },
+    options: .init()
+  )
+
+  let updated = try await client.updateObject(
+    request: .init().with {
+      $0.object = object.with { obj in
+        obj.temporaryHold = false
+      }
+      $0.ifMetagenerationMatch = object.metageneration
+      $0.updateMask = .init(paths: ["temporary_hold"])
+    },
+    options: .init()
+  )
+  print(
+    "successfully released temporary hold on object \(objectName) in bucket \(bucketId): \(updated)"
+  )
+}
+// [END storage_release_temporary_hold]

--- a/Sources/StorageSamples/Objects/RemoveFileOwner.swift
+++ b/Sources/StorageSamples/Objects/RemoveFileOwner.swift
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_remove_file_owner]
+import GoogleCloudStorage
+
+public func removeFileOwner(
+  client: StorageControlClient, bucketId: String, user: String
+) async throws {
+  let objectName = "object-to-update"
+  let object = try await client.getObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+      $0.readMask = .init(paths: ["*"])
+    },
+    options: .init()
+  )
+
+  let want = "user-\(user)"
+  var acl = object.acl
+  guard let index = acl.firstIndex(where: { $0.entity == want }) else {
+    print("entry for \(want) not found, nothing to update")
+    return
+  }
+  acl.remove(at: index)
+
+  let updated = try await client.updateObject(
+    request: .init().with {
+      $0.object = object.with { obj in
+        obj.acl = acl
+      }
+      $0.ifMetagenerationMatch = object.metageneration
+      $0.updateMask = .init(paths: ["acl"])
+    },
+    options: .init()
+  )
+  print("successfully updated object \(objectName) in bucket \(bucketId): \(updated)")
+}
+// [END storage_remove_file_owner]

--- a/Sources/StorageSamples/Objects/SetEventBasedHold.swift
+++ b/Sources/StorageSamples/Objects/SetEventBasedHold.swift
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_set_event_based_hold]
+import GoogleCloudStorage
+
+public func setEventBasedHold(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objectName = "object-to-update"
+  let object = try await client.getObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+    },
+    options: .init()
+  )
+
+  let updated = try await client.updateObject(
+    request: .init().with {
+      $0.object = object.with { obj in
+        obj.eventBasedHold = true
+      }
+      $0.ifMetagenerationMatch = object.metageneration
+      $0.updateMask = .init(paths: ["event_based_hold"])
+    },
+    options: .init()
+  )
+  print(
+    "successfully set event_based hold on object \(objectName) in bucket \(bucketId): \(updated)"
+  )
+}
+// [END storage_set_event_based_hold]

--- a/Sources/StorageSamples/Objects/SetMetadata.swift
+++ b/Sources/StorageSamples/Objects/SetMetadata.swift
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_set_metadata]
+import GoogleCloudStorage
+
+public func setMetadata(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objectName = "object-to-update"
+  let object = try await client.getObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+    },
+    options: .init()
+  )
+
+  var metadata = object.metadata
+  metadata["updated"] = "true"
+
+  let updated = try await client.updateObject(
+    request: .init().with {
+      $0.object = object.with { obj in
+        obj.metadata = metadata
+      }
+      $0.ifMetagenerationMatch = object.metageneration
+      $0.updateMask = .init(paths: ["metadata"])
+    },
+    options: .init()
+  )
+  print("successfully updated object \(objectName) in bucket \(bucketId): \(updated)")
+}
+// [END storage_set_metadata]

--- a/Sources/StorageSamples/Objects/SetObjectContexts.swift
+++ b/Sources/StorageSamples/Objects/SetObjectContexts.swift
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_set_object_contexts]
+import GoogleCloudStorage
+
+public func setObjectContexts(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objectName = "object-with-contexts"
+  let object = try await client.getObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+    },
+    options: .init()
+  )
+
+  var custom = object.contexts?.custom ?? [:]
+  custom["example"] = ObjectCustomContextPayload().with { payload in
+    payload.value = "true"
+  }
+
+  let updated = try await client.updateObject(
+    request: .init().with {
+      $0.object = object.with { obj in
+        obj.contexts = ObjectContexts().with { contexts in
+          contexts.custom = custom
+        }
+      }
+      $0.ifMetagenerationMatch = object.metageneration
+      $0.updateMask = .init(paths: ["contexts.custom.example"])
+    },
+    options: .init()
+  )
+  print(
+    "successfully set contexts for object \(objectName) in bucket \(bucketId): \(String(describing: updated.contexts))"
+  )
+}
+// [END storage_set_object_contexts]

--- a/Sources/StorageSamples/Objects/SetObjectRetentionPolicy.swift
+++ b/Sources/StorageSamples/Objects/SetObjectRetentionPolicy.swift
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_set_object_retention_policy]
+import Foundation
+import GoogleCloudStorage
+import GoogleCloudWKT
+
+public func setObjectRetentionPolicy(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objectName = "object-to-update"
+  let object = try await client.getObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+    },
+    options: .init()
+  )
+
+  let retainUntilTime = try GoogleCloudWKT.Timestamp(
+    seconds: Int64(Date().timeIntervalSince1970) + 24 * 60 * 60,
+    nanos: 0
+  )
+
+  let updated = try await client.updateObject(
+    request: .init().with {
+      $0.object = object.with { obj in
+        obj.retention = Object.Retention().with { retention in
+          retention.mode = .unlocked
+          retention.retainUntilTime = retainUntilTime
+        }
+      }
+      $0.overrideUnlockedRetention = true
+      $0.ifMetagenerationMatch = object.metageneration
+      $0.updateMask = .init(paths: ["retention"])
+    },
+    options: .init()
+  )
+  print("successfully set retention for object \(objectName) in bucket \(bucketId): \(updated)")
+}
+// [END storage_set_object_retention_policy]

--- a/Sources/StorageSamples/Objects/SetTemporaryHold.swift
+++ b/Sources/StorageSamples/Objects/SetTemporaryHold.swift
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_set_temporary_hold]
+import GoogleCloudStorage
+
+public func setTemporaryHold(
+  client: StorageControlClient, bucketId: String
+) async throws {
+  let objectName = "object-to-update"
+  let object = try await client.getObject(
+    request: .init().with {
+      $0.bucket = "projects/_/buckets/\(bucketId)"
+      $0.object = objectName
+    },
+    options: .init()
+  )
+
+  let updated = try await client.updateObject(
+    request: .init().with {
+      $0.object = object.with { obj in
+        obj.temporaryHold = true
+      }
+      $0.ifMetagenerationMatch = object.metageneration
+      $0.updateMask = .init(paths: ["temporary_hold"])
+    },
+    options: .init()
+  )
+  print(
+    "successfully set temporary hold on object \(objectName) in bucket \(bucketId): \(updated)"
+  )
+}
+// [END storage_set_temporary_hold]

--- a/Sources/StorageSamples/RunObjectSamples.swift
+++ b/Sources/StorageSamples/RunObjectSamples.swift
@@ -15,9 +15,15 @@
 import Foundation
 import GoogleCloudStorage
 
+/// Cloud Storage rate limits object metadata updates to approximately 1 update per second per object.
+/// Pacing consecutive update operations on the same object avoids `resourceExhausted` rate limit errors.
+fileprivate func paceObjectUpdates() async throws {
+  try await Task.sleep(nanoseconds: 1_200_000_000)
+}
+
 public func runObjectSamples(
   controlClient: StorageControlClient, dataClient: StorageClient, projectId: String,
-  bucketNames: inout [String]
+  serviceAccount: String, bucketNames: inout [String]
 ) async throws {
   let id = randomBucketId()
   let name = "projects/_/buckets/\(id)"
@@ -44,6 +50,10 @@ public func runObjectSamples(
   _ = try await dataClient.upload(sampleData, to: id, as: "prefixes/are-not-always/folders-003")
   _ = try await dataClient.upload(sampleData, to: id, as: "uploaded-file.txt")
   _ = try await dataClient.upload(sampleData, to: id, as: "deleted-object-name")
+  _ = try await dataClient.upload(sampleData, to: id, as: "object-to-read")
+  _ = try await dataClient.upload(sampleData, to: id, as: "object-to-update")
+  _ = try await dataClient.upload(sampleData, to: id, as: "update-storage-class")
+  _ = try await dataClient.upload(sampleData, to: id, as: "object-with-contexts")
 
   let tempFilePath = FileManager.default.temporaryDirectory.appendingPathComponent(
     "downloaded-file-\(UUID().uuidString).txt"
@@ -65,4 +75,77 @@ public func runObjectSamples(
   try await listFilesWithPrefix(client: controlClient, bucketId: id)
   print("running deleteFile() sample")
   try await deleteFile(client: controlClient, bucketId: id)
+
+  print("running setMetadata() sample")
+  try await setMetadata(client: controlClient, bucketId: id)
+  print("running getMetadata() sample")
+  try await getMetadata(client: controlClient, bucketId: id)
+
+  print("running printFileAcl() sample")
+  try await printFileAcl(client: controlClient, bucketId: id)
+  print("running printFileAclForUser() sample")
+  try await printFileAclForUser(client: controlClient, bucketId: id)
+
+  print("running setEventBasedHold() sample")
+  try await paceObjectUpdates()
+  try await setEventBasedHold(client: controlClient, bucketId: id)
+  print("running releaseEventBasedHold() sample")
+  try await paceObjectUpdates()
+  try await releaseEventBasedHold(client: controlClient, bucketId: id)
+
+  print("running setTemporaryHold() sample")
+  try await paceObjectUpdates()
+  try await setTemporaryHold(client: controlClient, bucketId: id)
+  print("running releaseTemporaryHold() sample")
+  try await paceObjectUpdates()
+  try await releaseTemporaryHold(client: controlClient, bucketId: id)
+
+  print("running changeFileStorageClass() sample")
+  try await changeFileStorageClass(client: controlClient, bucketId: id)
+
+  print("running setObjectContexts() sample")
+  try await setObjectContexts(client: controlClient, bucketId: id)
+  print("running getObjectContexts() sample")
+  try await getObjectContexts(client: controlClient, bucketId: id)
+
+  // Create a separate bucket with ACLs enabled and object retention enabled for ACL and retention samples
+  let retentionAclBucketId = randomBucketId()
+  let retentionAclBucketName = "projects/_/buckets/\(retentionAclBucketId)"
+  bucketNames.append(retentionAclBucketName)
+
+  print("creating bucket with ACLs and object retention enabled")
+  let _ = try await controlClient.createBucket(
+    request: .init().with {
+      $0.parent = "projects/_"
+      $0.bucketId = retentionAclBucketId
+      $0.bucket = .init().with { bucket in
+        bucket.project = "projects/\(projectId)"
+        bucket.iamConfig = .init().with { iamConfig in
+          iamConfig.uniformBucketLevelAccess = .init().with { ubla in
+            ubla.enabled = false
+          }
+        }
+        bucket.objectRetention = .init().with { objRetention in
+          objRetention.enabled = true
+        }
+      }
+    },
+    options: .init()
+  )
+
+  _ = try await dataClient.upload(
+    sampleData, to: retentionAclBucketId, as: "object-to-update")
+
+  print("running addFileOwner() sample")
+  try await addFileOwner(
+    client: controlClient, bucketId: retentionAclBucketId, user: serviceAccount)
+  print("running removeFileOwner() sample")
+  try await paceObjectUpdates()
+  try await removeFileOwner(
+    client: controlClient, bucketId: retentionAclBucketId, user: serviceAccount)
+
+  print("running setObjectRetentionPolicy() sample")
+  try await paceObjectUpdates()
+  try await setObjectRetentionPolicy(
+    client: controlClient, bucketId: retentionAclBucketId)
 }

--- a/Tests/StorageSamplesDriver/Driver.swift
+++ b/Tests/StorageSamplesDriver/Driver.swift
@@ -44,13 +44,16 @@ import Testing
 
   @Test(.enabled(if: Self.enabled())) func runObjectSamples() async throws {
     let projectId = ProcessInfo.processInfo.environment["GOOGLE_CLOUD_PROJECT"]!
+    let serviceAccount =
+      ProcessInfo.processInfo.environment["GOOGLE_CLOUD_SWIFT_TEST_SERVICE_ACCOUNT"]
+      ?? "swift-sdk-test@\(projectId).iam.gserviceaccount.com"
     let controlClient = try Self.makeClient()
     let dataClient = try Self.makeDataClient()
     var bucketNames: [String] = []
     do {
       try await StorageSamples.runObjectSamples(
         controlClient: controlClient, dataClient: dataClient, projectId: projectId,
-        bucketNames: &bucketNames)
+        serviceAccount: serviceAccount, bucketNames: &bucketNames)
       await StorageSamples.cleanupTestBuckets(client: controlClient, bucketNames: bucketNames)
     } catch {
       await StorageSamples.cleanupTestBuckets(client: controlClient, bucketNames: bucketNames)


### PR DESCRIPTION
Implement samples for issues #706 through #719:
- storage_add_file_owner (fixes #706)
- storage_change_file_storage_class (fixes #707)
- storage_get_metadata (fixes #708)
- storage_get_object_contexts (fixes #709)
- storage_print_file_acl (fixes #710)
- storage_print_file_acl_for_user (fixes #711)
- storage_release_event_based_hold (fixes #712)
- storage_release_temporary_hold (fixes #713)
- storage_remove_file_owner (fixes #714)
- storage_set_event_based_hold (fixes #715)
- storage_set_metadata (fixes #716)
- storage_set_object_contexts (fixes #717)
- storage_set_object_retention_policy (fixes #718)
- storage_set_temporary_hold (fixes #719)

Add pacing sleeps between consecutive object mutations to avoid Cloud Storage rate limits.