### PR TITLE
feat(gax): host header and endpoints

### DIFF
--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient.swift
@@ -40,7 +40,8 @@ public final class StorageClient: StorageProtocol, Sendable {
     let endpoint = options.client.endpoint ?? Self.defaultEndpoint
     self.options = options
     self.inner = try GoogleCloudGax._HTTPClient(
-      mock, endpoint: endpoint, credentials: options.client.credentials)
+      mock, endpoint: endpoint, credentials: options.client.credentials,
+      defaultEndpoint: Self.defaultEndpoint)
   }
 
   @_spi(GoogleCloudInternal) public init(

--- a/pkgs/swift-google-cloud-storage/Tests/StorageClientTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/StorageClientTests.swift
@@ -36,4 +36,86 @@ import Testing
   @Test func clientIsSendable() {
     Self.assertSendable(StorageClient.self)
   }
+
+  @Test(arguments: [
+    ("https://private.googleapis.com", "storage.googleapis.com"),
+    ("https://my-psc.p.googleapis.com", "storage.googleapis.com"),
+    ("https://restricted.googleapis.com", "storage.googleapis.com"),
+    ("https://storage.us-central1.rep.googleapis.com", "storage.us-central1.rep.googleapis.com"),
+    ("https://us-central1-storage.googleapis.com", "us-central1-storage.googleapis.com"),
+    ("https://storage.googleapis.com", "storage.googleapis.com"),
+  ]) func hostHeaderWithEndpoint(endpoint: String, expectedHost: String) async throws {
+    let registry = MockRegistry.create()
+    let requestUrl = "\(endpoint)/storage/v1/b/test-bucket/o/test-obj?alt=media"
+    registry.register(
+      response: .success(statusCode: 200, data: Data("data".utf8)),
+      for: requestUrl
+    )
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = endpoint
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+    let client = try StorageClient(options, mock: registry)
+    let task = client.readObject(from: "test-bucket", object: "test-obj")
+    _ = try await task.metadata
+
+    let request = registry.lastRequest(for: requestUrl)
+    #expect(request?.value(forHTTPHeaderField: "Host") == expectedHost)
+  }
+
+  @Test func hostHeaderWithUniverseDomain() async throws {
+    let registry = MockRegistry.create()
+    let requestUrl =
+      "https://storage.my-universe.com/storage/v1/b/test-bucket/o/test-obj?alt=media"
+    registry.register(
+      response: .success(statusCode: 200, data: Data("data".utf8)),
+      for: requestUrl
+    )
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = "https://storage.my-universe.com"
+        $0.universeDomain = "my-universe.com"
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+    let client = try StorageClient(options, mock: registry)
+    let task = client.readObject(from: "test-bucket", object: "test-obj")
+    _ = try await task.metadata
+
+    let request = registry.lastRequest(for: requestUrl)
+    #expect(request?.value(forHTTPHeaderField: "Host") == "storage.my-universe.com")
+  }
+
+  @Test func uploadHostHeaderWithOddEndpoint() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-obj"
+    let endpoint = "https://private.googleapis.com"
+    let uploadUrl =
+      "\(endpoint)/upload/storage/v1/b/\(bucket)/o?uploadType=multipart&name=\(objectName)"
+
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data("{\"name\":\"\(objectName)\"}".utf8),
+        headers: ["Content-Type": "application/json"]),
+      for: uploadUrl
+    )
+
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = endpoint
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+    let client = try StorageClient(options, mock: registry)
+    let data = Data("hello world".utf8)
+    _ = try await client.upload(data, to: bucket, as: objectName)
+
+    let request = registry.lastRequest(for: uploadUrl)
+    #expect(request?.value(forHTTPHeaderField: "Host") == "storage.googleapis.com")
+  }
 }

--- a/pkgs/swift-google-cloud-storage/Tests/StorageControlClientTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/StorageControlClientTests.swift
@@ -56,6 +56,20 @@ import Testing
       $0.endpoint = "custom.endpoint.com:443"
     }
     let _ = try StorageControlClient(bareOptions)
+
+    // With universe domain
+    let universeOptions = ClientOptions().with {
+      $0.credentials = credentials
+      $0.universeDomain = "my-universe.com"
+    }
+    let _ = try StorageControlClient(universeOptions)
+
+    // With VPC-SC odd endpoint
+    let oddEndpointOptions = ClientOptions().with {
+      $0.credentials = credentials
+      $0.endpoint = "https://private.googleapis.com"
+    }
+    let _ = try StorageControlClient(oddEndpointOptions)
   }
 
   @Test(arguments: [

--- a/pkgs/swift-google-gax/Sources/GoogleCloudGax/ClientOptions.swift
+++ b/pkgs/swift-google-gax/Sources/GoogleCloudGax/ClientOptions.swift
@@ -49,6 +49,11 @@ public struct ClientOptions: Sendable {
   /// and/or query parameters have no effect.
   public var endpoint: String? = nil
 
+  /// Overrides the default universe domain for the client.
+  ///
+  /// The default universe domain is `"googleapis.com"`.
+  public var universeDomain: String? = nil
+
   /// Overrides the default credentials for the client.
   ///
   /// `Credentials` defines how the client authenticates to Google Cloud APIs. Without an override, the client uses

--- a/pkgs/swift-google-gax/Sources/GoogleCloudGax/HTTPClient.swift
+++ b/pkgs/swift-google-gax/Sources/GoogleCloudGax/HTTPClient.swift
@@ -26,6 +26,7 @@ import struct Logging.Logger
   let logger: Logger?
   let quotaProject: String?
   let inner: any _HTTPClientProtocol
+  let hostHeader: String
 
   // Creates a new client.
   public init(from: ClientOptions, withDefaultEndpoint: String) throws {
@@ -34,6 +35,11 @@ import struct Logging.Logger
     self.quotaProject = from.quotaProject
     let endpoint = from.endpoint ?? withDefaultEndpoint
     self.baseURL = try Self.validateEndpoint(endpoint)
+    self.hostHeader = try _Host.header(
+      endpoint: from.endpoint,
+      defaultEndpoint: withDefaultEndpoint,
+      universeDomain: from.universeDomain ?? _Host.defaultUniverseDomain
+    )
     self.inner = HTTPClientHolder()
   }
 
@@ -42,13 +48,18 @@ import struct Logging.Logger
     _ inner: any _HTTPClientProtocol, endpoint: String,
     credentials: (any _CredentialsProtocol)? = nil,
     logger: Logging.Logger? = nil,
-    quotaProject: String? = nil
+    quotaProject: String? = nil,
+    defaultEndpoint: String? = nil
   ) throws {
     self.baseURL = try Self.validateEndpoint(endpoint)
     self.credentials = try credentials ?? GoogleCloudAuth.Credentials(configuration: .anonymous)
     self.logger = logger
     self.quotaProject = quotaProject
     self.inner = inner
+    self.hostHeader = try _Host.header(
+      endpoint: endpoint,
+      defaultEndpoint: defaultEndpoint ?? endpoint
+    )
   }
 
   @_spi(GoogleCloudInternal) public static func validateEndpoint(_ endpoint: String) throws
@@ -86,6 +97,7 @@ import struct Logging.Logger
     if let effectiveQuotaProject = options.quotaProject ?? self.quotaProject {
       request.setHeader(name: _HeaderNames.userProject, value: effectiveQuotaProject)
     }
+    request.setHeader(name: _HeaderNames.host, value: self.hostHeader)
     return request
   }
 
@@ -109,6 +121,7 @@ import struct Logging.Logger
     if let effectiveQuotaProject = options.quotaProject ?? self.quotaProject {
       request.setHeader(name: _HeaderNames.userProject, value: effectiveQuotaProject)
     }
+    request.setHeader(name: _HeaderNames.host, value: self.hostHeader)
     return request
   }
 
@@ -124,6 +137,7 @@ import struct Logging.Logger
     if let effectiveQuotaProject = options.quotaProject ?? self.quotaProject {
       request.setHeader(name: _HeaderNames.userProject, value: effectiveQuotaProject)
     }
+    request.setHeader(name: _HeaderNames.host, value: self.hostHeader)
     return request
   }
 

--- a/pkgs/swift-google-gax/Sources/GoogleCloudGax/HeaderNames.swift
+++ b/pkgs/swift-google-gax/Sources/GoogleCloudGax/HeaderNames.swift
@@ -20,4 +20,5 @@ public enum _HeaderNames {
   public static let apiClient = "x-goog-api-client"
   public static let requestParams = "x-goog-request-params"
   public static let userProject = "x-goog-user-project"
+  public static let host = "Host"
 }

--- a/pkgs/swift-google-gax/Sources/GoogleCloudGax/Host.swift
+++ b/pkgs/swift-google-gax/Sources/GoogleCloudGax/Host.swift
@@ -1,0 +1,139 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Helper to calculate the host header and gRPC authority given an endpoint and default endpoint.
+@_spi(GoogleCloudInternal)
+public enum _Host {
+  public static let defaultUniverseDomain = "googleapis.com"
+  private static let defaultSuffix = ".\(defaultUniverseDomain)"
+
+  /// Calculate the HTTP `Host` header given the custom endpoint, default endpoint, and universe domain.
+  ///
+  /// Regional and locational endpoints matching the service are detected and used as the host.
+  /// For VIPs, PSC, and private networks (such as `private.googleapis.com`), the service host is used.
+  public static func header(
+    endpoint: String?,
+    defaultEndpoint: String,
+    universeDomain: String = defaultUniverseDomain
+  ) throws -> String {
+    try originAndHeader(
+      endpoint: endpoint,
+      defaultEndpoint: defaultEndpoint,
+      universeDomain: universeDomain
+    ).header
+  }
+
+  /// Calculate the gRPC authority given the custom endpoint, default endpoint, and universe domain.
+  public static func authority(
+    endpoint: String?,
+    defaultEndpoint: String,
+    universeDomain: String = defaultUniverseDomain
+  ) throws -> String {
+    try originAndHeader(
+      endpoint: endpoint,
+      defaultEndpoint: defaultEndpoint,
+      universeDomain: universeDomain
+    ).authority
+  }
+
+  private static func normalizeEndpoint(_ endpoint: String) -> String {
+    endpoint.contains("://") ? endpoint : "https://\(endpoint)"
+  }
+
+  private static func originAndHeader(
+    endpoint: String?,
+    defaultEndpoint: String,
+    universeDomain: String
+  ) throws -> (authority: String, header: String) {
+    if defaultEndpoint.hasPrefix("/") {
+      throw ClientError.invalidEndpoint(defaultEndpoint)
+    }
+
+    guard let defaultComponents = URLComponents(string: normalizeEndpoint(defaultEndpoint)),
+      let defaultHost = defaultComponents.host, !defaultHost.isEmpty
+    else {
+      throw ClientError.invalidEndpoint(defaultEndpoint)
+    }
+
+    guard defaultHost.hasSuffix(defaultSuffix) else {
+      // Emulators, endpoint showcase and/or test servers pass localhost and
+      // should fallback to use the passed-in service host.
+      let authority = defaultComponents.port.map { "\(defaultHost):\($0)" } ?? defaultHost
+      return (authority: authority, header: defaultHost)
+    }
+
+    let service = String(defaultHost.dropLast(defaultSuffix.count))
+    guard !service.isEmpty else {
+      let authority = defaultComponents.port.map { "\(defaultHost):\($0)" } ?? defaultHost
+      return (authority: authority, header: defaultHost)
+    }
+
+    guard let endpoint = endpoint, !endpoint.isEmpty else {
+      // No endpoint provided, use the default service host at the universe domain.
+      let host = "\(service).\(universeDomain)"
+      return (authority: host, header: host)
+    }
+
+    if endpoint.hasPrefix("/") {
+      throw ClientError.invalidEndpoint(endpoint)
+    }
+
+    guard let customComponents = URLComponents(string: normalizeEndpoint(endpoint)),
+      let customHost = customComponents.host, !customHost.isEmpty
+    else {
+      throw ClientError.invalidEndpoint(endpoint)
+    }
+
+    let universeSuffix = ".\(universeDomain)"
+    let prefix: String
+    let effectiveUniverseDomain: String
+
+    if customHost.hasSuffix(universeSuffix) {
+      prefix = String(customHost.dropLast(universeSuffix.count))
+      effectiveUniverseDomain = universeDomain
+    } else if customHost.hasSuffix(defaultSuffix) {
+      prefix = String(customHost.dropLast(defaultSuffix.count))
+      effectiveUniverseDomain = defaultUniverseDomain
+    } else {
+      // Not a GCP universe domain. Use the endpoint override.
+      let authority = customComponents.port.map { "\(customHost):\($0)" } ?? customHost
+      return (authority: authority, header: customHost)
+    }
+
+    let parts = prefix.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+    switch parts.count {
+    case 3 where parts[2] == "rep" && parts[0] == service:
+      // This is a regional endpoint: `{service}.{region}.rep.googleapis.com`.
+      return (authority: customHost, header: customHost)
+    case 1:
+      // This is a locational endpoint: `{region}-{service}.googleapis.com`.
+      let location = parts[0]
+      if location.hasSuffix("-\(service)") {
+        let region = String(location.dropLast("-\(service)".count))
+        if !region.isEmpty {
+          return (authority: customHost, header: customHost)
+        }
+      }
+      // Fallback for VPC-SC / PSC or non-matching service
+      let fallback = "\(service).\(effectiveUniverseDomain)"
+      return (authority: fallback, header: fallback)
+    default:
+      // Fallback for VPC-SC / PSC
+      let fallback = "\(service).\(effectiveUniverseDomain)"
+      return (authority: fallback, header: fallback)
+    }
+  }
+}

--- a/pkgs/swift-google-gax/Sources/GoogleCloudGaxGRPC/GRPCClient.swift
+++ b/pkgs/swift-google-gax/Sources/GoogleCloudGaxGRPC/GRPCClient.swift
@@ -60,9 +60,18 @@ public final class _GRPCClient: Sendable {
     let transportSecurity: HTTP2ClientTransport.Posix.TransportSecurity =
       isSecure ? .tls : .plaintext
 
+    let authority = try _Host.authority(
+      endpoint: options.endpoint,
+      defaultEndpoint: defaultEndpoint,
+      universeDomain: options.universeDomain ?? _Host.defaultUniverseDomain
+    )
+
     let transport = try HTTP2ClientTransport.Posix(
       target: .dns(host: host, port: port),
-      transportSecurity: transportSecurity
+      transportSecurity: transportSecurity,
+      config: .defaults {
+        $0.http2.authority = authority
+      }
     )
 
     let client = GRPCClient(transport: transport)

--- a/pkgs/swift-google-gax/Tests/ClientOptionsTests.swift
+++ b/pkgs/swift-google-gax/Tests/ClientOptionsTests.swift
@@ -25,9 +25,12 @@ import GoogleCloudGax
     let got = ClientOptions().with {
       $0.endpoint = "test-only"
       $0.quotaProject = "my-quota-project"
+      $0.universeDomain = "my-universe.com"
     }
     #expect(got.endpoint == "test-only")
     #expect(got.quotaProject == "my-quota-project")
+    #expect(got.endpoint == "test-only")
+    #expect(got.universeDomain == "my-universe.com")
     #expect(got.credentials == nil)
   }
 
@@ -35,6 +38,7 @@ import GoogleCloudGax
     let got = ClientOptions()
     #expect(got.endpoint == nil)
     #expect(got.quotaProject == nil)
+    #expect(got.universeDomain == nil)
     #expect(got.credentials == nil)
     #expect(got.retryPolicy == nil)
   }

--- a/pkgs/swift-google-gax/Tests/GRPCClientTests.swift
+++ b/pkgs/swift-google-gax/Tests/GRPCClientTests.swift
@@ -56,6 +56,43 @@ import GoogleCloudGax
     let bareClient = try _GRPCClient(
       from: bareOptions, withDefaultEndpoint: "https://storage.googleapis.com")
     bareClient.close()
+
+    // VPC-SC private endpoint
+    let privateOptions = ClientOptions().with {
+      $0.credentials = credentials
+      $0.endpoint = "https://private.googleapis.com"
+    }
+    let privateClient = try _GRPCClient(
+      from: privateOptions, withDefaultEndpoint: "https://storage.googleapis.com")
+    privateClient.close()
+
+    // Regional endpoint
+    let regionalOptions = ClientOptions().with {
+      $0.credentials = credentials
+      $0.endpoint = "https://storage.us-central1.rep.googleapis.com"
+    }
+    let regionalClient = try _GRPCClient(
+      from: regionalOptions, withDefaultEndpoint: "https://storage.googleapis.com")
+    regionalClient.close()
+
+    // Locational endpoint
+    let locationalOptions = ClientOptions().with {
+      $0.credentials = credentials
+      $0.endpoint = "https://us-central1-storage.googleapis.com"
+    }
+    let locationalClient = try _GRPCClient(
+      from: locationalOptions, withDefaultEndpoint: "https://storage.googleapis.com")
+    locationalClient.close()
+
+    // Universe domain
+    let universeOptions = ClientOptions().with {
+      $0.credentials = credentials
+      $0.universeDomain = "my-universe.com"
+      $0.endpoint = "https://storage.my-universe.com"
+    }
+    let universeClient = try _GRPCClient(
+      from: universeOptions, withDefaultEndpoint: "https://storage.googleapis.com")
+    universeClient.close()
   }
 
   @Test(arguments: [

--- a/pkgs/swift-google-gax/Tests/HTTPClientTests.swift
+++ b/pkgs/swift-google-gax/Tests/HTTPClientTests.swift
@@ -657,6 +657,88 @@ import NIOHTTP1
     #expect(request.headers[_HeaderNames.userProject] == [expected])
   }
 
+  @Test func hostHeaderDefaultEndpoint() async throws {
+    let mock = MockHTTPClient { (request, _) in
+      #expect(request.headers.first(name: "Host") == "secretmanager.googleapis.com")
+      return HTTPClientResponse(
+        version: .http1_1,
+        status: .ok,
+        body: .bytes(.init(string: "{}"))
+      )
+    }
+
+    let client = try _HTTPClient(
+      mock,
+      endpoint: "https://secretmanager.googleapis.com",
+      defaultEndpoint: "https://secretmanager.googleapis.com"
+    )
+    let request = try await client.newRequest(path: "/v1/projects/p/secrets", query: [])
+    let response = try await request.execute()
+    #expect(response.status == .ok)
+  }
+
+  @Test func hostHeaderPrivateEndpointOverride() async throws {
+    let mock = MockHTTPClient { (request, _) in
+      #expect(request.headers.first(name: "Host") == "secretmanager.googleapis.com")
+      #expect(request.url == "https://private.googleapis.com/v1/projects/p/secrets")
+      return HTTPClientResponse(
+        version: .http1_1,
+        status: .ok,
+        body: .bytes(.init(string: "{}"))
+      )
+    }
+    let client = try _HTTPClient(
+      mock,
+      endpoint: "https://private.googleapis.com",
+      defaultEndpoint: "https://secretmanager.googleapis.com"
+    )
+    let request = try await client.newRequest(path: "/v1/projects/p/secrets", query: [])
+    let response = try await request.execute()
+    #expect(response.status == .ok)
+  }
+
+  @Test func hostHeaderRegionalEndpointOverride() async throws {
+    let mock = MockHTTPClient { (request, _) in
+      #expect(request.headers.first(name: "Host") == "secretmanager.us-central1.rep.googleapis.com")
+      #expect(
+        request.url == "https://secretmanager.us-central1.rep.googleapis.com/v1/projects/p/secrets")
+      return HTTPClientResponse(
+        version: .http1_1,
+        status: .ok,
+        body: .bytes(.init(string: "{}"))
+      )
+    }
+    let client = try _HTTPClient(
+      mock,
+      endpoint: "https://secretmanager.us-central1.rep.googleapis.com",
+      defaultEndpoint: "https://secretmanager.googleapis.com"
+    )
+    let request = try await client.newRequest(path: "/v1/projects/p/secrets", query: [])
+    let response = try await request.execute()
+    #expect(response.status == .ok)
+  }
+
+  @Test func hostHeaderLocationalEndpointOverride() async throws {
+    let mock = MockHTTPClient { (request, _) in
+      #expect(request.headers.first(name: "Host") == "us-central1-secretmanager.googleapis.com")
+      #expect(
+        request.url == "https://us-central1-secretmanager.googleapis.com/v1/projects/p/secrets")
+      return HTTPClientResponse(
+        version: .http1_1,
+        status: .ok,
+        body: .bytes(.init(string: "{}"))
+      )
+    }
+    let client = try _HTTPClient(
+      mock,
+      endpoint: "https://us-central1-secretmanager.googleapis.com",
+      defaultEndpoint: "https://secretmanager.googleapis.com"
+    )
+    let request = try await client.newRequest(path: "/v1/projects/p/secrets", query: [])
+    let response = try await request.execute()
+    #expect(response.status == .ok)
+  }
+
   /// A test response type.
   struct ResponseType: Codable, Equatable, Sendable {
     public let name: String

--- a/pkgs/swift-google-gax/Tests/HostTests.swift
+++ b/pkgs/swift-google-gax/Tests/HostTests.swift
@@ -1,0 +1,154 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+@_spi(GoogleCloudInternal) @testable import GoogleCloudGax
+
+@Suite struct HostTests {
+  @Test(arguments: [
+    ("http://www.googleapis.com", "test.googleapis.com"),
+    ("http://private.googleapis.com", "test.googleapis.com"),
+    ("http://restricted.googleapis.com", "test.googleapis.com"),
+    ("http://test-my-private-ep.p.googleapis.com", "test.googleapis.com"),
+    ("https://us-central1-test.googleapis.com", "us-central1-test.googleapis.com"),
+    ("https://us-central1-wrong.googleapis.com", "test.googleapis.com"),
+    ("https://us-central1test.googleapis.com", "test.googleapis.com"),
+    ("https://-test.googleapis.com", "test.googleapis.com"),
+    ("https://test.us-central1.rep.googleapis.com", "test.us-central1.rep.googleapis.com"),
+    ("https://test.my-universe-domain.com", "test.my-universe-domain.com"),
+    ("localhost:5678", "localhost"),
+    ("https://localhost:5678", "localhost"),
+  ]) func headerSuccess(input: String, want: String) throws {
+    let got = try _Host.header(
+      endpoint: input,
+      defaultEndpoint: "https://test.googleapis.com"
+    )
+    #expect(got == want)
+  }
+
+  @Test(arguments: [
+    ("https://service.googleapis.com", "service.googleapis.com"),
+    ("http://service.googleapis.com", "service.googleapis.com"),
+    ("https://storage.googleapis.com/", "storage.googleapis.com"),
+    ("http://storage.googleapis.com/", "storage.googleapis.com"),
+    ("test.googleapis.com", "test.googleapis.com"),
+    ("localhost:5678", "localhost"),
+    ("https://localhost:5678", "localhost"),
+  ]) func headerDefault(input: String, want: String) throws {
+    let got = try _Host.header(endpoint: nil, defaultEndpoint: input)
+    #expect(got == want)
+  }
+
+  @Test(arguments: [
+    ("http://www.my-custom-universe.com", "test.my-custom-universe.com"),
+    ("https://test.my-custom-universe.com", "test.my-custom-universe.com"),
+    ("http://private.my-custom-universe.com", "test.my-custom-universe.com"),
+    ("http://restricted.my-custom-universe.com", "test.my-custom-universe.com"),
+    ("http://test-my-private-ep.p.my-custom-universe.com", "test.my-custom-universe.com"),
+    ("https://us-central1-test.my-custom-universe.com", "us-central1-test.my-custom-universe.com"),
+    (
+      "https://test.us-central1.rep.my-custom-universe.com",
+      "test.us-central1.rep.my-custom-universe.com"
+    ),
+    ("https://www.googleapis.com", "test.googleapis.com"),
+    ("https://private.googleapis.com", "test.googleapis.com"),
+    ("https://restricted.googleapis.com", "test.googleapis.com"),
+    ("https://test.googleapis.com", "test.googleapis.com"),
+    ("https://us-central1-test.googleapis.com", "us-central1-test.googleapis.com"),
+  ]) func headerUniverseDomain(input: String, want: String) throws {
+    let got = try _Host.header(
+      endpoint: input,
+      defaultEndpoint: "https://test.googleapis.com",
+      universeDomain: "my-custom-universe.com"
+    )
+    #expect(got == want)
+  }
+
+  @Test(arguments: [
+    ("http://www.googleapis.com", "test.googleapis.com"),
+    ("http://private.googleapis.com", "test.googleapis.com"),
+    ("http://restricted.googleapis.com", "test.googleapis.com"),
+    ("http://test-my-private-ep.p.googleapis.com", "test.googleapis.com"),
+    ("https://us-central1-test.googleapis.com", "us-central1-test.googleapis.com"),
+    ("https://us-central1-wrong.googleapis.com", "test.googleapis.com"),
+    ("https://us-central1test.googleapis.com", "test.googleapis.com"),
+    ("https://-test.googleapis.com", "test.googleapis.com"),
+    ("https://test.us-central1.rep.googleapis.com", "test.us-central1.rep.googleapis.com"),
+    ("https://test.my-universe-domain.com", "test.my-universe-domain.com"),
+    ("localhost:5678", "localhost:5678"),
+    ("http://localhost:5678", "localhost:5678"),
+  ]) func authoritySuccess(input: String, want: String) throws {
+    let got = try _Host.authority(
+      endpoint: input,
+      defaultEndpoint: "https://test.googleapis.com"
+    )
+    #expect(got == want)
+  }
+
+  @Test(arguments: [
+    ("https://service.googleapis.com", "service.googleapis.com"),
+    ("http://service.googleapis.com", "service.googleapis.com"),
+    ("https://storage.googleapis.com/", "storage.googleapis.com"),
+    ("http://storage.googleapis.com/", "storage.googleapis.com"),
+    ("test.googleapis.com", "test.googleapis.com"),
+    ("https://localhost:5678", "localhost:5678"),
+    ("http://localhost:5678", "localhost:5678"),
+  ]) func authorityDefault(input: String, want: String) throws {
+    let got = try _Host.authority(endpoint: nil, defaultEndpoint: input)
+    #expect(got == want)
+  }
+
+  @Test(arguments: [
+    ("http://www.my-custom-universe.com", "test.my-custom-universe.com"),
+    ("http://private.my-custom-universe.com", "test.my-custom-universe.com"),
+    ("http://restricted.my-custom-universe.com", "test.my-custom-universe.com"),
+    ("http://test-my-private-ep.p.my-custom-universe.com", "test.my-custom-universe.com"),
+    ("https://us-central1-test.my-custom-universe.com", "us-central1-test.my-custom-universe.com"),
+    (
+      "https://test.us-central1.rep.my-custom-universe.com",
+      "test.us-central1.rep.my-custom-universe.com"
+    ),
+  ]) func authorityUniverseDomain(input: String, want: String) throws {
+    let got = try _Host.authority(
+      endpoint: input,
+      defaultEndpoint: "https://test.googleapis.com",
+      universeDomain: "my-custom-universe.com"
+    )
+    #expect(got == want)
+  }
+
+  @Test func errors() {
+    #expect(throws: ClientError.self) {
+      _ = try _Host.header(
+        endpoint: "https:///a/b/c",
+        defaultEndpoint: "https://test.googleapis.com"
+      )
+    }
+
+    #expect(throws: ClientError.self) {
+      _ = try _Host.header(
+        endpoint: "/a/b/c",
+        defaultEndpoint: "https://test.googleapis.com"
+      )
+    }
+
+    #expect(throws: ClientError.self) {
+      _ = try _Host.header(
+        endpoint: nil,
+        defaultEndpoint: "https:///"
+      )
+    }
+  }
+}


### PR DESCRIPTION
Correctly set the `Host` header for HTTP requests and `:authority` for gRPC connections when using VPC-SC, Private Service Connect (PSC), regional, locational, and universe domain endpoints.

Fixes #445