### PR TITLE
fix(gax): continue pagination on empty intermediate pages

### DIFF
--- a/packages/swift-google-gax/Sources/GoogleCloudGax/Pagination.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/Pagination.swift
@@ -51,28 +51,18 @@ public final class PaginatedResponseSequence<Item, ResponseType: _PaginatedRespo
     }
 
     public func next() async throws -> Item? {
-      // 1. If we have cached items, serve them first.
-      if !buffer.isEmpty {
-        return buffer.removeFirst()
+      // Continue fetching pages until we have items to return or there are no more pages.
+      // According to AIP-158, intermediate pages may be empty while still returning a next page token.
+      while buffer.isEmpty && !hasReachedEnd {
+        let response = try await listRpc(nextToken)
+        buffer = response._getPaginatedItems()
+        nextToken = response._nextPageToken()
+        if nextToken.isEmpty {
+          hasReachedEnd = true
+        }
       }
 
-      // 2. Stop if we've previously determined there's no more data.
-      guard !hasReachedEnd else { return nil }
-
-      // 3. Fetch the next page using the page token from the previous response.
-      let response = try await listRpc(nextToken)
-      buffer = response._getPaginatedItems()
-
-      // 4. Update the token. If there is no next token, remember that we
-      // don't need to fetch any more pages.
-      nextToken = response._nextPageToken()
-      if nextToken.isEmpty {
-        hasReachedEnd = true
-      }
-
-      // 5. If the fetch returned nothing, we are done.
-      if buffer.isEmpty {
-        hasReachedEnd = true
+      guard !buffer.isEmpty else {
         return nil
       }
 

--- a/packages/swift-google-gax/Tests/AggregatedPaginationTests.swift
+++ b/packages/swift-google-gax/Tests/AggregatedPaginationTests.swift
@@ -107,6 +107,27 @@ import GoogleCloudGax
       ])
   }
 
+  @Test func emptyIntermediatePageAggregatedList() async throws {
+    let service = Service([
+      Response(
+        items: [
+          "group1": Item(name: "item1")
+        ], nextPageToken: "p1"),
+      Response(
+        items: [:], nextPageToken: "p2"),
+      Response(
+        items: [
+          "group2": Item(name: "item2")
+        ], nextPageToken: nil),
+    ])
+    let got = try await aggregateAll(service)
+    #expect(
+      got == [
+        "group1": Item(name: "item1"),
+        "group2": Item(name: "item2"),
+      ])
+  }
+
   func aggregateAll(_ service: Service) async throws -> [String: Item] {
     var result: [String: Item] = [:]
     for try await (group, item) in service.aggregatedListItems(

--- a/packages/swift-google-gax/Tests/PaginationTests.swift
+++ b/packages/swift-google-gax/Tests/PaginationTests.swift
@@ -115,4 +115,71 @@ import Testing
     }
     #expect(array.isEmpty)
   }
+
+  @Test func emptyIntermediatePage() async throws {
+    let service = PaginatedService(
+      mockResponses: [
+        ListItemsResponse(items: [Item(name: "item1"), Item(name: "item2")], nextPageToken: "abc"),
+        ListItemsResponse(items: [], nextPageToken: "def"),
+        ListItemsResponse(items: [Item(name: "item3"), Item(name: "item4")], nextPageToken: ""),
+      ])
+    var array: [Item] = []
+    for try await item in service.listItems(
+      byItem: .init()
+    ) {
+      array.append(item)
+    }
+    #expect(
+      array == [
+        Item(name: "item1"), Item(name: "item2"), Item(name: "item3"), Item(name: "item4"),
+      ])
+  }
+
+  @Test func emptyInitialPage() async throws {
+    let service = PaginatedService(
+      mockResponses: [
+        ListItemsResponse(items: [], nextPageToken: "abc"),
+        ListItemsResponse(items: [Item(name: "item1"), Item(name: "item2")], nextPageToken: ""),
+      ])
+    var array: [Item] = []
+    for try await item in service.listItems(
+      byItem: .init()
+    ) {
+      array.append(item)
+    }
+    #expect(array == [Item(name: "item1"), Item(name: "item2")])
+  }
+
+  @Test func multipleConsecutiveEmptyPages() async throws {
+    let service = PaginatedService(
+      mockResponses: [
+        ListItemsResponse(items: [Item(name: "item1")], nextPageToken: "p1"),
+        ListItemsResponse(items: [], nextPageToken: "p2"),
+        ListItemsResponse(items: [], nextPageToken: "p3"),
+        ListItemsResponse(items: [Item(name: "item2")], nextPageToken: ""),
+      ])
+    var array: [Item] = []
+    for try await item in service.listItems(
+      byItem: .init()
+    ) {
+      array.append(item)
+    }
+    #expect(array == [Item(name: "item1"), Item(name: "item2")])
+  }
+
+  @Test func emptyPagesEndingInEmptyPage() async throws {
+    let service = PaginatedService(
+      mockResponses: [
+        ListItemsResponse(items: [], nextPageToken: "p1"),
+        ListItemsResponse(items: [], nextPageToken: "p2"),
+        ListItemsResponse(items: [], nextPageToken: ""),
+      ])
+    var array: [Item] = []
+    for try await item in service.listItems(
+      byItem: .init()
+    ) {
+      array.append(item)
+    }
+    #expect(array.isEmpty)
+  }
 }


### PR DESCRIPTION
This PR fixes #723.

According to [AIP-158](https://google.aip.dev/158), an API response may yield 0 items while returning a non-empty `next_page_token` (for example, when server-side filtering, partition scanning, or permissions skip items on the server). Previously, `PaginatedResponseSequence._ItemIterator.next()` terminated immediately when `buffer.isEmpty`, prematurely ending pagination.

The initial commit in this PR adds tests reproducing the failure. The follow-up commit applies the fix to continue fetching subsequent pages while the buffer is empty and more pages are available.