### PR TITLE
feat(gax): simplify `ProtoJSON` serialization

### DIFF
--- a/Tests/ProtoJSON/FieldsDouble.swift
+++ b/Tests/ProtoJSON/FieldsDouble.swift
@@ -72,4 +72,82 @@ import Testing
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(value(got).map({ $0.isNaN }) ?? false, "got=\(got)")
   }
+
+  @Test(
+    "double fields serialize",
+    arguments: [
+      (
+        #"{"map":{},"repeated":[],"singular":0}"#,
+        T()
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":1.5}"#,
+        T().with { $0.singular = 1.5 }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":"Infinity"}"#,
+        T().with { $0.singular = .infinity }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":"-Infinity"}"#,
+        T().with { $0.singular = -.infinity }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":"NaN"}"#,
+        T().with { $0.singular = .nan }
+      ),
+      (
+        #"{"map":{},"option":"Infinity","repeated":[],"singular":0}"#,
+        T().with { $0.option = .infinity }
+      ),
+      (
+        #"{"map":{},"option":"-Infinity","repeated":[],"singular":0}"#,
+        T().with { $0.option = -.infinity }
+      ),
+      (
+        #"{"map":{},"option":"NaN","repeated":[],"singular":0}"#,
+        T().with { $0.option = .nan }
+      ),
+      (
+        #"{"map":{},"repeated":["Infinity","-Infinity"],"singular":0}"#,
+        T().with { $0.repeated = [.infinity, -.infinity] }
+      ),
+      (
+        #"{"map":{},"repeated":["NaN"],"singular":0}"#,
+        T().with { $0.repeated = [.nan] }
+      ),
+      (
+        #"{"map":{"a":"Infinity"},"repeated":[],"singular":0}"#,
+        T().with { $0.map = ["a": .infinity] }
+      ),
+      (
+        #"{"map":{"a":"-Infinity"},"repeated":[],"singular":0}"#,
+        T().with { $0.map = ["a": -.infinity] }
+      ),
+      (
+        #"{"map":{"a":"NaN"},"repeated":[],"singular":0}"#,
+        T().with { $0.map = ["a": .nan] }
+      ),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    encoder.nonConformingFloatEncodingStrategy = .convertToString(
+      positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN"
+    )
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    let isNaN =
+      input.singular.isNaN || (input.option?.isNaN ?? false)
+      || input.repeated.contains(where: { $0.isNaN })
+      || input.map.values.contains(where: { $0.isNaN })
+    if !isNaN {
+      #expect(input == roundtrip)
+    }
+  }
 }

--- a/Tests/ProtoJSON/FieldsDouble.swift
+++ b/Tests/ProtoJSON/FieldsDouble.swift
@@ -131,11 +131,8 @@ import Testing
     ]
   )
   func serialize(want: String, input: T) throws {
-    let encoder = JSONEncoder()
+    let encoder = _ProtoJSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
-    encoder.nonConformingFloatEncodingStrategy = .convertToString(
-      positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN"
-    )
     let data = try encoder.encode(input)
     let got = String(data: data, encoding: .utf8)!
     #expect(got == want)

--- a/Tests/ProtoJSON/FieldsDoubleValue.swift
+++ b/Tests/ProtoJSON/FieldsDoubleValue.swift
@@ -30,10 +30,106 @@ import Testing
       (#"{"repeated": [4.2]        }"#, T().with { $0.repeated = [4.2] }),
       (#"{"map":      {}           }"#, T()),
       (#"{"map":      {"a": 4.2 }  }"#, T().with { $0.map = ["a": 4.2] }),
+      (#"{"singular": "Infinity"   }"#, T().with { $0.singular = .infinity }),
+      (#"{"singular": "-Infinity"  }"#, T().with { $0.singular = -.infinity }),
+      (
+        #"{"repeated": ["Infinity", "-Infinity"]}"#,
+        T().with { $0.repeated = [.infinity, -.infinity] }
+      ),
+      (#"{"map":      {"a": "Infinity"} }"#, T().with { $0.map = ["a": .infinity] }),
+      (#"{"map":      {"a": "-Infinity"} }"#, T().with { $0.map = ["a": -.infinity] }),
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
+  }
+
+  @Test(
+    "DoubleValue fields deserialize NaN",
+    arguments: [
+      (
+        #"{"singular": "NaN"        }"#,
+        { @Sendable (got: T) -> Float64? in got.singular }
+      ),
+      (
+        #"{"repeated": ["NaN"]      }"#,
+        { @Sendable (got: T) -> Float64? in got.repeated.first }
+      ),
+      (
+        #"{"map":      {"a": "NaN"} }"#,
+        { @Sendable (got: T) -> Float64? in got.map["a"] }
+      ),
+    ]
+  ) func deserializeNaN(input: String, value: @Sendable (T) -> Float64?) throws {
+    let decoder = _ProtoJSONDecoder()
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
+    #expect(value(got).map({ $0.isNaN }) ?? false, "got=\(got)")
+  }
+
+  @Test(
+    "DoubleValue fields serialize",
+    arguments: [
+      (
+        #"{"map":{},"repeated":[]}"#,
+        T()
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":4.2}"#,
+        T().with { $0.singular = 4.2 }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":"Infinity"}"#,
+        T().with { $0.singular = .infinity }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":"-Infinity"}"#,
+        T().with { $0.singular = -.infinity }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":"NaN"}"#,
+        T().with { $0.singular = .nan }
+      ),
+      (
+        #"{"map":{},"repeated":["Infinity","-Infinity"]}"#,
+        T().with { $0.repeated = [.infinity, -.infinity] }
+      ),
+      (
+        #"{"map":{},"repeated":["NaN"]}"#,
+        T().with { $0.repeated = [.nan] }
+      ),
+      (
+        #"{"map":{"a":"Infinity"},"repeated":[]}"#,
+        T().with { $0.map = ["a": .infinity] }
+      ),
+      (
+        #"{"map":{"a":"-Infinity"},"repeated":[]}"#,
+        T().with { $0.map = ["a": -.infinity] }
+      ),
+      (
+        #"{"map":{"a":"NaN"},"repeated":[]}"#,
+        T().with { $0.map = ["a": .nan] }
+      ),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    encoder.nonConformingFloatEncodingStrategy = .convertToString(
+      positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN"
+    )
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    let isNaN =
+      (input.singular?.isNaN ?? false)
+      || input.repeated.contains(where: { $0.isNaN })
+      || input.map.values.contains(where: { $0.isNaN })
+    if !isNaN {
+      #expect(input == roundtrip)
+    }
   }
 }

--- a/Tests/ProtoJSON/FieldsDoubleValue.swift
+++ b/Tests/ProtoJSON/FieldsDoubleValue.swift
@@ -113,11 +113,8 @@ import Testing
     ]
   )
   func serialize(want: String, input: T) throws {
-    let encoder = JSONEncoder()
+    let encoder = _ProtoJSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
-    encoder.nonConformingFloatEncodingStrategy = .convertToString(
-      positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN"
-    )
     let data = try encoder.encode(input)
     let got = String(data: data, encoding: .utf8)!
     #expect(got == want)

--- a/Tests/ProtoJSON/FieldsFloat.swift
+++ b/Tests/ProtoJSON/FieldsFloat.swift
@@ -72,4 +72,82 @@ import Testing
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(value(got).map({ $0.isNaN }) ?? false, "got=\(got)")
   }
+
+  @Test(
+    "float fields serialize",
+    arguments: [
+      (
+        #"{"map":{},"repeated":[],"singular":0}"#,
+        T()
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":1.5}"#,
+        T().with { $0.singular = 1.5 }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":"Infinity"}"#,
+        T().with { $0.singular = .infinity }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":"-Infinity"}"#,
+        T().with { $0.singular = -.infinity }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":"NaN"}"#,
+        T().with { $0.singular = .nan }
+      ),
+      (
+        #"{"map":{},"option":"Infinity","repeated":[],"singular":0}"#,
+        T().with { $0.option = .infinity }
+      ),
+      (
+        #"{"map":{},"option":"-Infinity","repeated":[],"singular":0}"#,
+        T().with { $0.option = -.infinity }
+      ),
+      (
+        #"{"map":{},"option":"NaN","repeated":[],"singular":0}"#,
+        T().with { $0.option = .nan }
+      ),
+      (
+        #"{"map":{},"repeated":["Infinity","-Infinity"],"singular":0}"#,
+        T().with { $0.repeated = [.infinity, -.infinity] }
+      ),
+      (
+        #"{"map":{},"repeated":["NaN"],"singular":0}"#,
+        T().with { $0.repeated = [.nan] }
+      ),
+      (
+        #"{"map":{"a":"Infinity"},"repeated":[],"singular":0}"#,
+        T().with { $0.map = ["a": .infinity] }
+      ),
+      (
+        #"{"map":{"a":"-Infinity"},"repeated":[],"singular":0}"#,
+        T().with { $0.map = ["a": -.infinity] }
+      ),
+      (
+        #"{"map":{"a":"NaN"},"repeated":[],"singular":0}"#,
+        T().with { $0.map = ["a": .nan] }
+      ),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    encoder.nonConformingFloatEncodingStrategy = .convertToString(
+      positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN"
+    )
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    let isNaN =
+      input.singular.isNaN || (input.option?.isNaN ?? false)
+      || input.repeated.contains(where: { $0.isNaN })
+      || input.map.values.contains(where: { $0.isNaN })
+    if !isNaN {
+      #expect(input == roundtrip)
+    }
+  }
 }

--- a/Tests/ProtoJSON/FieldsFloat.swift
+++ b/Tests/ProtoJSON/FieldsFloat.swift
@@ -131,11 +131,8 @@ import Testing
     ]
   )
   func serialize(want: String, input: T) throws {
-    let encoder = JSONEncoder()
+    let encoder = _ProtoJSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
-    encoder.nonConformingFloatEncodingStrategy = .convertToString(
-      positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN"
-    )
     let data = try encoder.encode(input)
     let got = String(data: data, encoding: .utf8)!
     #expect(got == want)

--- a/Tests/ProtoJSON/FieldsFloatValue.swift
+++ b/Tests/ProtoJSON/FieldsFloatValue.swift
@@ -30,10 +30,106 @@ import Testing
       (#"{"repeated": [4.2]        }"#, T().with { $0.repeated = [4.2] }),
       (#"{"map":      {}           }"#, T()),
       (#"{"map":      {"a": 4.2 }  }"#, T().with { $0.map = ["a": 4.2] }),
+      (#"{"singular": "Infinity"   }"#, T().with { $0.singular = .infinity }),
+      (#"{"singular": "-Infinity"  }"#, T().with { $0.singular = -.infinity }),
+      (
+        #"{"repeated": ["Infinity", "-Infinity"]}"#,
+        T().with { $0.repeated = [.infinity, -.infinity] }
+      ),
+      (#"{"map":      {"a": "Infinity"} }"#, T().with { $0.map = ["a": .infinity] }),
+      (#"{"map":      {"a": "-Infinity"} }"#, T().with { $0.map = ["a": -.infinity] }),
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
+  }
+
+  @Test(
+    "FloatValue fields deserialize NaN",
+    arguments: [
+      (
+        #"{"singular": "NaN"        }"#,
+        { @Sendable (got: T) -> Float32? in got.singular }
+      ),
+      (
+        #"{"repeated": ["NaN"]      }"#,
+        { @Sendable (got: T) -> Float32? in got.repeated.first }
+      ),
+      (
+        #"{"map":      {"a": "NaN"} }"#,
+        { @Sendable (got: T) -> Float32? in got.map["a"] }
+      ),
+    ]
+  ) func deserializeNaN(input: String, value: @Sendable (T) -> Float32?) throws {
+    let decoder = _ProtoJSONDecoder()
+    let got = try decoder.decode(T.self, from: Data(input.utf8))
+    #expect(value(got).map({ $0.isNaN }) ?? false, "got=\(got)")
+  }
+
+  @Test(
+    "FloatValue fields serialize",
+    arguments: [
+      (
+        #"{"map":{},"repeated":[]}"#,
+        T()
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":4.2}"#,
+        T().with { $0.singular = 4.2 }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":"Infinity"}"#,
+        T().with { $0.singular = .infinity }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":"-Infinity"}"#,
+        T().with { $0.singular = -.infinity }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":"NaN"}"#,
+        T().with { $0.singular = .nan }
+      ),
+      (
+        #"{"map":{},"repeated":["Infinity","-Infinity"]}"#,
+        T().with { $0.repeated = [.infinity, -.infinity] }
+      ),
+      (
+        #"{"map":{},"repeated":["NaN"]}"#,
+        T().with { $0.repeated = [.nan] }
+      ),
+      (
+        #"{"map":{"a":"Infinity"},"repeated":[]}"#,
+        T().with { $0.map = ["a": .infinity] }
+      ),
+      (
+        #"{"map":{"a":"-Infinity"},"repeated":[]}"#,
+        T().with { $0.map = ["a": -.infinity] }
+      ),
+      (
+        #"{"map":{"a":"NaN"},"repeated":[]}"#,
+        T().with { $0.map = ["a": .nan] }
+      ),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    encoder.nonConformingFloatEncodingStrategy = .convertToString(
+      positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN"
+    )
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    let isNaN =
+      (input.singular?.isNaN ?? false)
+      || input.repeated.contains(where: { $0.isNaN })
+      || input.map.values.contains(where: { $0.isNaN })
+    if !isNaN {
+      #expect(input == roundtrip)
+    }
   }
 }

--- a/Tests/ProtoJSON/FieldsFloatValue.swift
+++ b/Tests/ProtoJSON/FieldsFloatValue.swift
@@ -113,11 +113,8 @@ import Testing
     ]
   )
   func serialize(want: String, input: T) throws {
-    let encoder = JSONEncoder()
+    let encoder = _ProtoJSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
-    encoder.nonConformingFloatEncodingStrategy = .convertToString(
-      positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN"
-    )
     let data = try encoder.encode(input)
     let got = String(data: data, encoding: .utf8)!
     #expect(got == want)

--- a/packages/swift-google-gax/Sources/GoogleCloudGax/HTTPClientRequest.swift
+++ b/packages/swift-google-gax/Sources/GoogleCloudGax/HTTPClientRequest.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+@_spi(GoogleCloudInternal) import class GoogleCloudWKT._ProtoJSONEncoder
 import struct AsyncHTTPClient.HTTPClientRequest
 import struct NIOCore.ByteBuffer
 import struct NIOHTTP1.HTTPHeaders
@@ -68,6 +69,15 @@ enum _RequestBody: Sendable {
   public mutating func setBody(data: Data, ofContentType: String) {
     self.body = .data(data)
     self.headers.replaceOrAdd(name: "Content-Type", value: ofContentType)
+  }
+
+  public mutating func setBody<T: Encodable>(
+    json: T,
+    ofContentType contentType: String = "application/json"
+  ) throws {
+    let encoder = _ProtoJSONEncoder()
+    let data = try encoder.encode(json)
+    self.setBody(data: data, ofContentType: contentType)
   }
 
   public mutating func setBody(buffer: NIOCore.ByteBuffer) {

--- a/packages/swift-google-gax/Tests/HTTPClientTests.swift
+++ b/packages/swift-google-gax/Tests/HTTPClientTests.swift
@@ -179,6 +179,73 @@ import NIOHTTP1
     #expect(data == .init("{}".utf8))
   }
 
+  @Test func postRequestBodyJSON() async throws {
+    struct TestPayload: Encodable {
+      var name: String
+      var floatVal: Float32
+      var doubleVal: Float64
+    }
+
+    let mock = MockHTTPClient { (request, timeout) in
+      #expect(timeout == .seconds(1))
+      #expect(request.method == .POST)
+      #expect(request.url == "http://localhost:8080/v1/projects/my-project/secrets?$alt=json")
+      #expect(request.headers["Content-Type"] == ["application/json"])
+
+      let body = try #require(request.body)
+      let collected = try await body.collect(upTo: 1024)
+      let bodyString = String(buffer: collected)
+      #expect(bodyString.contains(#""floatVal":"NaN""#))
+      #expect(bodyString.contains(#""doubleVal":"Infinity""#))
+      #expect(bodyString.contains(#""name":"test""#))
+
+      return HTTPClientResponse(
+        version: .http1_1,
+        status: .ok,
+        body: .bytes(.init(string: "{}"))
+      )
+    }
+
+    let endpoint = "http://localhost:8080"
+    let path = "/v1/projects/my-project/secrets"
+    let client = try _HTTPClient(mock, endpoint: endpoint)
+    var request = try await client.newRequest(
+      path: path,
+      query: [URLQueryItem(name: "$alt", value: "json")],
+    )
+    request.setMethod(.POST)
+    try request.setBody(
+      json: TestPayload(name: "test", floatVal: .nan, doubleVal: .infinity)
+    )
+    let response = try await request.execute(timeout: .seconds(1))
+    #expect(response.status == .ok)
+  }
+
+  @Test func postRequestBodyJSONCustomContentType() async throws {
+    struct TestPayload: Encodable {
+      var name: String
+    }
+
+    let mock = MockHTTPClient { (request, _) in
+      #expect(request.headers["Content-Type"] == ["application/merge-patch+json"])
+
+      return HTTPClientResponse(
+        version: .http1_1,
+        status: .ok,
+        body: .bytes(.init(string: "{}"))
+      )
+    }
+
+    let client = try _HTTPClient(mock, endpoint: "http://localhost:8080")
+    var request = try await client.newRequest(path: "/v1/test", query: [])
+    try request.setBody(
+      json: TestPayload(name: "patch"),
+      ofContentType: "application/merge-patch+json"
+    )
+    let response = try await request.execute(timeout: .seconds(1))
+    #expect(response.status == .ok)
+  }
+
   @Test func rpcNoTimeout() async throws {
     let mock = MockHTTPClient { (request, timeout) in
       #expect(timeout == _HTTPClientRequest.defaultTimeout)

--- a/packages/swift-google-wkt/Sources/GoogleCloudWKT/AnyPackable.swift
+++ b/packages/swift-google-wkt/Sources/GoogleCloudWKT/AnyPackable.swift
@@ -35,8 +35,7 @@ public func _slowAnyDeserialize<M: Decodable & _AnyPackable>(
   if M._anyTypeUrl != from._type {
     throw AnyError.mismatchedTypeUrl
   }
-  let encoder = JSONEncoder();
-  encoder.outputFormatting = [.withoutEscapingSlashes]
+  let encoder = _ProtoJSONEncoder()
   let data = try encoder.encode(from.fields)
   let decoder = _ProtoJSONDecoder()
   return try decoder.decode(M.self, from: data)
@@ -45,8 +44,7 @@ public func _slowAnyDeserialize<M: Decodable & _AnyPackable>(
 // Serializes a message of type `M` into an `Any`.
 @_spi(GoogleCloudInternal)
 public func _slowAnySerialize<M: Encodable>(message: M) throws -> Struct {
-  let encoder = JSONEncoder()
-  encoder.outputFormatting = [.withoutEscapingSlashes]
+  let encoder = _ProtoJSONEncoder()
   let data = try encoder.encode(message)
   let decoder = _ProtoJSONDecoder()
   return try decoder.decode(Struct.self, from: data)

--- a/packages/swift-google-wkt/Sources/GoogleCloudWKT/ProtoJSONEncoder.swift
+++ b/packages/swift-google-wkt/Sources/GoogleCloudWKT/ProtoJSONEncoder.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Encodes values using the ProtoJSON mapping.
+///
+/// The Google Cloud client libraries for Swift use HTTP+JSON as their primary transport.
+/// The ProtoJSON encoding differs from typical JSON in a number of ways, including:
+/// - Non-number floating point values (NaN, +Inf, -Inf) are represented as strings.
+///
+/// This encoder configures the native Swift JSON encoder to implement ProtoJSON rules.
+@_spi(GoogleCloudInternal) final public class _ProtoJSONEncoder {
+  public var outputFormatting: JSONEncoder.OutputFormatting = [.withoutEscapingSlashes]
+
+  public init() {}
+
+  public func encode<T>(_ value: T) throws -> Data where T: Encodable {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = self.outputFormatting
+    encoder.nonConformingFloatEncodingStrategy = .convertToString(
+      positiveInfinity: "Infinity",
+      negativeInfinity: "-Infinity",
+      nan: "NaN"
+    )
+    return try encoder.encode(value)
+  }
+}

--- a/packages/swift-google-wkt/Tests/ProtoJSONEncoderTest.swift
+++ b/packages/swift-google-wkt/Tests/ProtoJSONEncoderTest.swift
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+@_spi(GoogleCloudInternal) import GoogleCloudWKT
+
+@Suite struct ProtoJSONEncoderTest {
+  struct FloatModel: Codable, Equatable {
+    var floatVal: Float32
+    var doubleVal: Float64
+    var url: String
+  }
+
+  @Test func encodeNonConformingFloats() throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+
+    let model = FloatModel(
+      floatVal: .nan,
+      doubleVal: .infinity,
+      url: "https://example.com/foo/bar"
+    )
+    let data = try encoder.encode(model)
+    let jsonString = try #require(String(data: data, encoding: .utf8))
+
+    #expect(
+      jsonString
+        == #"{"doubleVal":"Infinity","floatVal":"NaN","url":"https://example.com/foo/bar"}"#
+    )
+
+    let negModel = FloatModel(
+      floatVal: -.infinity,
+      doubleVal: -.infinity,
+      url: "test/url"
+    )
+    let negData = try encoder.encode(negModel)
+    let negJson = try #require(String(data: negData, encoding: .utf8))
+    #expect(
+      negJson
+        == #"{"doubleVal":"-Infinity","floatVal":"-Infinity","url":"test/url"}"#
+    )
+  }
+
+  @Test func roundtripWithProtoJSONDecoder() throws {
+    let encoder = _ProtoJSONEncoder()
+    let decoder = _ProtoJSONDecoder()
+
+    let model = FloatModel(
+      floatVal: 3.14,
+      doubleVal: .infinity,
+      url: "https://example.com/test"
+    )
+    let data = try encoder.encode(model)
+    let decoded = try decoder.decode(FloatModel.self, from: data)
+    #expect(decoded == model)
+  }
+}


### PR DESCRIPTION
Add `setBody(json:ofContentType:)` on `_HTTPClientRequest`. This
function serializes the `json` parameter using
`GoogleCloudWKT._ProtoJSONEncoder`, which will follow all the ProtoJSON
special rules.

Towards #796
