### PR TITLE
fix(storage): properly rewind seekable source on retry in performSimpleUpload

### DIFF
--- a/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/MultipartUploadStream.swift
+++ b/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/MultipartUploadStream.swift
@@ -26,7 +26,7 @@ struct PreparedMultipartUpload: Sendable {
 struct MultipartUploadStream: AsyncSequence, Sendable {
   typealias Element = NIOCore.ByteBuffer
 
-  let source: any UploadSource
+  var source: any UploadSource
   let boundary: String
   let metadataJson: Data
   let contentType: String
@@ -47,6 +47,14 @@ struct MultipartUploadStream: AsyncSequence, Sendable {
     self.contentType = contentType
     self.totalSize = totalSize
     self.chunkSize = chunkSize
+  }
+
+  /// Rewinds the underlying source to offset 0 if it is seekable.
+  mutating func rewind() async throws {
+    if var seekable = source as? (any SeekableUploadSource) {
+      try await seekable.seek(to: 0)
+      source = seekable
+    }
   }
 
   /// Computes the exact Content-Length for the multipart request body.
@@ -78,27 +86,27 @@ struct MultipartUploadStream: AsyncSequence, Sendable {
 
     // Only inspect/read the source if automatic checksum computation is needed.
     let autoCalculators = calculators.filter { !($0 is ProvidedChecksumCalculator) }
-    if !autoCalculators.isEmpty {
-      if var seekable = source as? (any SeekableUploadSource) {
+    if var seekable = source as? (any SeekableUploadSource) {
+      if !autoCalculators.isEmpty {
         while let chunk = try await seekable.read(maxBytes: chunkSize) {
           for i in calculators.indices {
             calculators[i].update(chunk)
           }
         }
-        try await seekable.seek(to: 0)
-        preparedSource = seekable
-      } else {
-        var nonSeekable = source
-        var buffer = NIOCore.ByteBuffer()
-        while let chunk = try await nonSeekable.read(maxBytes: chunkSize) {
-          for i in calculators.indices {
-            calculators[i].update(chunk)
-          }
-          var nio = chunk.byteBuffer
-          buffer.writeBuffer(&nio)
-        }
-        preparedSource = BytesSource(buffer: ByteBuffer(buffer))
       }
+      try await seekable.seek(to: 0)
+      preparedSource = seekable
+    } else if !autoCalculators.isEmpty {
+      var nonSeekable = source
+      var buffer = NIOCore.ByteBuffer()
+      while let chunk = try await nonSeekable.read(maxBytes: chunkSize) {
+        for i in calculators.indices {
+          calculators[i].update(chunk)
+        }
+        var nio = chunk.byteBuffer
+        buffer.writeBuffer(&nio)
+      }
+      preparedSource = BytesSource(buffer: ByteBuffer(buffer))
     }
 
     let checksum =

--- a/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -194,15 +194,13 @@ extension StorageClient {
         totalSize: totalSize,
         options: options.checksums
       )
-    let stream = prepared.stream
+    var stream = prepared.stream
     let checksum = prepared.checksum
 
     let resumeState = ResumeState(
       details: UploadDetails(bytesUploaded: 0, totalBytes: totalSize))
     return try await resumeLoop.run(state: resumeState) { _ in
-      if var seekable = stream.source as? (any SeekableUploadSource) {
-        try await seekable.seek(to: 0)
-      }
+      try await stream.rewind()
 
       var request = try await httpClient.newRequest(
         path: "/upload/storage/v1/b/\(bucketId)/o", query: queryItems)

--- a/packages/swift-google-cloud-storage/Tests/MultipartUploadStreamTests.swift
+++ b/packages/swift-google-cloud-storage/Tests/MultipartUploadStreamTests.swift
@@ -170,4 +170,118 @@ import Testing
       Issue.record("Expected .internalError, got \(String(describing: error))")
     }
   }
+
+  /// Tests that MultipartUploadStream can be iterated multiple times when using struct-based sources because the stored source is not mutated by iteration.
+  @Test func multipartUploadStreamCanBeIteratedMultipleTimes() async throws {
+    let boundary = "TestBoundaryMultiIter"
+    let metadataJson = Data("{\"name\":\"test.txt\"}".utf8)
+    let payload = Data("Testing multiple iterations".utf8)
+    let source = BytesSource(data: payload)
+
+    let stream = MultipartUploadStream(
+      source: source,
+      boundary: boundary,
+      metadataJson: metadataJson,
+      contentType: "text/plain",
+      totalSize: UInt64(payload.count),
+      chunkSize: 4
+    )
+
+    var firstPass = NIOCore.ByteBuffer()
+    for try await chunk in stream {
+      var copy = chunk
+      firstPass.writeBuffer(&copy)
+    }
+
+    var secondPass = NIOCore.ByteBuffer()
+    for try await chunk in stream {
+      var copy = chunk
+      secondPass.writeBuffer(&copy)
+    }
+
+    #expect(firstPass.readableBytes == secondPass.readableBytes)
+    #expect(firstPass == secondPass)
+  }
+
+  /// Tests that casting stream.source to an existential copy does not mutate stream.source when source is a value type.
+  @Test func existentialCastMutationDoesNotMutateStreamSource() async throws {
+    let payload = Data([1, 2, 3, 4, 5, 6, 7, 8])
+    let source = BytesSource(data: payload)
+    let stream = MultipartUploadStream(
+      source: source,
+      boundary: "Boundary123",
+      metadataJson: Data("{}".utf8),
+      contentType: "application/octet-stream",
+      totalSize: UInt64(payload.count),
+      chunkSize: 4
+    )
+
+    // Attempting to mutate stream.source via existential cast (as in performSimpleUpload):
+    if var seekable = stream.source as? (any SeekableUploadSource) {
+      // Read chunks from the local copy
+      let chunk = try await seekable.read(maxBytes: 4)
+      #expect(chunk != nil)
+      // Seek the local copy
+      try await seekable.seek(to: 0)
+    }
+
+    // A fresh iterator from stream.source still starts from offset 0, untouched by mutations to `seekable`
+    var collected = NIOCore.ByteBuffer()
+    for try await chunk in stream {
+      var copy = chunk
+      collected.writeBuffer(&copy)
+    }
+    #expect(UInt64(collected.readableBytes) == stream.bodyLength)
+  }
+
+  /// Tests that MultipartUploadStream.prepare rewinds a seekable source back to offset 0 even if it had been partially read.
+  @Test func multipartUploadStreamPrepareRewindsPartiallyReadSource() async throws {
+    let payload = Data([1, 2, 3, 4, 5, 6, 7, 8])
+    var source = BytesSource(data: payload)
+    // Read 4 bytes beforehand
+    _ = try await source.read(maxBytes: 4)
+
+    let prepared = try await MultipartUploadStream.prepare(
+      source: source,
+      boundary: "BoundaryRewind",
+      metadataJson: Data("{}".utf8),
+      contentType: "application/octet-stream",
+      totalSize: UInt64(payload.count),
+      options: .none,
+      chunkSize: 4
+    )
+
+    var collected = NIOCore.ByteBuffer()
+    for try await chunk in prepared.stream {
+      var copy = chunk
+      collected.writeBuffer(&copy)
+    }
+    #expect(UInt64(collected.readableBytes) == prepared.stream.bodyLength)
+  }
+
+  /// Tests that MultipartUploadStream.rewind rewinds a seekable source back to offset 0.
+  @Test func multipartUploadStreamRewindRewindsSource() async throws {
+    let payload = Data([1, 2, 3, 4, 5, 6, 7, 8])
+    var source = BytesSource(data: payload)
+    // Read 4 bytes beforehand
+    _ = try await source.read(maxBytes: 4)
+
+    var stream = MultipartUploadStream(
+      source: source,
+      boundary: "BoundaryRewind",
+      metadataJson: Data("{}".utf8),
+      contentType: "application/octet-stream",
+      totalSize: UInt64(payload.count),
+      chunkSize: 4
+    )
+
+    try await stream.rewind()
+
+    var collected = NIOCore.ByteBuffer()
+    for try await chunk in stream {
+      var copy = chunk
+      collected.writeBuffer(&copy)
+    }
+    #expect(UInt64(collected.readableBytes) == stream.bodyLength)
+  }
 }

--- a/packages/swift-google-cloud-storage/Tests/SimpleUploadTests.swift
+++ b/packages/swift-google-cloud-storage/Tests/SimpleUploadTests.swift
@@ -284,6 +284,123 @@ import Testing
 
     let requests = registry.recordedRequests()
     #expect(requests.count == 2)
+    #expect(requests[0].body != nil)
+    #expect(requests[1].body != nil)
+    #expect(requests[0].body == requests[1].body)
+  }
+
+  /// Tests that a 503 failure during simple upload with FileSource retries and succeeds, verifying stream rewinding/fresh iterator.
+  @Test func simpleUploadFileSourceTransientFailureRetriesAndSucceeds() async throws {
+    let tempDirectory = FileManager.default.temporaryDirectory
+    let fileURL = tempDirectory.appendingPathComponent("test_\(UUID().uuidString).txt")
+    let data = Data(repeating: 0x42, count: 1024)
+    try data.write(to: fileURL)
+    defer { try? FileManager.default.removeItem(at: fileURL) }
+
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-file-retry"
+    let source = FileSource(fileURL: fileURL)
+
+    let simpleUploadUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=multipart&name=\(objectName)")
+
+    // 1. First attempt fails with 503 Service Unavailable
+    registry.register(
+      response: .success(
+        statusCode: 503, data: Data("Service Unavailable".utf8),
+        headers: nil),
+      for: simpleUploadUrl)
+
+    // 2. Retry attempt succeeds with 200 OK
+    registry.register(
+      response: .success(
+        statusCode: 200, data: makeObjectJSON(name: objectName, bucket: bucket, size: data.count),
+        headers: nil),
+      for: simpleUploadUrl)
+
+    let client = try makeClient(
+      registry: registry,
+      retryPolicy: BaseRetryPolicy().withAttemptLimit(3)
+    )
+    let object = try await client.upload(source, to: bucket, as: objectName)
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == "projects/_/buckets/\(bucket)")
+    #expect(object.size == Int64(data.count))
+
+    let requests = registry.recordedRequests()
+    #expect(requests.count == 2)
+    #expect(requests[0].body != nil)
+    #expect(requests[1].body != nil)
+    #expect(requests[0].body == requests[1].body)
+  }
+
+  /// Tests that a 503 failure during simple upload with a class-based reference-type SeekableUploadSource retries and succeeds.
+  @Test func simpleUploadClassSourceTransientFailureRetriesAndSucceeds() async throws {
+    final class MockClassSeekableSource: SeekableUploadSource, @unchecked Sendable {
+      let data: Data
+      private var offset: Int = 0
+
+      init(data: Data) {
+        self.data = data
+      }
+
+      var totalSize: UInt64? {
+        UInt64(data.count)
+      }
+
+      func read(maxBytes: Int) async throws -> GoogleCloudStorage.ByteBuffer? {
+        guard offset < data.count else { return nil }
+        let end = min(offset + maxBytes, data.count)
+        let chunk = data.subdata(in: offset..<end)
+        offset = end
+        return GoogleCloudStorage.ByteBuffer(chunk)
+      }
+
+      func seek(to offset: UInt64) async throws {
+        self.offset = Int(offset)
+      }
+    }
+
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-class-retry"
+    let data = Data(repeating: 0x42, count: 1024)
+    let source = MockClassSeekableSource(data: data)
+
+    let simpleUploadUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=multipart&name=\(objectName)")
+
+    // 1. First attempt fails with 503 Service Unavailable
+    registry.register(
+      response: .success(
+        statusCode: 503, data: Data("Service Unavailable".utf8),
+        headers: nil),
+      for: simpleUploadUrl)
+
+    // 2. Retry attempt succeeds with 200 OK
+    registry.register(
+      response: .success(
+        statusCode: 200, data: makeObjectJSON(name: objectName, bucket: bucket, size: data.count),
+        headers: nil),
+      for: simpleUploadUrl)
+
+    let client = try makeClient(
+      registry: registry,
+      retryPolicy: BaseRetryPolicy().withAttemptLimit(3)
+    )
+    let object = try await client.upload(source, to: bucket, as: objectName)
+
+    #expect(object.name == objectName)
+    #expect(object.bucket == "projects/_/buckets/\(bucket)")
+    #expect(object.size == Int64(data.count))
+
+    let requests = registry.recordedRequests()
+    #expect(requests.count == 2)
+    #expect(requests[0].body != nil)
+    #expect(requests[1].body != nil)
+    #expect(requests[0].body == requests[1].body)
   }
 
   /// Tests that a 503 error with NeverResume policy throws immediately without retrying.


### PR DESCRIPTION
Mutating a local existential copy prevented rewinding seekable upload sources in the performSimpleUpload retry loop. Add a mutating rewind() method on MultipartUploadStream that reassigns source = seekable after seeking to 0, ensuring both value and reference type sources are rewound.

Fixes #724