### PR TITLE
feat(StorageW1R3): configurable CRC32C checksums

### DIFF
--- a/Tests/StorageW1R3/BenchmarkRunner.swift
+++ b/Tests/StorageW1R3/BenchmarkRunner.swift
@@ -54,6 +54,7 @@ extension StorageW1R3 {
       let size = pickObjectSize()
       let objectName = Self.randomObjectName()
       let isResumable = Bool.random()
+      let uploadCrc32c = self.pickCrc32c()
       let uploadSlice = buffer.getSlice(at: 0, length: size) ?? buffer.slice()
       let iterationId = IterationId(
         task: taskIndex, taskStartInstant: taskStartInstant, iteration: iteration)
@@ -67,19 +68,22 @@ extension StorageW1R3 {
           bucketName: bucketName,
           objectName: objectName,
           buffer: uploadSlice,
-          isResumable: isResumable)
+          isResumable: isResumable,
+          crc32cEnabled: uploadCrc32c)
       else {
         continue
       }
 
       for readIndex in 0..<readCount {
+        let downloadCrc32c = self.pickCrc32c()
         await self.sampleDownload(
           iterationId: iterationId,
           counters: counters,
           readIndex: readIndex,
           client: storageClient,
           object: uploadedObject,
-          size: size)
+          size: size,
+          crc32cEnabled: downloadCrc32c)
       }
 
       if self.noDelete {
@@ -121,7 +125,8 @@ extension StorageW1R3 {
     bucketName: String,
     objectName: String,
     buffer: NIOCore.ByteBuffer,
-    isResumable: Bool
+    isResumable: Bool,
+    crc32cEnabled: Bool
   ) async -> GoogleCloudStorage.Object? {
     let uploadOp: Operation = isResumable ? .resumable : .singleShot
 
@@ -129,7 +134,8 @@ extension StorageW1R3 {
       iterationId: iterationId,
       op: uploadOp,
       targetSize: buffer.readableBytes,
-      object: objectName
+      object: objectName,
+      crc32cEnabled: crc32cEnabled
     )
     do {
       let object = try await StorageOperations.upload(
@@ -138,7 +144,8 @@ extension StorageW1R3 {
         bucketName: bucketName,
         objectName: objectName,
         buffer: buffer,
-        isResumable: isResumable
+        isResumable: isResumable,
+        crc32cEnabled: crc32cEnabled
       )
       let sample = uploadBuilder.success()
       self.emitSample(sample)
@@ -163,16 +170,19 @@ extension StorageW1R3 {
     client: StorageClient,
     object: GoogleCloudStorage.Object,
     size: Int,
+    crc32cEnabled: Bool
   ) async {
     let readOp = Operation.read(readIndex)
     let readBuilder = SampleBuilder(
       iterationId: iterationId,
       op: readOp,
       targetSize: size,
-      object: object.name
+      object: object.name,
+      crc32cEnabled: crc32cEnabled
     )
 
-    let (transferSize, readError) = await StorageOperations.download(client: client, object: object)
+    let (transferSize, readError) = await StorageOperations.download(
+      client: client, object: object, crc32cEnabled: crc32cEnabled)
 
     if let error = readError {
       let details = await counters.errorDetails(error: error)
@@ -208,6 +218,7 @@ extension StorageW1R3 {
       op: .delete,
       targetSize: batch.count,
       object: batch[0].name,
+      crc32cEnabled: false
     )
 
     do {

--- a/Tests/StorageW1R3/README.md
+++ b/Tests/StorageW1R3/README.md
@@ -58,7 +58,7 @@ Then upload the results of the experiment:
 ```shell
 bq load --source_format CSV --skip_leading_rows 1 \
     ${GOOGLE_CLOUD_PROJECT}:w1r3.swift001 bm-${TS}.txt \
-    Task:int64,Iteration:int64,IterationStart:int64,Operation,Size:int64,TransferSize:int64,ElapsedMicroseconds:int64,Object,Result,Details
+    Task:int64,Iteration:int64,IterationStart:int64,Operation,Size:int64,TransferSize:int64,ElapsedMicroseconds:int64,Object,Crc32cEnabled:bool,Result,Details
 ```
 
 [compute-optimized]: https://cloud.google.com/compute/docs/compute-optimized-machines

--- a/Tests/StorageW1R3/Sample.swift
+++ b/Tests/StorageW1R3/Sample.swift
@@ -17,7 +17,7 @@ import Foundation
 /// A recorded measurement sample representing the result and timing of a single operation.
 public struct Sample: Sendable {
   public static let header =
-    "Task,Iteration,IterationStart,Operation,Size,TransferSize,ElapsedMicroseconds,Object,Result,Details"
+    "Task,Iteration,IterationStart,Operation,Size,TransferSize,ElapsedMicroseconds,Object,Crc32cEnabled,Result,Details"
 
   public let task: Int
   public let iteration: Int
@@ -27,10 +27,11 @@ public struct Sample: Sendable {
   public let transferSize: Int
   public let elapsedMicros: Int64
   public let object: String
+  public let crc32cEnabled: Bool
   public let result: ExperimentResult
   public let details: String
 
   public func toRow() -> String {
-    "\(task),\(iteration),\(iterationStartMicros),\(operation.name),\(size),\(transferSize),\(elapsedMicros),\(object),\(result.name),\(details)"
+    "\(task),\(iteration),\(iterationStartMicros),\(operation.name),\(size),\(transferSize),\(elapsedMicros),\(object),\(crc32cEnabled),\(result.name),\(details)"
   }
 }

--- a/Tests/StorageW1R3/SampleBuilder.swift
+++ b/Tests/StorageW1R3/SampleBuilder.swift
@@ -24,12 +24,14 @@ public struct SampleBuilder: Sendable {
   public let op: Operation
   public let targetSize: Int
   public let object: String
+  public let crc32cEnabled: Bool
 
   public init(
     iterationId: IterationId,
     op: Operation,
     targetSize: Int,
-    object: String
+    object: String,
+    crc32cEnabled: Bool
   ) {
     self.task = iterationId.task
     self.clock = ContinuousClock()
@@ -43,6 +45,7 @@ public struct SampleBuilder: Sendable {
     self.op = op
     self.targetSize = targetSize
     self.object = object
+    self.crc32cEnabled = crc32cEnabled
   }
 
   private var elapsedMicroseconds: Int64 {
@@ -61,6 +64,7 @@ public struct SampleBuilder: Sendable {
       transferSize: transferSize ?? targetSize,
       elapsedMicros: elapsedMicroseconds,
       object: object,
+      crc32cEnabled: crc32cEnabled,
       result: .ok,
       details: ""
     )
@@ -76,6 +80,7 @@ public struct SampleBuilder: Sendable {
       transferSize: 0,
       elapsedMicros: elapsedMicroseconds,
       object: object,
+      crc32cEnabled: crc32cEnabled,
       result: .err,
       details: details.replacingOccurrences(of: ",", with: ";")
     )
@@ -91,6 +96,7 @@ public struct SampleBuilder: Sendable {
       transferSize: transferSize,
       elapsedMicros: elapsedMicroseconds,
       object: object,
+      crc32cEnabled: crc32cEnabled,
       result: .int,
       details: details.replacingOccurrences(of: ",", with: ";")
     )

--- a/Tests/StorageW1R3/StorageOperations.swift
+++ b/Tests/StorageW1R3/StorageOperations.swift
@@ -26,12 +26,14 @@ enum StorageOperations {
     bucketName: String,
     objectName: String,
     buffer: NIOCore.ByteBuffer,
-    isResumable: Bool
+    isResumable: Bool,
+    crc32cEnabled: Bool
   ) async throws -> GoogleCloudStorage.Object {
     let options = UploadOptions().with {
       $0.preconditions = StoragePreconditions().with {
         $0.ifGenerationMatch = 0
       }
+      $0.checksums = crc32cEnabled ? .default : .none
       // If resumable, chunk size is set to 32MiB; if simple, threshold handles it
       if isResumable {
         $0.chunkSize = 32 * 1024 * 1024
@@ -64,11 +66,11 @@ enum StorageOperations {
 
   /// Downloads (reads) an object from Cloud Storage, returning total bytes transferred.
   static func download(
-    client: StorageClient, object: GoogleCloudStorage.Object
+    client: StorageClient, object: GoogleCloudStorage.Object, crc32cEnabled: Bool
   ) async -> (transferSize: Int, error: (any Error)?) {
-    var options = ReadObjectOptions()
-    if object.generation > 0 {
-      options.generation = UInt64(object.generation)
+    let options = ReadObjectOptions().with {
+      $0.generation = if object.generation > 0 { UInt64(object.generation) } else { nil }
+      $0.checksums = crc32cEnabled ? .default : .none
     }
 
     let readTask = client.readObject(from: object.bucket, object: object.name, options: options)

--- a/Tests/StorageW1R3/StorageW1R3.swift
+++ b/Tests/StorageW1R3/StorageW1R3.swift
@@ -179,6 +179,23 @@ struct StorageW1R3: AsyncParsableCommand, Sendable {
   )
   var controlClientCount: Int = 1
 
+  @Option(
+    name: [.customLong("crc32c"), .customLong("crc32c-mode")],
+    help: "CRC32C checksum mode: always (default), random, or never."
+  )
+  var crc32c: Crc32cOption = .always
+
+  func pickCrc32c() -> Bool {
+    switch self.crc32c {
+    case .always:
+      return true
+    case .never:
+      return false
+    case .random:
+      return Bool.random()
+    }
+  }
+
   func validate() throws {
     guard minObjectSize <= maxObjectSize else {
       throw ValidationError(
@@ -202,6 +219,25 @@ struct StorageW1R3: AsyncParsableCommand, Sendable {
     }
     guard controlClientCount >= 1 else {
       throw ValidationError("control-client-count must be at least 1")
+    }
+  }
+}
+
+enum Crc32cOption: String, ExpressibleByArgument, CaseIterable, Sendable {
+  case always
+  case random
+  case never
+
+  init?(argument: String) {
+    switch argument.lowercased() {
+    case "always", "enabled", "true":
+      self = .always
+    case "random":
+      self = .random
+    case "never", "disabled", "false":
+      self = .never
+    default:
+      return nil
     }
   }
 }


### PR DESCRIPTION
Add an option to StorageW1R3 to either always use CRC32C checksums (default), randomly enable/disable CRC32C checksums within each iteration, or never use CRC32C checksums. Record whether CRC32C was enabled in the sample output in the Crc32cEnabled column.

Towards #647 