### PR TITLE
feat(gax): add per-request and per-client quota_project_id options

### DIFF
--- a/packages/swift-google-gax/Sources/GoogleCloudGax/ClientOptions.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/ClientOptions.swift
@@ -60,8 +60,28 @@ public struct ClientOptions: Sendable {
 
   /// Overrides the quota project for all requests sent by the client.
   ///
+  /// By default, Google Cloud APIs attribute quota and billing usage to the project associated
+  /// with the credentials (for example, the project where a service account was created) or to
+  /// the project owning the accessed resource. Setting `quotaProject` instructs the service to
+  /// charge quota and billing to the specified project ID or project number instead.
+  ///
+  /// Common scenarios for setting a quota project include:
+  /// - Authenticating with user credentials (such as those created by
+  ///   `gcloud auth application-default login`), which are not inherently tied to a project.
+  /// - Accessing resources in another project (such as Cloud Storage Requester Pays buckets)
+  ///   where the caller's project must be billed for the request.
+  /// - Using a centralized service account across multiple projects where APIs and quotas are
+  ///   managed separately.
+  ///
+  /// The authenticated principal must have the `serviceusage.services.use` IAM permission
+  /// (granted by the [Service Usage Consumer] role, `roles/serviceusage.serviceUsageConsumer`) on
+  /// the specified project.
+  ///
   /// When set, the `x-goog-user-project` header is sent with this value on every request,
-  /// overriding any credential-level quota project unless overridden by ``RequestOptions/quotaProject``.
+  /// overriding any credential-level quota project unless overridden per request by
+  /// ``RequestOptions/quotaProject``.
+  ///
+  /// [Service Usage Consumer]: https://cloud.google.com/service-usage/docs/access-control
   public var quotaProject: String? = nil
 
   /// Enables logging and sets the logger.

--- a/packages/swift-google-gax/Sources/GoogleCloudGax/ClientOptions.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/ClientOptions.swift
@@ -58,6 +58,12 @@ public struct ClientOptions: Sendable {
   /// [Application Default Credentials]: https://docs.cloud.google.com/docs/authentication/client-libraries
   public var credentials: Credentials? = nil
 
+  /// Overrides the quota project for all requests sent by the client.
+  ///
+  /// When set, the `x-goog-user-project` header is sent with this value on every request,
+  /// overriding any credential-level quota project unless overridden by ``RequestOptions/quotaProject``.
+  public var quotaProject: String? = nil
+
   /// Enables logging and sets the logger.
   ///
   /// When logging is enabled, the client will log the full contents of each request, response, and

--- a/packages/swift-google-gax/Sources/GoogleCloudGax/HTTPClient.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/HTTPClient.swift
@@ -24,12 +24,14 @@ import struct Logging.Logger
   let baseURL: URLComponents
   let credentials: any _CredentialsProtocol
   let logger: Logger?
+  let quotaProject: String?
   let inner: any _HTTPClientProtocol
 
   // Creates a new client.
   public init(from: ClientOptions, withDefaultEndpoint: String) throws {
     self.credentials = try from.credentials ?? GoogleCloudAuth.Credentials()
     self.logger = from.logger
+    self.quotaProject = from.quotaProject
     let endpoint = from.endpoint ?? withDefaultEndpoint
     self.baseURL = try Self.validateEndpoint(endpoint)
     self.inner = HTTPClientHolder()
@@ -40,10 +42,12 @@ import struct Logging.Logger
     _ inner: any _HTTPClientProtocol, endpoint: String,
     credentials: (any _CredentialsProtocol)? = nil,
     logger: Logging.Logger? = nil,
+    quotaProject: String? = nil
   ) throws {
     self.baseURL = try Self.validateEndpoint(endpoint)
     self.credentials = try credentials ?? GoogleCloudAuth.Credentials(configuration: .anonymous)
     self.logger = logger
+    self.quotaProject = quotaProject
     self.inner = inner
   }
 
@@ -64,7 +68,11 @@ import struct Logging.Logger
     return parsed
   }
 
-  public func newRequest(path: String, query: [URLQueryItem]) async throws -> _HTTPClientRequest {
+  public func newRequest(
+    path: String,
+    query: [URLQueryItem],
+    options: RequestOptions = .init()
+  ) async throws -> _HTTPClientRequest {
     var components = self.baseURL
     components.path = path
     if !query.isEmpty {
@@ -75,10 +83,17 @@ import struct Logging.Logger
     for (key, value) in headers {
       request.addHeader(name: key, value: value)
     }
+    if let effectiveQuotaProject = options.quotaProject ?? self.quotaProject {
+      request.setHeader(name: _HeaderNames.userProject, value: effectiveQuotaProject)
+    }
     return request
   }
 
-  public func newRequest(percentEncodedPath: String, query: [URLQueryItem]) async throws
+  public func newRequest(
+    percentEncodedPath: String,
+    query: [URLQueryItem],
+    options: RequestOptions = .init()
+  ) async throws
     -> _HTTPClientRequest
   {
     var components = self.baseURL
@@ -91,22 +106,34 @@ import struct Logging.Logger
     for (key, value) in headers {
       request.addHeader(name: key, value: value)
     }
+    if let effectiveQuotaProject = options.quotaProject ?? self.quotaProject {
+      request.setHeader(name: _HeaderNames.userProject, value: effectiveQuotaProject)
+    }
     return request
   }
 
-  public func newRequest(urlComponents: URLComponents) async throws -> _HTTPClientRequest {
+  public func newRequest(
+    urlComponents: URLComponents,
+    options: RequestOptions = .init()
+  ) async throws -> _HTTPClientRequest {
     var request = _HTTPClientRequest(self.inner, url: urlComponents)
     let headers = try await self.credentials.headers()
     for (key, value) in headers {
       request.addHeader(name: key, value: value)
     }
+    if let effectiveQuotaProject = options.quotaProject ?? self.quotaProject {
+      request.setHeader(name: _HeaderNames.userProject, value: effectiveQuotaProject)
+    }
     return request
   }
 
-  public func newRequest(uri: String) async throws -> _HTTPClientRequest {
+  public func newRequest(
+    uri: String,
+    options: RequestOptions = .init()
+  ) async throws -> _HTTPClientRequest {
     guard let components = URLComponents(string: uri) else {
       throw RequestError.binding("bad URL for uri=\(uri)")
     }
-    return try await newRequest(urlComponents: components)
+    return try await newRequest(urlComponents: components, options: options)
   }
 }

--- a/packages/swift-google-gax/Sources/GoogleCloudGax/HeaderNames.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/HeaderNames.swift
@@ -19,4 +19,5 @@ import Foundation
 public enum _HeaderNames {
   public static let apiClient = "x-goog-api-client"
   public static let requestParams = "x-goog-request-params"
+  public static let userProject = "x-goog-user-project"
 }

--- a/packages/swift-google-gax/Sources/GoogleCloudGax/RequestOptions.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/RequestOptions.swift
@@ -80,4 +80,10 @@ public struct RequestOptions: Sendable {
   ///
   /// Without an override, the request uses the polling backoff policy configured in the client.
   public var pollingBackoffPolicy: (any BackoffPolicy)? = nil
+
+  /// Overrides the quota project for this request.
+  ///
+  /// When set, the `x-goog-user-project` header is sent with this value, overriding any client-level
+  /// or credential-level quota project.
+  public var quotaProject: String? = nil
 }

--- a/packages/swift-google-gax/Sources/GoogleCloudGax/RequestOptions.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/RequestOptions.swift
@@ -83,7 +83,23 @@ public struct RequestOptions: Sendable {
 
   /// Overrides the quota project for this request.
   ///
-  /// When set, the `x-goog-user-project` header is sent with this value, overriding any client-level
-  /// or credential-level quota project.
+  /// By default, Google Cloud APIs attribute quota and billing usage to the project associated
+  /// with the credentials, the project configured on ``ClientOptions/quotaProject``, or the
+  /// project owning the accessed resource. Setting `quotaProject` instructs the service to charge
+  /// quota and billing for this request to the specified project ID or project number instead.
+  ///
+  /// This is commonly used when:
+  /// - Making requests to a Cloud Storage Requester Pays bucket or other cross-project resource
+  ///   where a specific project must be billed.
+  /// - Multiplexing requests across multiple consumer projects using a single client instance.
+  ///
+  /// The authenticated principal must have the `serviceusage.services.use` IAM permission
+  /// (granted by the [Service Usage Consumer] role, `roles/serviceusage.serviceUsageConsumer`) on
+  /// the specified project.
+  ///
+  /// When set, the `x-goog-user-project` header is sent with this value, taking precedence over
+  /// ``ClientOptions/quotaProject`` and any credential-level quota project.
+  ///
+  /// [Service Usage Consumer]: https://cloud.google.com/service-usage/docs/access-control
   public var quotaProject: String? = nil
 }

--- a/packages/swift-google-gax/Sources/GoogleCloudGaxGRPC/GRPCClient.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGaxGRPC/GRPCClient.swift
@@ -41,9 +41,11 @@ public final class _GRPCClient: Sendable {
   let client: GRPCClient<HTTP2ClientTransport.Posix>
   let connectionTask: Task<Void, any Error>
   let credentials: GoogleCloudAuth.Credentials
+  let quotaProject: String?
 
   public init(from options: ClientOptions, withDefaultEndpoint defaultEndpoint: String) throws {
     self.credentials = try options.credentials ?? GoogleCloudAuth.Credentials()
+    self.quotaProject = options.quotaProject
 
     let rawEndpoint = options.endpoint ?? defaultEndpoint
     let endpointWithScheme = rawEndpoint.contains("://") ? rawEndpoint : "https://\(rawEndpoint)"
@@ -103,10 +105,17 @@ public final class _GRPCClient: Sendable {
       callOptions.timeout = attemptTimeout
     }
 
+    let effectiveQuotaProject = options.quotaProject ?? self.quotaProject
     var metadata = Metadata()
     let authHeaders = try await self.credentials.headers()
     for (key, value) in authHeaders {
+      if effectiveQuotaProject != nil && key.lowercased() == _HeaderNames.userProject {
+        continue
+      }
       metadata.addString(value, forKey: key)
+    }
+    if let effectiveQuotaProject {
+      metadata.addString(effectiveQuotaProject, forKey: _HeaderNames.userProject)
     }
 
     metadata.addString(clientHeader, forKey: GoogleCloudGax._HeaderNames.apiClient)

--- a/packages/swift-google-gax/Tests/ClientOptionsTests.swift
+++ b/packages/swift-google-gax/Tests/ClientOptionsTests.swift
@@ -22,14 +22,19 @@ import GoogleCloudGax
 
 @Suite struct ClientOptionsTests {
   @Test func then() {
-    let got = ClientOptions().with { $0.endpoint = "test-only" }
+    let got = ClientOptions().with {
+      $0.endpoint = "test-only"
+      $0.quotaProject = "my-quota-project"
+    }
     #expect(got.endpoint == "test-only")
+    #expect(got.quotaProject == "my-quota-project")
     #expect(got.credentials == nil)
   }
 
   @Test func defaults() {
     let got = ClientOptions()
     #expect(got.endpoint == nil)
+    #expect(got.quotaProject == nil)
     #expect(got.credentials == nil)
     #expect(got.retryPolicy == nil)
   }

--- a/packages/swift-google-gax/Tests/GRPCClientExecuteTests.swift
+++ b/packages/swift-google-gax/Tests/GRPCClientExecuteTests.swift
@@ -279,4 +279,87 @@ import Testing
       Issue.record("Expected RequestError, got \(error)")
     }
   }
+
+  @Test func executeQuotaProjectPrecedence() async throws {
+    actor MetadataCollector {
+      var userProjects: [String] = []
+      func record(_ values: [String]) {
+        userProjects = values
+      }
+    }
+    let collector = MetadataCollector()
+
+    struct InspectingEchoService: RegistrableRPCService {
+      let collector: MetadataCollector
+      func registerMethods<Transport: ServerTransport>(with router: inout RPCRouter<Transport>) {
+        router.registerHandler(
+          forMethod: MethodDescriptor(
+            service: ServiceDescriptor(package: "test", service: "Echo"),
+            method: "Echo"
+          ),
+          deserializer: ProtobufDeserializer<Google_Protobuf_Empty>(),
+          serializer: ProtobufSerializer<Google_Protobuf_Empty>()
+        ) { request, _ in
+          let values = request.metadata[stringValues: _HeaderNames.userProject].map { String($0) }
+          await collector.record(values)
+          return StreamingServerResponse(metadata: [:]) { writer in
+            try await writer.write(Google_Protobuf_Empty())
+            return [:]
+          }
+        }
+      }
+    }
+
+    let server = GRPCServer(
+      transport: .http2NIOPosix(
+        address: .ipv4(host: "127.0.0.1", port: 0),
+        transportSecurity: .plaintext
+      ),
+      services: [InspectingEchoService(collector: collector)]
+    )
+
+    try await withThrowingDiscardingTaskGroup { group in
+      group.addTask {
+        try await server.serve()
+      }
+
+      let listeningAddress = try await server.listeningAddress?.ipv4
+      guard let port = listeningAddress?.port else {
+        Issue.record("Failed to get listening port")
+        server.beginGracefulShutdown()
+        return
+      }
+
+      let endpoint = "http://127.0.0.1:\(port)"
+      var clientOptions = ClientOptions()
+      clientOptions.endpoint = endpoint
+      clientOptions.credentials = try Credentials(configuration: .anonymous)
+      clientOptions.quotaProject = "client-quota-proj"
+
+      let client = try _GRPCClient(from: clientOptions, withDefaultEndpoint: endpoint)
+      defer {
+        client.close()
+        server.beginGracefulShutdown()
+      }
+
+      // 1. Uses ClientOptions.quotaProject when RequestOptions.quotaProject is nil
+      let _: Google_Protobuf_Empty = try await client.execute(
+        path: "/test.Echo/Echo",
+        request: Google_Protobuf_Empty(),
+        options: RequestOptions(),
+        clientHeader: ""
+      )
+      #expect(await collector.userProjects == ["client-quota-proj"])
+
+      // 2. RequestOptions.quotaProject overrides ClientOptions.quotaProject
+      let requestOptions = RequestOptions().with { $0.quotaProject = "request-quota-proj" }
+      let _: Google_Protobuf_Empty = try await client.execute(
+        path: "/test.Echo/Echo",
+        request: Google_Protobuf_Empty(),
+        options: requestOptions,
+        clientHeader: ""
+      )
+      #expect(await collector.userProjects == ["request-quota-proj"])
+    }
+  }
 }

--- a/packages/swift-google-gax/Tests/GRPCClientExecuteTests.swift
+++ b/packages/swift-google-gax/Tests/GRPCClientExecuteTests.swift
@@ -280,7 +280,21 @@ import Testing
     }
   }
 
-  @Test func executeQuotaProjectPrecedence() async throws {
+  @Test(arguments: [
+    // Uses ClientOptions.quotaProject when RequestOptions.quotaProject is nil
+    (clientQuota: "client-quota-proj", requestQuota: nil as String?, expected: "client-quota-proj"),
+    // RequestOptions.quotaProject overrides ClientOptions.quotaProject
+    (
+      clientQuota: "client-quota-proj",
+      requestQuota: "request-quota-proj",
+      expected: "request-quota-proj"
+    ),
+  ])
+  func executeQuotaProjectPrecedence(
+    clientQuota: String?,
+    requestQuota: String?,
+    expected: String
+  ) async throws {
     actor MetadataCollector {
       var userProjects: [String] = []
       func record(_ values: [String]) {
@@ -334,7 +348,7 @@ import Testing
       var clientOptions = ClientOptions()
       clientOptions.endpoint = endpoint
       clientOptions.credentials = try Credentials(configuration: .anonymous)
-      clientOptions.quotaProject = "client-quota-proj"
+      clientOptions.quotaProject = clientQuota
 
       let client = try _GRPCClient(from: clientOptions, withDefaultEndpoint: endpoint)
       defer {
@@ -342,24 +356,14 @@ import Testing
         server.beginGracefulShutdown()
       }
 
-      // 1. Uses ClientOptions.quotaProject when RequestOptions.quotaProject is nil
-      let _: Google_Protobuf_Empty = try await client.execute(
-        path: "/test.Echo/Echo",
-        request: Google_Protobuf_Empty(),
-        options: RequestOptions(),
-        clientHeader: ""
-      )
-      #expect(await collector.userProjects == ["client-quota-proj"])
-
-      // 2. RequestOptions.quotaProject overrides ClientOptions.quotaProject
-      let requestOptions = RequestOptions().with { $0.quotaProject = "request-quota-proj" }
+      let requestOptions = RequestOptions().with { $0.quotaProject = requestQuota }
       let _: Google_Protobuf_Empty = try await client.execute(
         path: "/test.Echo/Echo",
         request: Google_Protobuf_Empty(),
         options: requestOptions,
         clientHeader: ""
       )
-      #expect(await collector.userProjects == ["request-quota-proj"])
+      #expect(await collector.userProjects == [expected])
     }
   }
 }

--- a/packages/swift-google-gax/Tests/HTTPClientTests.swift
+++ b/packages/swift-google-gax/Tests/HTTPClientTests.swift
@@ -620,6 +620,43 @@ import NIOHTTP1
     #expect(response.status == .ok)
   }
 
+  @Test func quotaProjectPrecedence() async throws {
+    let credentials = MockCredentials([
+      { [("Authorization", "Bearer token"), ("x-goog-user-project", "cred-project")] },
+      { [("Authorization", "Bearer token"), ("x-goog-user-project", "cred-project")] },
+      { [("Authorization", "Bearer token"), ("x-goog-user-project", "cred-project")] },
+    ])
+
+    let mock = MockHTTPClient { (request, _) in
+      HTTPClientResponse(
+        version: .http1_1,
+        status: .ok,
+        body: .bytes(.init(string: "{}"))
+      )
+    }
+
+    // 1. Credentials quota project used when neither client nor request options set quotaProject
+    let clientDefault = try _HTTPClient(
+      mock, endpoint: "http://localhost:8080", credentials: credentials)
+    let req1 = try await clientDefault.newRequest(path: "/test", query: [])
+    #expect(req1.headers[_HeaderNames.userProject] == ["cred-project"])
+
+    // 2. ClientOptions.quotaProject overrides credential header without duplication
+    let clientWithQuota = try _HTTPClient(
+      mock,
+      endpoint: "http://localhost:8080",
+      credentials: credentials,
+      quotaProject: "client-project"
+    )
+    let req2 = try await clientWithQuota.newRequest(path: "/test", query: [])
+    #expect(req2.headers[_HeaderNames.userProject] == ["client-project"])
+
+    // 3. RequestOptions.quotaProject overrides both ClientOptions.quotaProject and credential header
+    let reqOptions = RequestOptions().with { $0.quotaProject = "request-project" }
+    let req3 = try await clientWithQuota.newRequest(path: "/test", query: [], options: reqOptions)
+    #expect(req3.headers[_HeaderNames.userProject] == ["request-project"])
+  }
+
   /// A test response type.
   struct ResponseType: Codable, Equatable, Sendable {
     public let name: String

--- a/packages/swift-google-gax/Tests/HTTPClientTests.swift
+++ b/packages/swift-google-gax/Tests/HTTPClientTests.swift
@@ -620,14 +620,23 @@ import NIOHTTP1
     #expect(response.status == .ok)
   }
 
-  @Test func quotaProjectPrecedence() async throws {
-    let credentials = MockCredentials([
-      { [("Authorization", "Bearer token"), ("x-goog-user-project", "cred-project")] },
-      { [("Authorization", "Bearer token"), ("x-goog-user-project", "cred-project")] },
-      { [("Authorization", "Bearer token"), ("x-goog-user-project", "cred-project")] },
-    ])
-
-    let mock = MockHTTPClient { (request, _) in
+  @Test(arguments: [
+    // Credentials quota project used when neither client nor request options set quotaProject
+    (clientQuota: nil as String?, requestQuota: nil as String?, expected: "cred-project"),
+    // ClientOptions.quotaProject overrides credential header without duplication
+    (clientQuota: "client-project", requestQuota: nil, expected: "client-project"),
+    // RequestOptions.quotaProject overrides both ClientOptions.quotaProject and credential header
+    (clientQuota: "client-project", requestQuota: "request-project", expected: "request-project"),
+  ])
+  func quotaProjectPrecedence(
+    clientQuota: String?,
+    requestQuota: String?,
+    expected: String
+  ) async throws {
+    let credentials = MockCredentials {
+      [("Authorization", "Bearer token"), ("x-goog-user-project", "cred-project")]
+    }
+    let mock = MockHTTPClient { (_, _) in
       HTTPClientResponse(
         version: .http1_1,
         status: .ok,
@@ -635,26 +644,17 @@ import NIOHTTP1
       )
     }
 
-    // 1. Credentials quota project used when neither client nor request options set quotaProject
-    let clientDefault = try _HTTPClient(
-      mock, endpoint: "http://localhost:8080", credentials: credentials)
-    let req1 = try await clientDefault.newRequest(path: "/test", query: [])
-    #expect(req1.headers[_HeaderNames.userProject] == ["cred-project"])
-
-    // 2. ClientOptions.quotaProject overrides credential header without duplication
-    let clientWithQuota = try _HTTPClient(
+    let client = try _HTTPClient(
       mock,
       endpoint: "http://localhost:8080",
       credentials: credentials,
-      quotaProject: "client-project"
+      quotaProject: clientQuota
     )
-    let req2 = try await clientWithQuota.newRequest(path: "/test", query: [])
-    #expect(req2.headers[_HeaderNames.userProject] == ["client-project"])
+    var options = RequestOptions()
+    options.quotaProject = requestQuota
 
-    // 3. RequestOptions.quotaProject overrides both ClientOptions.quotaProject and credential header
-    let reqOptions = RequestOptions().with { $0.quotaProject = "request-project" }
-    let req3 = try await clientWithQuota.newRequest(path: "/test", query: [], options: reqOptions)
-    #expect(req3.headers[_HeaderNames.userProject] == ["request-project"])
+    let request = try await client.newRequest(path: "/test", query: [], options: options)
+    #expect(request.headers[_HeaderNames.userProject] == [expected])
   }
 
   /// A test response type.

--- a/packages/swift-google-gax/Tests/HTTPClientTests.swift
+++ b/packages/swift-google-gax/Tests/HTTPClientTests.swift
@@ -633,9 +633,9 @@ import NIOHTTP1
     requestQuota: String?,
     expected: String
   ) async throws {
-    let credentials = MockCredentials {
-      [("Authorization", "Bearer token"), ("x-goog-user-project", "cred-project")]
-    }
+    let credentials = MockCredentials([
+      { [("Authorization", "Bearer token"), ("x-goog-user-project", "cred-project")] }
+    ])
     let mock = MockHTTPClient { (_, _) in
       HTTPClientResponse(
         version: .http1_1,

--- a/packages/swift-google-gax/Tests/RequestOptionsTests.swift
+++ b/packages/swift-google-gax/Tests/RequestOptionsTests.swift
@@ -22,12 +22,17 @@ import GoogleCloudGax
 
 @Suite struct RequestOptionsTests {
   @Test func then() {
-    let got = RequestOptions().with { $0.attemptTimeout = .seconds(3) }
+    let got = RequestOptions().with {
+      $0.attemptTimeout = .seconds(3)
+      $0.quotaProject = "my-quota-project"
+    }
     #expect(got.attemptTimeout == .seconds(3))
+    #expect(got.quotaProject == "my-quota-project")
   }
 
   @Test func defaults() {
     let got = RequestOptions()
     #expect(got.attemptTimeout == nil)
+    #expect(got.quotaProject == nil)
   }
 }


### PR DESCRIPTION
Towards #785