### PR TITLE
docs(gax): fix `ContinueOnIO` comments

### DIFF
--- a/packages/swift-google-gax/Sources/GoogleCloudGax/ContinueOnIO+PollingErrorPolicy.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/ContinueOnIO+PollingErrorPolicy.swift
@@ -28,8 +28,8 @@ extension ContinueOnIO: PollingErrorPolicy where P: PollingErrorPolicy & Sendabl
 extension PollingErrorPolicy {
   /// Decorate a ``PollingErrorPolicy`` to continue on I/O errors.
   ///
-  /// This policy decorates an inner policy and retries any errors that are I/O errors
-  /// **if** the request is idempotent.
+  /// This policy decorates an inner policy. It continues polling if the polling request failed with
+  /// an I/O error, otherwise it delegates to the inner policy.
   ///
   /// For other errors it returns the same value as the inner policy.
   public func continueOnIoErrors() -> ContinueOnIO<Self> {

--- a/packages/swift-google-gax/Sources/GoogleCloudGax/ContinueOnIO+RetryPolicy.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/ContinueOnIO+RetryPolicy.swift
@@ -32,8 +32,8 @@ extension ContinueOnIO: RetryPolicy where P: RetryPolicy & Sendable {
 extension RetryPolicy {
   /// Decorate a `RetryPolicy` to continue on I/O errors.
   ///
-  /// This policy decorates an inner policy and retries any errors that are I/O errors
-  /// **if** the request is idempotent.
+  /// This policy decorates an inner policy and retries any errors that are I/O errors. Typically
+  /// this decorator is combined with ``StrictIdempotency`` to only retry idempotent requests.
   ///
   /// For other errors it returns the same value as the inner policy.
   public func retryOnIO() -> ContinueOnIO<Self> {


### PR DESCRIPTION
The documentation created the impression that this handled idempotency too.

Fixes #722 