### PR TITLE
feat(gax): retry attempt timeout

### DIFF
--- a/packages/swift-google-gax/Sources/GoogleCloudGax/RetryLoop.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/RetryLoop.swift
@@ -27,18 +27,21 @@ import Foundation
   let backoffPolicy: any BackoffPolicy
   let retryThrottler: any RetryThrottler
   let idempotent: Bool
+  let attemptTimeout: Duration?
 
   /// A simple constructor for tests.
   public init(
     retryPolicy: any RetryPolicy,
     backoffPolicy: any BackoffPolicy,
     retryThrottler: any RetryThrottler,
-    idempotent: Bool
+    idempotent: Bool,
+    attemptTimeout: Duration? = nil
   ) {
     self.retryPolicy = retryPolicy
     self.backoffPolicy = backoffPolicy
     self.retryThrottler = retryThrottler
     self.idempotent = idempotent
+    self.attemptTimeout = attemptTimeout
   }
 
   /// Initializes a retry loop for the retry stub.
@@ -50,6 +53,7 @@ import Foundation
     self.backoffPolicy = options.backoffPolicy ?? withDefault.backoffPolicy
     self.retryThrottler = options.retryThrottler ?? withDefault.retryThrottler
     self.idempotent = options.idempotency ?? idempotent
+    self.attemptTimeout = options.attemptTimeout
   }
 
   /// Runs the retry loop.
@@ -116,8 +120,13 @@ import Foundation
       attemptCount += 1
       state.attemptCount = attemptCount
 
+      let timeout = Self.effectiveTimeout(
+        attemptTimeout: attemptTimeout,
+        remainingTime: remainingTime
+      )
+
       do {
-        let response = try await inner(remainingTime)
+        let response = try await inner(timeout)
         retryThrottler.onSuccess()
         return response
       } catch {
@@ -136,6 +145,22 @@ import Foundation
           continue
         }
       }
+    }
+  }
+
+  static func effectiveTimeout(
+    attemptTimeout: Duration?,
+    remainingTime: Duration?
+  ) -> Duration? {
+    switch (attemptTimeout, remainingTime) {
+    case (.some(let attempt), .some(let remaining)):
+      min(attempt, remaining)
+    case (.some(let attempt), .none):
+      attempt
+    case (.none, .some(let remaining)):
+      remaining
+    case (.none, .none):
+      nil
     }
   }
 }

--- a/packages/swift-google-gax/Tests/RetryLoopTests.swift
+++ b/packages/swift-google-gax/Tests/RetryLoopTests.swift
@@ -91,6 +91,147 @@ import Testing
     #expect(loop.idempotent == want)
   }
 
+  @Test(arguments: [
+    (nil, nil, nil),
+    (Duration.seconds(4), nil, Duration.seconds(4)),
+    (nil, Duration.seconds(4), Duration.seconds(4)),
+    (Duration.seconds(2), Duration.seconds(4), Duration.seconds(2)),
+    (Duration.seconds(4), Duration.seconds(2), Duration.seconds(2)),
+    (Duration.seconds(2), Duration.seconds(2), Duration.seconds(2)),
+  ])
+  func effectiveTimeouts(
+    attempt: Duration?,
+    remaining: Duration?,
+    want: Duration?
+  ) {
+    let got = _RetryLoop.effectiveTimeout(attemptTimeout: attempt, remainingTime: remaining)
+    #expect(got == want)
+  }
+
+  @Test func attemptTimeoutFromRequest() {
+    let defaultOptions = ClientOptions()
+    let requestOptions = RequestOptions().with { $0.attemptTimeout = .seconds(5) }
+    let loop = _RetryLoop(options: requestOptions, withDefault: defaultOptions, idempotent: true)
+    #expect(loop.attemptTimeout == .seconds(5))
+  }
+
+  @Test func attemptTimeoutDefaultWhenNil() {
+    let defaultOptions = ClientOptions()
+    let requestOptions = RequestOptions()
+    let loop = _RetryLoop(options: requestOptions, withDefault: defaultOptions, idempotent: true)
+    #expect(loop.attemptTimeout == nil)
+  }
+
+  @Test func attemptTimeoutPassedToInner() async throws {
+    let loop = _RetryLoop(
+      retryPolicy: MockPolicy(
+        onError: { _, e in .retry(e) },
+        remainingTime: { _ in .seconds(60) }
+      ),
+      backoffPolicy: MockBackoff(),
+      retryThrottler: MockThrottler(),
+      idempotent: true,
+      attemptTimeout: .seconds(5)
+    )
+
+    var capturedTimeout: Duration?
+    let response = try await loop.run(
+      inner: { timeout in
+        capturedTimeout = timeout
+        return "success"
+      },
+      sleep: { _ in }
+    )
+
+    #expect(response == "success")
+    #expect(capturedTimeout == .seconds(5))
+  }
+
+  @Test func remainingTimeUsedWhenSmallerThanAttemptTimeout() async throws {
+    let loop = _RetryLoop(
+      retryPolicy: MockPolicy(
+        onError: { _, e in .retry(e) },
+        remainingTime: { _ in .seconds(2) }
+      ),
+      backoffPolicy: MockBackoff(),
+      retryThrottler: MockThrottler(),
+      idempotent: true,
+      attemptTimeout: .seconds(5)
+    )
+
+    var capturedTimeout: Duration?
+    let response = try await loop.run(
+      inner: { timeout in
+        capturedTimeout = timeout
+        return "success"
+      },
+      sleep: { _ in }
+    )
+
+    #expect(response == "success")
+    #expect(capturedTimeout == .seconds(2))
+  }
+
+  @Test func attemptTimeoutUsedWhenPolicyHasNoTimeLimit() async throws {
+    let loop = _RetryLoop(
+      retryPolicy: MockPolicy(
+        onError: { _, e in .retry(e) },
+        remainingTime: { _ in nil }
+      ),
+      backoffPolicy: MockBackoff(),
+      retryThrottler: MockThrottler(),
+      idempotent: true,
+      attemptTimeout: .seconds(5)
+    )
+
+    var capturedTimeout: Duration?
+    let response = try await loop.run(
+      inner: { timeout in
+        capturedTimeout = timeout
+        return "success"
+      },
+      sleep: { _ in }
+    )
+
+    #expect(response == "success")
+    #expect(capturedTimeout == .seconds(5))
+  }
+
+  @Test func timeoutDynamicallyAdjustsAcrossAttempts() async throws {
+    let transientError = transient()
+    let remainingTimeValues: [Duration?] = [.seconds(10), .seconds(3)]
+    let remainingTimeIndex = AtomicCounter()
+    var capturedTimeouts: [Duration?] = []
+
+    let loop = _RetryLoop(
+      retryPolicy: MockPolicy(
+        onError: { _, e in .retry(e) },
+        remainingTime: { _ in
+          let index = remainingTimeIndex.increment()
+          return index < remainingTimeValues.count ? remainingTimeValues[index] : nil
+        }
+      ),
+      backoffPolicy: MockBackoff(),
+      retryThrottler: MockThrottler(),
+      idempotent: true,
+      attemptTimeout: .seconds(5)
+    )
+
+    let response = try await loop.run(
+      inner: { timeout in
+        capturedTimeouts.append(timeout)
+        if capturedTimeouts.count == 1 {
+          throw transientError
+        }
+        return "success"
+      },
+      sleep: { _ in }
+    )
+
+    #expect(response == "success")
+    #expect(capturedTimeouts == [.seconds(5), .seconds(3)])
+  }
+
   @Test func immediateSuccess() async throws {
     let loop = _RetryLoop(
       retryPolicy: MockPolicy(onError: { _, e in .retry(e) }),


### PR DESCRIPTION
Use the minimum of the retry loop remaining time and the request timeout before sending the request.

Fixes #441 