### PR TITLE
fix(storage): `StorageResumePolicy` try harder

### DIFF
--- a/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageResumePolicy.swift
+++ b/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageResumePolicy.swift
@@ -19,8 +19,8 @@ import GoogleRpc
 /// Evaluates whether an error is considered resumable in Google Cloud Storage.
 ///
 /// In Google Cloud Storage, resumable data transfers (uploads and downloads) can be resumed
-/// on I/O errors, transient HTTP status codes (408, 429, 502, 503, 504), and transient
-/// gRPC/service status codes (`unavailable`, `resourceExhausted`, `deadlineExceeded`).
+/// on I/O errors, transient HTTP status codes (408, 429, and 5xx), and transient
+/// gRPC/service status codes (`unavailable`, `resourceExhausted`, `deadlineExceeded`, `internal`).
 ///
 /// This policy can be composed with decorators such as ``StopOnConsecutiveErrors`` or
 /// ``LimitedTotalResumes``:
@@ -43,10 +43,11 @@ public struct StorageResumePolicy<Details: Sendable>: ResumePolicy, Sendable, Eq
       return true
     case .http(let details):
       let code = details.http_status_code
-      return code == 408 || code == 429 || code == 502 || code == 503 || code == 504
+      return code == 408 || code == 429 || (500...599).contains(code)
     case .service(let details):
       let code = details.code
       return code == .unavailable || code == .resourceExhausted || code == .deadlineExceeded
+        || code == .`internal`
     case .binding, .exhausted, .unimplemented, .malformedResponse:
       return false
     @unknown default:

--- a/packages/swift-google-cloud-storage/Tests/ResumableUploadTests.swift
+++ b/packages/swift-google-cloud-storage/Tests/ResumableUploadTests.swift
@@ -165,7 +165,7 @@ import Testing
     }
   }
 
-  /// Tests handling of HTTP error responses (e.g. HTTP 500) during chunk upload in a resumable session.
+  /// Tests handling of HTTP error responses (e.g. HTTP 400) during chunk upload in a resumable session.
   @Test func resumableUploadHTTPError() async throws {
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
@@ -175,7 +175,7 @@ import Testing
 
     let startUrl = registry.url(
       "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
-    let chunkUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=test-id")
+    let chunkUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=test-http-error")
 
     registry.register(
       response: .success(
@@ -184,7 +184,7 @@ import Testing
       for: startUrl)
     registry.register(
       response: .success(
-        statusCode: 500, data: Data("Internal Server Error".utf8),
+        statusCode: 400, data: Data("Bad Request".utf8),
         headers: nil),
       for: chunkUrl)
 
@@ -194,7 +194,7 @@ import Testing
       try await client.upload(source, to: bucket, as: objectName)
     }
     if case .http(let details) = error {
-      #expect(details.http_status_code == 500)
+      #expect(details.http_status_code == 400)
     } else {
       Issue.record("Expected .http RequestError, got \(String(describing: error))")
     }

--- a/packages/swift-google-cloud-storage/Tests/ResumePolicyTests.swift
+++ b/packages/swift-google-cloud-storage/Tests/ResumePolicyTests.swift
@@ -16,6 +16,7 @@ import Foundation
 import GoogleCloudAuth
 @_spi(GoogleCloudInternal) import GoogleCloudGax
 @_spi(GoogleCloudInternal) @testable import GoogleCloudStorage
+import GoogleRpc
 import Testing
 
 @Suite struct ResumePolicyTests {
@@ -110,6 +111,7 @@ import Testing
     // Recoverable HTTP status codes
     let err408 = RequestError.http(HTTPDetails(http_status_code: 408, headers: [:]))
     let err429 = RequestError.http(HTTPDetails(http_status_code: 429, headers: [:]))
+    let err500 = RequestError.http(HTTPDetails(http_status_code: 500, headers: [:]))
     let err502 = RequestError.http(HTTPDetails(http_status_code: 502, headers: [:]))
     let err503 = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
     let err504 = RequestError.http(HTTPDetails(http_status_code: 504, headers: [:]))
@@ -117,10 +119,26 @@ import Testing
 
     #expect(isResume(policy.onError(state: state, error: err408)))
     #expect(isResume(policy.onError(state: state, error: err429)))
+    #expect(isResume(policy.onError(state: state, error: err500)))
     #expect(isResume(policy.onError(state: state, error: err502)))
     #expect(isResume(policy.onError(state: state, error: err503)))
     #expect(isResume(policy.onError(state: state, error: err504)))
     #expect(isResume(policy.onError(state: state, error: errIO)))
+
+    // Recoverable gRPC status codes
+    let rpcUnavailable = RequestError.service(
+      ServiceError(code: Code.unavailable, message: "unavailable"))
+    let rpcResourceExhausted = RequestError.service(
+      ServiceError(code: Code.resourceExhausted, message: "quota exceeded"))
+    let rpcDeadlineExceeded = RequestError.service(
+      ServiceError(code: Code.deadlineExceeded, message: "deadline exceeded"))
+    let rpcInternal = RequestError.service(
+      ServiceError(code: Code.`internal`, message: "internal error"))
+
+    #expect(isResume(policy.onError(state: state, error: rpcUnavailable)))
+    #expect(isResume(policy.onError(state: state, error: rpcResourceExhausted)))
+    #expect(isResume(policy.onError(state: state, error: rpcDeadlineExceeded)))
+    #expect(isResume(policy.onError(state: state, error: rpcInternal)))
 
     // Permanent HTTP status codes
     let err400 = RequestError.http(HTTPDetails(http_status_code: 400, headers: [:]))
@@ -128,14 +146,23 @@ import Testing
     let err403 = RequestError.http(HTTPDetails(http_status_code: 403, headers: [:]))
     let err404 = RequestError.http(HTTPDetails(http_status_code: 404, headers: [:]))
     let err412 = RequestError.http(HTTPDetails(http_status_code: 412, headers: [:]))
-    let err500 = RequestError.http(HTTPDetails(http_status_code: 500, headers: [:]))
 
     #expect(isPermanent(policy.onError(state: state, error: err400)))
     #expect(isPermanent(policy.onError(state: state, error: err401)))
     #expect(isPermanent(policy.onError(state: state, error: err403)))
     #expect(isPermanent(policy.onError(state: state, error: err404)))
     #expect(isPermanent(policy.onError(state: state, error: err412)))
-    #expect(isPermanent(policy.onError(state: state, error: err500)))
+
+    // Permanent gRPC status codes
+    let rpcPermissionDenied = RequestError.service(
+      ServiceError(code: Code.permissionDenied, message: "permission denied"))
+    let rpcNotFound = RequestError.service(ServiceError(code: Code.notFound, message: "not found"))
+    let rpcInvalidArgument = RequestError.service(
+      ServiceError(code: Code.invalidArgument, message: "invalid argument"))
+
+    #expect(isPermanent(policy.onError(state: state, error: rpcPermissionDenied)))
+    #expect(isPermanent(policy.onError(state: state, error: rpcNotFound)))
+    #expect(isPermanent(policy.onError(state: state, error: rpcInvalidArgument)))
   }
 
   @Test func storageResumePolicyConsecutiveErrors() {

--- a/packages/swift-google-cloud-storage/Tests/SimpleUploadTests.swift
+++ b/packages/swift-google-cloud-storage/Tests/SimpleUploadTests.swift
@@ -122,7 +122,7 @@ import Testing
     }
   }
 
-  /// Tests handling of HTTP error responses (e.g., HTTP 500) during a simple upload.
+  /// Tests handling of HTTP error responses (e.g., HTTP 400) during a simple upload.
   @Test func simpleUploadHTTPError() async throws {
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
@@ -135,7 +135,7 @@ import Testing
 
     registry.register(
       response: .success(
-        statusCode: 500, data: Data("Internal Server Error".utf8),
+        statusCode: 400, data: Data("Bad Request".utf8),
         headers: nil),
       for: simpleUploadUrl)
 
@@ -145,7 +145,7 @@ import Testing
       try await client.upload(source, to: bucket, as: objectName)
     }
     if case .http(let details) = error {
-      #expect(details.http_status_code == 500)
+      #expect(details.http_status_code == 400)
     } else {
       Issue.record("Expected .http RequestError, got \(String(describing: error))")
     }


### PR DESCRIPTION
Google Cloud Storage expects clients to treat all HTTP 500s (mapped to `.internal` under gRPC / request errors) as retryable.

Fixes #758 