### PR TITLE
feat(gax): make client retry policy optional

### DIFF
--- a/packages/swift-google-gax/Sources/GoogleCloudGax/ClientOptions.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/ClientOptions.swift
@@ -78,7 +78,7 @@ public struct ClientOptions: Sendable {
   ///
   /// By default the clients use ``BaseRetryPolicy`` with a limit of 60 seconds or 10 attempts.
   /// Whichever limit is reached first stops the retry loop.
-  public var retryPolicy: any RetryPolicy = defaultRetryPolicy()
+  public var retryPolicy: (any RetryPolicy)? = nil
 
   /// Configures the client's backoff policy.
   ///

--- a/packages/swift-google-gax/Sources/GoogleCloudGax/RetryLoop.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/RetryLoop.swift
@@ -46,7 +46,7 @@ import Foundation
   /// The generated retry stub uses this initializer. It creates the retry loop based on the
   /// request and client options.
   public init(options: RequestOptions, withDefault: ClientOptions, idempotent: Bool) {
-    self.retryPolicy = options.retryPolicy ?? withDefault.retryPolicy
+    self.retryPolicy = options.retryPolicy ?? withDefault.retryPolicy ?? defaultRetryPolicy()
     self.backoffPolicy = options.backoffPolicy ?? withDefault.backoffPolicy
     self.retryThrottler = options.retryThrottler ?? withDefault.retryThrottler
     self.idempotent = options.idempotency ?? idempotent

--- a/packages/swift-google-gax/Tests/ClientOptionsTests.swift
+++ b/packages/swift-google-gax/Tests/ClientOptionsTests.swift
@@ -31,5 +31,6 @@ import GoogleCloudGax
     let got = ClientOptions()
     #expect(got.endpoint == nil)
     #expect(got.credentials == nil)
+    #expect(got.retryPolicy == nil)
   }
 }

--- a/packages/swift-google-gax/Tests/RetryLoopTests.swift
+++ b/packages/swift-google-gax/Tests/RetryLoopTests.swift
@@ -41,6 +41,14 @@ import Testing
     #expect(loop.retryPolicy is NeverRetry)
   }
 
+  @Test func retryPolicyDefaultFallbackWhenNil() {
+    let defaultOptions = ClientOptions()
+    let requestOptions = RequestOptions()
+    let loop = _RetryLoop(options: requestOptions, withDefault: defaultOptions, idempotent: true)
+    #expect(
+      loop.retryPolicy is LimitedAttemptCount<LimitedElapsedTime<BaseRetryPolicy>>)
+  }
+
   @Test func backoffPolicyFromDefault() {
     let defaultOptions = ClientOptions().with { $0.backoffPolicy = LinearBackoffPolicy() }
     let requestOptions = RequestOptions()


### PR DESCRIPTION
Allow `ClientOptions.retryPolicy` to be optional (`nil` by default) so clients can differentiate between unconfigured retry policies and user-configured overrides.

In a future PR, the storage control client will use this to set its own default policy. Likely this will be the case for all hand-crafted clients.

The `_RetryLoop` type uses `defaultRetryPolicy()` if the client's retry policy is `nil`.


Towards #529 