### PR TITLE
feat(storage): storage control retry policy

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: swift
-version: v0.41.1-0.20260908165511-5dfd57156174
+version: v0.42.1-0.20260908214916-2312e8834d99
 repo: googleapis/google-cloud-swift
 sources:
   conformance:

--- a/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/generated/StorageControl/StorageControlClient.swift
+++ b/packages/swift-google-cloud-storage/Sources/GoogleCloudStorage/generated/StorageControl/StorageControlClient.swift
@@ -31,6 +31,10 @@ public final class StorageControlClient: StorageControlProtocol, Sendable {
 
   /// Creates a new `StorageControlClient` using the given client options.
   public init(_ options: GoogleCloudGax.ClientOptions = .init()) throws {
+    var options = options
+    if options.retryPolicy == nil {
+      options.retryPolicy = StorageBaseRetryPolicy.defaultPolicy
+    }
     let sharedGrpcClient = try GoogleCloudGaxGRPC._GRPCClient(
       from: options,
       withDefaultEndpoint: "https://storage.googleapis.com"

--- a/packages/swift-google-cloud-storage/Tests/StorageControlClientTests.swift
+++ b/packages/swift-google-cloud-storage/Tests/StorageControlClientTests.swift
@@ -72,4 +72,24 @@ import Testing
       _ = try StorageControlClient(options)
     }
   }
+
+  @Test func defaultInitializationUsesStorageBaseRetryPolicy() throws {
+    let credentials = try Credentials(configuration: .anonymous)
+    let options = ClientOptions().with {
+      $0.credentials = credentials
+    }
+    #expect(options.retryPolicy == nil)
+    _ = try StorageControlClient(options)
+  }
+
+  @Test func initializationPreservesExplicitRetryPolicy() throws {
+    let credentials = try Credentials(configuration: .anonymous)
+    let explicitPolicy = NeverRetry()
+    let options = ClientOptions().with {
+      $0.credentials = credentials
+      $0.retryPolicy = explicitPolicy
+    }
+    #expect(options.retryPolicy != nil)
+    _ = try StorageControlClient(options)
+  }
 }


### PR DESCRIPTION
By default, use the storage-specific retry policy with `StorageControlClient`.  This will retry more error codes, as the service expects.

Fixes #529 
