### PR TITLE
fix(auth): normalize x-goog-user-project header key

### DIFF
--- a/packages/swift-google-auth/Sources/GoogleCloudAuth/Providers/ExternalAccountCredentials.swift
+++ b/packages/swift-google-auth/Sources/GoogleCloudAuth/Providers/ExternalAccountCredentials.swift
@@ -182,7 +182,7 @@ struct ExternalAccountCredentials: CredentialsProvider, Sendable {
     let token = try await cache.token()
     var headers: AuthHeaders = [("Authorization", "\(token.tokenType) \(token.accessToken)")]
     if let project = workforcePoolUserProject {
-      headers.append(("X-Goog-User-Project", project))
+      headers.append(("x-goog-user-project", project))
     }
     return headers
   }

--- a/packages/swift-google-auth/Sources/GoogleCloudAuth/Providers/MDSCredentials.swift
+++ b/packages/swift-google-auth/Sources/GoogleCloudAuth/Providers/MDSCredentials.swift
@@ -56,7 +56,7 @@ struct MDSCredentials: CredentialsProvider, Sendable {
     let token = try await self.cache.token()
     var headers = [("Authorization", "Bearer \(token.accessToken)")]
     if let quota = self.provider.quotaProjectID {
-      headers.append(("X-Goog-User-Project", quota))
+      headers.append(("x-goog-user-project", quota))
     }
     return headers
   }

--- a/packages/swift-google-auth/Sources/GoogleCloudAuth/Providers/UserCredentials.swift
+++ b/packages/swift-google-auth/Sources/GoogleCloudAuth/Providers/UserCredentials.swift
@@ -46,6 +46,7 @@ typealias UserCredentials = UserCredentialsGeneric<ContinuousClock>
 struct UserCredentialsGeneric<C: Clock>: CredentialsProvider, Sendable
 where C.Instant.Duration == Duration {
   private let cache: TokenCache<C>
+  private let quotaProjectID: String?
   private let universeDomain: String?
 
   /// Dependency injection for tests
@@ -62,6 +63,7 @@ where C.Instant.Duration == Duration {
       throw CredentialsError.notSupported(
         "User accounts are not supported in custom universes: \(universeDomain)")
     }
+    self.quotaProjectID = quotaProjectID ?? user.quotaProjectId
     self.universeDomain = universeDomain
 
     // Resolve Token URI
@@ -92,7 +94,11 @@ where C.Instant.Duration == Duration {
 
   func headers() async throws -> AuthHeaders {
     let token = try await cache.token()
-    return [("Authorization", "\(token.tokenType) \(token.accessToken)")]
+    var headers: AuthHeaders = [("Authorization", "\(token.tokenType) \(token.accessToken)")]
+    if let quotaProjectID = quotaProjectID {
+      headers.append(("x-goog-user-project", quotaProjectID))
+    }
+    return headers
   }
 
   func universeDomain() async -> String? {

--- a/packages/swift-google-auth/Tests/ExternalAccountTests.swift
+++ b/packages/swift-google-auth/Tests/ExternalAccountTests.swift
@@ -257,7 +257,7 @@ private actor MockFailingSubjectTokenProvider: SubjectTokenProvider {
       headers.contains {
         $0.0 == "Authorization" && $0.1 == "Bearer ya29.fake-sts-access-token"
       })
-    #expect(headers.contains { $0.0 == "X-Goog-User-Project" && $0.1 == "quota-project" })
+    #expect(headers.contains { $0.0 == "x-goog-user-project" && $0.1 == "quota-project" })
   }
 
   @Test("Programmatic credentials retry correctly on transient errors")

--- a/packages/swift-google-auth/Tests/MDSCredentialsTests.swift
+++ b/packages/swift-google-auth/Tests/MDSCredentialsTests.swift
@@ -52,7 +52,7 @@ import Testing
       "Missing authorization header in \(headers)"
     )
     #expect(
-      headers.contains { $0.0 == "X-Goog-User-Project" && $0.1 == "my-quota-project" },
+      headers.contains { $0.0 == "x-goog-user-project" && $0.1 == "my-quota-project" },
       "Missing quota project ID header in \(headers)"
     )
   }

--- a/packages/swift-google-auth/Tests/UserCredentialsTests.swift
+++ b/packages/swift-google-auth/Tests/UserCredentialsTests.swift
@@ -529,4 +529,89 @@ typealias UserCredentials = UserCredentialsGeneric<TestClock>
       headers.contains { $0.0 == "Authorization" && $0.1 == "Bearer recovered-timeout-token" })
     #expect(attempts.getCount() == 2)
   }
+
+  @Test func headersIncludesQuotaProjectFromUserAccountData() async throws {
+    let responsePayload = Oauth2RefreshResponse(
+      accessToken: "mock-token",
+      expiresIn: 3600,
+      tokenType: "Bearer"
+    )
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    let encodedData = try encoder.encode(responsePayload)
+
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData))
+        )
+      }
+    ])
+
+    let data = UserAccountData(
+      type: "authorized_user",
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      refreshToken: "test-refresh-token",
+      quotaProjectId: "user-json-quota-proj"
+    )
+
+    let source = try UserCredentials(
+      user: data,
+      httpClient: AuthHTTPClient(mock: mock),
+      retryConfiguration: .defaultConfiguration,
+      clock: TestClock()
+    )
+
+    let headers = try await source.headers()
+    #expect(
+      headers.contains { $0.0 == "x-goog-user-project" && $0.1 == "user-json-quota-proj" })
+  }
+
+  @Test func headersQuotaProjectParameterOverridesUserAccountData() async throws {
+    let responsePayload = Oauth2RefreshResponse(
+      accessToken: "mock-token",
+      expiresIn: 3600,
+      tokenType: "Bearer"
+    )
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    let encodedData = try encoder.encode(responsePayload)
+
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData))
+        )
+      }
+    ])
+
+    let data = UserAccountData(
+      type: "authorized_user",
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      refreshToken: "test-refresh-token",
+      quotaProjectId: "user-json-quota-proj"
+    )
+
+    let source = try UserCredentials(
+      user: data,
+      quotaProjectID: "override-quota-proj",
+      httpClient: AuthHTTPClient(mock: mock),
+      retryConfiguration: .defaultConfiguration,
+      clock: TestClock()
+    )
+
+    let headers = try await source.headers()
+    #expect(
+      headers.contains { $0.0 == "x-goog-user-project" && $0.1 == "override-quota-proj" })
+    #expect(
+      !headers.contains { $0.0 == "x-goog-user-project" && $0.1 == "user-json-quota-proj" })
+  }
 }


### PR DESCRIPTION
fix(auth/user): store provided `quotaProjectID`, falling back to user
fix(auth/user): emit `x-goog-user-project` header if provided
fix(auth): Added quota_project_id decoding to ServiceAccountData and fallback resolution in ServiceAccountCredentials.

Towards #785 