### PR TITLE
ci: doc builds need `package edit`

### DIFF
--- a/.github/workflows/user-guide.yml
+++ b/.github/workflows/user-guide.yml
@@ -45,8 +45,10 @@ jobs:
             [GoogleCloudStorage]=storage
             [GoogleCloudSecretManagerV1]=google-cloud-secretmanager-v1
           )
-          echo DEBBUG DEBUG "${!targets[@]}"
           mkdir -p .render
+          swift package edit --path $PWD/packages/swift-google-wkt  swift-google-wkt
+          swift package edit --path $PWD/packages/swift-google-auth swift-google-auth
+          swift package edit --path $PWD/packages/swift-google-gax  swift-google-gax
           for target in "${!targets[@]}"; do
             dir="${target[${target}]}"
             swift package \

--- a/ci/gcb/scripts/docs.sh
+++ b/ci/gcb/scripts/docs.sh
@@ -36,6 +36,9 @@ clean_targets=(
     GoogleCloudWorkflowsV1
 )
 echo "--- Building ${#clean_targets[@]} targets with warnings as errors"
+swift package edit --path "${REPO_ROOT}/packages/swift-google-wkt"  swift-google-wkt
+swift package edit --path "${REPO_ROOT}/packages/swift-google-auth" swift-google-auth
+swift package edit --path "${REPO_ROOT}/packages/swift-google-gax"  swift-google-gax
 for target in "${clean_targets[@]}"; do
     count=$((count + 1))
 


### PR DESCRIPTION
To generate and test the documentation we need to build somet things. That means we need to `package edit` before generating the docs, because sometimes the packages use new features in gax or wkt.

Towards #445 