### PR TITLE
feat(storage): add per-request and per-client quota_project_id options

### DIFF
--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/DownloadOptions.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/DownloadOptions.swift
@@ -240,8 +240,27 @@ public struct ReadObjectOptions: Sendable {
 
   /// Overrides the quota project for this download operation.
   ///
-  /// When set, the `x-goog-user-project` header is sent with this value, overriding any client-level
-  /// or credential-level quota project.
+  /// By default, Google Cloud Storage attributes quota and billing usage to the project associated
+  /// with the credentials, the project configured on `StorageClientOptions.client.quotaProject`,
+  /// or the project owning the bucket. Setting `quotaProject` instructs the service to charge
+  /// quota and billing for this download to the specified project ID or project number instead.
+  ///
+  /// This is commonly used when:
+  /// - Downloading from a [Requester Pays] bucket where the caller's project must be billed for
+  ///   data access and egress.
+  /// - Authenticating with user credentials (such as those created by
+  ///   `gcloud auth application-default login`), which are not inherently tied to a project.
+  /// - Multiplexing downloads across multiple consumer projects using a single `StorageClient`.
+  ///
+  /// The authenticated principal must have the `serviceusage.services.use` IAM permission
+  /// (granted by the [Service Usage Consumer] role, `roles/serviceusage.serviceUsageConsumer`) on
+  /// the specified project.
+  ///
+  /// When set, the `x-goog-user-project` header is sent with this value, taking precedence over
+  /// any client-level or credential-level quota project.
+  ///
+  /// [Requester Pays]: https://cloud.google.com/storage/docs/requester-pays
+  /// [Service Usage Consumer]: https://cloud.google.com/service-usage/docs/access-control
   public var quotaProject: String? = nil
 
   /// Default configuration options.

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/DownloadOptions.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/DownloadOptions.swift
@@ -238,6 +238,12 @@ public struct ReadObjectOptions: Sendable {
   /// Overrides the backoff policy for this download.
   public var backoffPolicy: (any BackoffPolicy)? = nil
 
+  /// Overrides the quota project for this download operation.
+  ///
+  /// When set, the `x-goog-user-project` header is sent with this value, overriding any client-level
+  /// or credential-level quota project.
+  public var quotaProject: String? = nil
+
   /// Default configuration options.
   public static var `default`: ReadObjectOptions { ReadObjectOptions() }
 

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/DownloadOptions.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/DownloadOptions.swift
@@ -277,6 +277,20 @@ public struct ReadObjectOptions: Sendable {
   }
 }
 
+extension ReadObjectOptions {
+  internal func withDefaults(_ defaults: Self) -> Self {
+    var copy = self
+    copy.resumePolicy = self.resumePolicy ?? defaults.resumePolicy
+    copy.backoffPolicy = self.backoffPolicy ?? defaults.backoffPolicy
+    copy.quotaProject = self.quotaProject ?? defaults.quotaProject
+    return copy
+  }
+
+  internal var requestOptions: RequestOptions {
+    RequestOptions().with { $0.quotaProject = self.quotaProject }
+  }
+}
+
 /// Calculates the remaining range to request when resuming an interrupted download.
 ///
 /// - Parameters:

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Download.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Download.swift
@@ -40,10 +40,13 @@ extension StorageClient {
       backoffPolicy: effectiveBackoffPolicy
     )
 
+    var effectiveOptions = options
+    effectiveOptions.quotaProject = options.quotaProject ?? self.options.download.quotaProject
+
     let coordinator = ReadObjectCoordinator(
       bucket: bucket,
       object: object,
-      options: options,
+      options: effectiveOptions,
       httpClient: inner,
       resumeLoop: resumeLoop
     )
@@ -172,8 +175,11 @@ extension GoogleCloudGax._HTTPClient {
     let bucketId = BucketName.extractBucketName(bucket)
     let encodedBucket =
       bucketId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? bucketId
+    let reqOptions = RequestOptions().with { $0.quotaProject = options.quotaProject }
     var request = try await self.newRequest(
-      percentEncodedPath: "/storage/v1/b/\(encodedBucket)/o/\(encodedObject)", query: queryItems)
+      percentEncodedPath: "/storage/v1/b/\(encodedBucket)/o/\(encodedObject)",
+      query: queryItems,
+      options: reqOptions)
     request.setMethod(.GET)
 
     if let rangeHeader = options.range.headerValue {

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Download.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Download.swift
@@ -29,19 +29,12 @@ extension StorageClient {
     object: String,
     options: ReadObjectOptions = .init()
   ) -> ReadObjectTask {
-    let clientOptions = self.options.client
-    let effectiveBackoffPolicy =
-      options.backoffPolicy ?? self.options.download.backoffPolicy ?? clientOptions.backoffPolicy
-    let effectiveResumePolicy =
-      options.resumePolicy ?? self.options.download.resumePolicy
-      ?? StorageResumePolicy<DownloadDetails>().stopOnConsecutiveErrors()
+    let effectiveOptions = options.withDefaults(self.options.download)
     let resumeLoop = _ResumeLoop(
-      resumePolicy: effectiveResumePolicy,
-      backoffPolicy: effectiveBackoffPolicy
+      resumePolicy: effectiveOptions.resumePolicy
+        ?? StorageResumePolicy<DownloadDetails>().stopOnConsecutiveErrors(),
+      backoffPolicy: effectiveOptions.backoffPolicy ?? self.options.client.backoffPolicy
     )
-
-    var effectiveOptions = options
-    effectiveOptions.quotaProject = options.quotaProject ?? self.options.download.quotaProject
 
     let coordinator = ReadObjectCoordinator(
       bucket: bucket,
@@ -175,11 +168,10 @@ extension GoogleCloudGax._HTTPClient {
     let bucketId = BucketName.extractBucketName(bucket)
     let encodedBucket =
       bucketId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? bucketId
-    let reqOptions = RequestOptions().with { $0.quotaProject = options.quotaProject }
     var request = try await self.newRequest(
       percentEncodedPath: "/storage/v1/b/\(encodedBucket)/o/\(encodedObject)",
       query: queryItems,
-      options: reqOptions)
+      options: options.requestOptions)
     request.setMethod(.GET)
 
     if let rangeHeader = options.range.headerValue {

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -60,6 +60,9 @@ extension StorageClient {
       ?? UploadOptions.defaultResumableUploadThreshold
     let httpClient = self.inner
 
+    var effectiveOptions = options
+    effectiveOptions.quotaProject = options.quotaProject ?? self.options.upload.quotaProject
+
     var source = source
 
     // Determine if simple or resumable
@@ -71,8 +74,8 @@ extension StorageClient {
         source: &source,
         bucket: bucket,
         objectName: objectName,
-        metadata: options.metadata,
-        options: options,
+        metadata: effectiveOptions.metadata,
+        options: effectiveOptions,
         totalSize: totalSize,
         resumeLoop: resumeLoop
       )
@@ -82,12 +85,12 @@ extension StorageClient {
         source: &source,
         bucket: bucket,
         objectName: objectName,
-        metadata: options.metadata,
+        metadata: effectiveOptions.metadata,
         uploadId: nil,
         initialStatus: .inprogress(0),
-        chunkSize: options.chunkSize,
+        chunkSize: effectiveOptions.chunkSize,
         totalSize: source.totalSize,
-        options: options,
+        options: effectiveOptions,
         resumeLoop: resumeLoop
       )
     }
@@ -125,6 +128,9 @@ extension StorageClient {
       ?? UploadOptions.defaultResumableUploadThreshold
     let httpClient = self.inner
 
+    var effectiveOptions = options
+    effectiveOptions.quotaProject = options.quotaProject ?? self.options.upload.quotaProject
+
     var source = source
 
     // Determine if simple or resumable
@@ -136,8 +142,8 @@ extension StorageClient {
         source: &source,
         bucket: bucket,
         objectName: objectName,
-        metadata: options.metadata,
-        options: options,
+        metadata: effectiveOptions.metadata,
+        options: effectiveOptions,
         totalSize: totalSize,
         resumeLoop: resumeLoop
       )
@@ -147,12 +153,12 @@ extension StorageClient {
         source: &source,
         bucket: bucket,
         objectName: objectName,
-        metadata: options.metadata,
+        metadata: effectiveOptions.metadata,
         uploadId: nil,
         initialStatus: .inprogress(0),
-        chunkSize: options.chunkSize,
+        chunkSize: effectiveOptions.chunkSize,
         totalSize: source.totalSize,
-        options: options,
+        options: effectiveOptions,
         resumeLoop: resumeLoop
       )
     }
@@ -202,8 +208,9 @@ extension StorageClient {
     return try await resumeLoop.run(state: resumeState) { _ in
       try await stream.rewind()
 
+      let reqOptions = RequestOptions().with { $0.quotaProject = options.quotaProject }
       var request = try await httpClient.newRequest(
-        path: "/upload/storage/v1/b/\(bucketId)/o", query: queryItems)
+        path: "/upload/storage/v1/b/\(bucketId)/o", query: queryItems, options: reqOptions)
       request.setMethod(.POST)
       if let checksum = checksum {
         request.setHeader(name: "x-goog-hash", value: checksum)
@@ -675,6 +682,8 @@ extension StorageClient {
       backoffPolicy: effectiveBackoffPolicy
     )
     let httpClient = self.inner
+    var effectiveOptions = options
+    effectiveOptions.quotaProject = options.quotaProject ?? self.options.upload.quotaProject
     var source = source
     let totalSize = source.totalSize
 
@@ -686,9 +695,9 @@ extension StorageClient {
       metadata: nil,
       uploadId: uploadId,
       initialStatus: .unknown,
-      chunkSize: options.chunkSize,
+      chunkSize: effectiveOptions.chunkSize,
       totalSize: totalSize,
-      options: options,
+      options: effectiveOptions,
       resumeLoop: resumeLoop
     )
   }
@@ -748,8 +757,9 @@ extension StorageClient {
     }
 
     let bucketId = BucketName.extractBucketName(bucket)
+    let reqOptions = RequestOptions().with { $0.quotaProject = options.quotaProject }
     var request = try await httpClient.newRequest(
-      path: "/upload/storage/v1/b/\(bucketId)/o", query: queryItems)
+      path: "/upload/storage/v1/b/\(bucketId)/o", query: queryItems, options: reqOptions)
     request.setMethod(.POST)
     request.setHeader(name: "Content-Type", value: "application/json; charset=UTF-8")
 
@@ -767,7 +777,8 @@ extension StorageClient {
     uploadId: String,
     options: UploadOptions? = nil
   ) async throws -> GoogleCloudGax._HTTPClientRequest {
-    var request = try await httpClient.newRequest(uri: uploadId)
+    let reqOptions = RequestOptions().with { $0.quotaProject = options?.quotaProject }
+    var request = try await httpClient.newRequest(uri: uploadId, options: reqOptions)
     request.setMethod(.PUT)
     request.setHeader(name: "Content-Type", value: "application/octet-stream")
     request.setHeader(name: "Content-Range", value: "bytes */*")
@@ -787,7 +798,8 @@ extension StorageClient {
     options: UploadOptions,
     checksum: String? = nil
   ) async throws -> GoogleCloudGax._HTTPClientRequest {
-    var request = try await httpClient.newRequest(uri: uploadId)
+    let reqOptions = RequestOptions().with { $0.quotaProject = options.quotaProject }
+    var request = try await httpClient.newRequest(uri: uploadId, options: reqOptions)
     request.setMethod(.PUT)
     request.setHeader(name: "Content-Type", value: "application/octet-stream")
 

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -45,23 +45,15 @@ extension StorageClient {
     as objectName: String,
     options: UploadOptions = .default
   ) async throws -> Object {
-    let clientOptions = self.options.client
-    let effectiveBackoffPolicy =
-      options.backoffPolicy ?? self.options.upload.backoffPolicy ?? clientOptions.backoffPolicy
-    let effectiveResumePolicy =
-      options.resumePolicy ?? self.options.upload.resumePolicy
-      ?? StorageResumePolicy<UploadDetails>().stopOnConsecutiveErrors()
+    let effectiveOptions = options.withDefaults(self.options.upload)
     let resumeLoop = _ResumeLoop(
-      resumePolicy: effectiveResumePolicy,
-      backoffPolicy: effectiveBackoffPolicy
+      resumePolicy: effectiveOptions.resumePolicy
+        ?? StorageResumePolicy<UploadDetails>().stopOnConsecutiveErrors(),
+      backoffPolicy: effectiveOptions.backoffPolicy ?? self.options.client.backoffPolicy
     )
     let effectiveThreshold =
-      options.resumableUploadThreshold ?? self.options.upload.resumableUploadThreshold
-      ?? UploadOptions.defaultResumableUploadThreshold
+      effectiveOptions.resumableUploadThreshold ?? UploadOptions.defaultResumableUploadThreshold
     let httpClient = self.inner
-
-    var effectiveOptions = options
-    effectiveOptions.quotaProject = options.quotaProject ?? self.options.upload.quotaProject
 
     var source = source
 
@@ -110,26 +102,15 @@ extension StorageClient {
     as objectName: String,
     options: UploadOptions = .default
   ) async throws -> Object {
-    let clientOptions = self.options.client
-    let effectiveBackoffPolicy =
-      options.backoffPolicy ?? self.options.upload.backoffPolicy ?? clientOptions.backoffPolicy
-    let effectiveResumePolicy: any ResumePolicy<UploadDetails>
-    if let explicitResume = options.resumePolicy ?? self.options.upload.resumePolicy {
-      effectiveResumePolicy = explicitResume
-    } else {
-      effectiveResumePolicy = StorageResumePolicy().stopOnConsecutiveErrors()
-    }
+    let effectiveOptions = options.withDefaults(self.options.upload)
     let resumeLoop = _ResumeLoop(
-      resumePolicy: effectiveResumePolicy,
-      backoffPolicy: effectiveBackoffPolicy
+      resumePolicy: effectiveOptions.resumePolicy
+        ?? StorageResumePolicy<UploadDetails>().stopOnConsecutiveErrors(),
+      backoffPolicy: effectiveOptions.backoffPolicy ?? self.options.client.backoffPolicy
     )
     let effectiveThreshold =
-      options.resumableUploadThreshold ?? self.options.upload.resumableUploadThreshold
-      ?? UploadOptions.defaultResumableUploadThreshold
+      effectiveOptions.resumableUploadThreshold ?? UploadOptions.defaultResumableUploadThreshold
     let httpClient = self.inner
-
-    var effectiveOptions = options
-    effectiveOptions.quotaProject = options.quotaProject ?? self.options.upload.quotaProject
 
     var source = source
 
@@ -208,9 +189,9 @@ extension StorageClient {
     return try await resumeLoop.run(state: resumeState) { _ in
       try await stream.rewind()
 
-      let reqOptions = RequestOptions().with { $0.quotaProject = options.quotaProject }
       var request = try await httpClient.newRequest(
-        path: "/upload/storage/v1/b/\(bucketId)/o", query: queryItems, options: reqOptions)
+        path: "/upload/storage/v1/b/\(bucketId)/o", query: queryItems,
+        options: options.requestOptions)
       request.setMethod(.POST)
       if let checksum = checksum {
         request.setHeader(name: "x-goog-hash", value: checksum)
@@ -668,22 +649,13 @@ extension StorageClient {
     uploadId: String,
     options: UploadOptions = .default
   ) async throws -> Object {
-    let clientOptions = self.options.client
-    let effectiveBackoffPolicy =
-      options.backoffPolicy ?? self.options.upload.backoffPolicy ?? clientOptions.backoffPolicy
-    let effectiveResumePolicy: any ResumePolicy<UploadDetails>
-    if let explicitResume = options.resumePolicy ?? self.options.upload.resumePolicy {
-      effectiveResumePolicy = explicitResume
-    } else {
-      effectiveResumePolicy = StorageResumePolicy().stopOnConsecutiveErrors()
-    }
+    let effectiveOptions = options.withDefaults(self.options.upload)
     let resumeLoop = _ResumeLoop(
-      resumePolicy: effectiveResumePolicy,
-      backoffPolicy: effectiveBackoffPolicy
+      resumePolicy: effectiveOptions.resumePolicy
+        ?? StorageResumePolicy<UploadDetails>().stopOnConsecutiveErrors(),
+      backoffPolicy: effectiveOptions.backoffPolicy ?? self.options.client.backoffPolicy
     )
     let httpClient = self.inner
-    var effectiveOptions = options
-    effectiveOptions.quotaProject = options.quotaProject ?? self.options.upload.quotaProject
     var source = source
     let totalSize = source.totalSize
 
@@ -757,9 +729,9 @@ extension StorageClient {
     }
 
     let bucketId = BucketName.extractBucketName(bucket)
-    let reqOptions = RequestOptions().with { $0.quotaProject = options.quotaProject }
     var request = try await httpClient.newRequest(
-      path: "/upload/storage/v1/b/\(bucketId)/o", query: queryItems, options: reqOptions)
+      path: "/upload/storage/v1/b/\(bucketId)/o", query: queryItems, options: options.requestOptions
+    )
     request.setMethod(.POST)
     request.setHeader(name: "Content-Type", value: "application/json; charset=UTF-8")
 
@@ -777,8 +749,8 @@ extension StorageClient {
     uploadId: String,
     options: UploadOptions? = nil
   ) async throws -> GoogleCloudGax._HTTPClientRequest {
-    let reqOptions = RequestOptions().with { $0.quotaProject = options?.quotaProject }
-    var request = try await httpClient.newRequest(uri: uploadId, options: reqOptions)
+    var request = try await httpClient.newRequest(
+      uri: uploadId, options: options?.requestOptions ?? .init())
     request.setMethod(.PUT)
     request.setHeader(name: "Content-Type", value: "application/octet-stream")
     request.setHeader(name: "Content-Range", value: "bytes */*")
@@ -798,8 +770,7 @@ extension StorageClient {
     options: UploadOptions,
     checksum: String? = nil
   ) async throws -> GoogleCloudGax._HTTPClientRequest {
-    let reqOptions = RequestOptions().with { $0.quotaProject = options.quotaProject }
-    var request = try await httpClient.newRequest(uri: uploadId, options: reqOptions)
+    var request = try await httpClient.newRequest(uri: uploadId, options: options.requestOptions)
     request.setMethod(.PUT)
     request.setHeader(name: "Content-Type", value: "application/octet-stream")
 

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient.swift
@@ -40,7 +40,8 @@ public final class StorageClient: StorageProtocol, Sendable {
     let endpoint = options.client.endpoint ?? Self.defaultEndpoint
     self.options = options
     self.inner = try GoogleCloudGax._HTTPClient(
-      mock, endpoint: endpoint, credentials: options.client.credentials)
+      mock, endpoint: endpoint, credentials: options.client.credentials,
+      quotaProject: options.client.quotaProject)
   }
 
   @_spi(GoogleCloudInternal) public init(

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/UploadOptions.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/UploadOptions.swift
@@ -515,8 +515,28 @@ public struct UploadOptions: Sendable {
 
   /// Overrides the quota project for this upload operation.
   ///
-  /// When set, the `x-goog-user-project` header is sent with this value, overriding any client-level
-  /// or credential-level quota project.
+  /// By default, Google Cloud Storage attributes quota and billing usage to the project associated
+  /// with the credentials, the project configured on `StorageClientOptions.client.quotaProject`,
+  /// or the project owning the bucket. Setting `quotaProject` instructs the service to charge
+  /// quota and billing for this upload to the specified project ID or project number instead.
+  ///
+  /// This is commonly used when:
+  /// - Uploading to a [Requester Pays] bucket where the caller's project must be billed for the
+  ///   operation.
+  /// - Authenticating with user credentials (such as those created by
+  ///   `gcloud auth application-default login`), which are not inherently tied to a project.
+  /// - Multiplexing uploads across multiple consumer projects using a single `StorageClient`.
+  ///
+  /// The authenticated principal must have the `serviceusage.services.use` IAM permission
+  /// (granted by the [Service Usage Consumer] role, `roles/serviceusage.serviceUsageConsumer`) on
+  /// the specified project.
+  ///
+  /// When set, the `x-goog-user-project` header is sent with this value across all requests for
+  /// this upload (including resumable upload session initiation, chunk uploads, and status
+  /// queries), taking precedence over any client-level or credential-level quota project.
+  ///
+  /// [Requester Pays]: https://cloud.google.com/storage/docs/requester-pays
+  /// [Service Usage Consumer]: https://cloud.google.com/service-usage/docs/access-control
   public var quotaProject: String? = nil
 
   /// Legacy validation enum property for backward compatibility.

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/UploadOptions.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/UploadOptions.swift
@@ -573,6 +573,22 @@ public struct UploadOptions: Sendable {
   }
 }
 
+extension UploadOptions {
+  internal func withDefaults(_ defaults: Self) -> Self {
+    var copy = self
+    copy.resumableUploadThreshold =
+      self.resumableUploadThreshold ?? defaults.resumableUploadThreshold
+    copy.resumePolicy = self.resumePolicy ?? defaults.resumePolicy
+    copy.backoffPolicy = self.backoffPolicy ?? defaults.backoffPolicy
+    copy.quotaProject = self.quotaProject ?? defaults.quotaProject
+    return copy
+  }
+
+  internal var requestOptions: RequestOptions {
+    RequestOptions().with { $0.quotaProject = self.quotaProject }
+  }
+}
+
 /// Customer encryption metadata returned in object responses.
 extension CustomerEncryption {
   /// Base64-encoded string representation of `keySha256Bytes`.

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/UploadOptions.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/UploadOptions.swift
@@ -513,6 +513,12 @@ public struct UploadOptions: Sendable {
   /// Overrides the backoff policy for this upload.
   public var backoffPolicy: (any BackoffPolicy)? = nil
 
+  /// Overrides the quota project for this upload operation.
+  ///
+  /// When set, the `x-goog-user-project` header is sent with this value, overriding any client-level
+  /// or credential-level quota project.
+  public var quotaProject: String? = nil
+
   /// Legacy validation enum property for backward compatibility.
   public var validation: ChecksumValidation {
     get {

--- a/pkgs/swift-google-cloud-storage/Tests/DownloadOptionsTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/DownloadOptionsTests.swift
@@ -183,4 +183,14 @@ import Testing
     #expect(err1 != err3)
     #expect(err4 == err5)
   }
+
+  @Test func readObjectOptionsQuotaProject() {
+    let defaults = ReadObjectOptions.default
+    #expect(defaults.quotaProject == nil)
+
+    let custom = ReadObjectOptions().with {
+      $0.quotaProject = "my-download-quota-project"
+    }
+    #expect(custom.quotaProject == "my-download-quota-project")
+  }
 }

--- a/pkgs/swift-google-cloud-storage/Tests/DownloadOptionsTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/DownloadOptionsTests.swift
@@ -193,4 +193,31 @@ import Testing
     }
     #expect(custom.quotaProject == "my-download-quota-project")
   }
+
+  @Test func readObjectOptionsWithDefaults() {
+    let defaults = ReadObjectOptions().with {
+      $0.resumePolicy = NeverResume<DownloadDetails>()
+      $0.backoffPolicy = ExponentialBackoff()
+      $0.quotaProject = "default-download-quota"
+    }
+
+    // 1. Falls back to defaults when per-request options are nil
+    let emptyOptions = ReadObjectOptions()
+    let resolvedFromEmpty = emptyOptions.withDefaults(defaults)
+    #expect(resolvedFromEmpty.resumePolicy is NeverResume<DownloadDetails>)
+    #expect(resolvedFromEmpty.backoffPolicy is ExponentialBackoff)
+    #expect(resolvedFromEmpty.quotaProject == "default-download-quota")
+    #expect(resolvedFromEmpty.requestOptions.quotaProject == "default-download-quota")
+
+    // 2. Per-request options take precedence over defaults
+    let overrideOptions = ReadObjectOptions().with {
+      $0.resumePolicy = AlwaysResume<DownloadDetails>()
+      $0.quotaProject = "override-download-quota"
+    }
+    let resolvedFromOverride = overrideOptions.withDefaults(defaults)
+    #expect(resolvedFromOverride.resumePolicy is AlwaysResume<DownloadDetails>)
+    #expect(resolvedFromOverride.backoffPolicy is ExponentialBackoff)
+    #expect(resolvedFromOverride.quotaProject == "override-download-quota")
+    #expect(resolvedFromOverride.requestOptions.quotaProject == "override-download-quota")
+  }
 }

--- a/pkgs/swift-google-cloud-storage/Tests/DownloadOptionsTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/DownloadOptionsTests.swift
@@ -194,30 +194,42 @@ import Testing
     #expect(custom.quotaProject == "my-download-quota-project")
   }
 
-  @Test func readObjectOptionsWithDefaults() {
+  @Test(
+    arguments: [
+      (
+        options: ReadObjectOptions(),
+        expectedIsAlwaysResume: false,
+        expectedQuotaProject: "default-download-quota"
+      ),
+      (
+        options: ReadObjectOptions().with {
+          $0.resumePolicy = AlwaysResume<DownloadDetails>()
+          $0.quotaProject = "override-download-quota"
+        },
+        expectedIsAlwaysResume: true,
+        expectedQuotaProject: "override-download-quota"
+      ),
+    ]
+  )
+  func readObjectOptionsWithDefaults(
+    options: ReadObjectOptions,
+    expectedIsAlwaysResume: Bool,
+    expectedQuotaProject: String
+  ) {
     let defaults = ReadObjectOptions().with {
       $0.resumePolicy = NeverResume<DownloadDetails>()
       $0.backoffPolicy = ExponentialBackoff()
       $0.quotaProject = "default-download-quota"
     }
 
-    // 1. Falls back to defaults when per-request options are nil
-    let emptyOptions = ReadObjectOptions()
-    let resolvedFromEmpty = emptyOptions.withDefaults(defaults)
-    #expect(resolvedFromEmpty.resumePolicy is NeverResume<DownloadDetails>)
-    #expect(resolvedFromEmpty.backoffPolicy is ExponentialBackoff)
-    #expect(resolvedFromEmpty.quotaProject == "default-download-quota")
-    #expect(resolvedFromEmpty.requestOptions.quotaProject == "default-download-quota")
-
-    // 2. Per-request options take precedence over defaults
-    let overrideOptions = ReadObjectOptions().with {
-      $0.resumePolicy = AlwaysResume<DownloadDetails>()
-      $0.quotaProject = "override-download-quota"
+    let resolved = options.withDefaults(defaults)
+    if expectedIsAlwaysResume {
+      #expect(resolved.resumePolicy is AlwaysResume<DownloadDetails>)
+    } else {
+      #expect(resolved.resumePolicy is NeverResume<DownloadDetails>)
     }
-    let resolvedFromOverride = overrideOptions.withDefaults(defaults)
-    #expect(resolvedFromOverride.resumePolicy is AlwaysResume<DownloadDetails>)
-    #expect(resolvedFromOverride.backoffPolicy is ExponentialBackoff)
-    #expect(resolvedFromOverride.quotaProject == "override-download-quota")
-    #expect(resolvedFromOverride.requestOptions.quotaProject == "override-download-quota")
+    #expect(resolved.backoffPolicy is ExponentialBackoff)
+    #expect(resolved.quotaProject == expectedQuotaProject)
+    #expect(resolved.requestOptions.quotaProject == expectedQuotaProject)
   }
 }

--- a/pkgs/swift-google-cloud-storage/Tests/DownloadTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/DownloadTests.swift
@@ -1323,4 +1323,63 @@ import Testing
     let lastReq = registry.lastRequest(for: downloadUrl)
     #expect(lastReq != nil)
   }
+
+  @Test(arguments: [
+    // Uses client-level quota when download and request quota are nil
+    (
+      clientQuota: "client-level-quota",
+      downloadQuota: nil as String?,
+      requestQuota: nil as String?,
+      expected: "client-level-quota"
+    ),
+    // Uses download-default-quota when per-request quotaProject is nil
+    (
+      clientQuota: "client-level-quota",
+      downloadQuota: "download-default-quota",
+      requestQuota: nil,
+      expected: "download-default-quota"
+    ),
+    // Per-request quotaProject overrides download-default-quota and client-level-quota
+    (
+      clientQuota: "client-level-quota",
+      downloadQuota: "download-default-quota",
+      requestQuota: "request-level-quota",
+      expected: "request-level-quota"
+    ),
+  ])
+  func downloadObjectQuotaProjectPrecedence(
+    clientQuota: String?,
+    downloadQuota: String?,
+    requestQuota: String?,
+    expected: String
+  ) async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "quota.txt"
+    let payload = Data("Quota Content".utf8)
+    let downloadUrl = registry.url("/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: payload,
+        headers: ["Content-Length": String(payload.count)]
+      ),
+      for: downloadUrl
+    )
+
+    let clientOptions = StorageClientOptions().with {
+      $0.client.endpoint = registry.endpoint
+      $0.client.quotaProject = clientQuota
+      $0.download.quotaProject = downloadQuota
+    }
+    let client = try StorageClient(clientOptions, mock: registry)
+
+    let reqOptions = ReadObjectOptions().with { $0.quotaProject = requestQuota }
+    let task = client.readObject(from: bucket, object: objectName, options: reqOptions)
+    for try await _ in task.body {}
+    #expect(
+      registry.lastRequest(for: downloadUrl)?.value(forHTTPHeaderField: "x-goog-user-project")
+        == expected)
+  }
 }

--- a/pkgs/swift-google-cloud-storage/Tests/SimpleUploadTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/SimpleUploadTests.swift
@@ -667,4 +667,63 @@ import Testing
     #expect(requests.count == 1)
     #expect(requests.first?.url?.absoluteString == simpleUploadUrl.absoluteString)
   }
+
+  @Test(arguments: [
+    // Uses client-level quota when upload and request quota are nil
+    (
+      clientQuota: "client-level-quota",
+      uploadQuota: nil as String?,
+      requestQuota: nil as String?,
+      expected: "client-level-quota"
+    ),
+    // Uses upload-default-quota when per-request quotaProject is nil
+    (
+      clientQuota: "client-level-quota",
+      uploadQuota: "upload-default-quota",
+      requestQuota: nil,
+      expected: "upload-default-quota"
+    ),
+    // Per-request quotaProject overrides upload-default-quota and client-level-quota
+    (
+      clientQuota: "client-level-quota",
+      uploadQuota: "upload-default-quota",
+      requestQuota: "request-level-quota",
+      expected: "request-level-quota"
+    ),
+  ])
+  func simpleUploadQuotaProjectPrecedence(
+    clientQuota: String?,
+    uploadQuota: String?,
+    requestQuota: String?,
+    expected: String
+  ) async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "quota-upload"
+    let data = Data("Quota Upload Content".utf8)
+    let source = BytesSource(data: data)
+
+    let simpleUploadUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=multipart&name=\(objectName)")
+
+    registry.register(
+      response: .success(
+        statusCode: 200,
+        data: makeObjectJSON(name: objectName, bucket: bucket, size: data.count),
+        headers: nil),
+      for: simpleUploadUrl)
+
+    let clientOptions = StorageClientOptions().with {
+      $0.client.endpoint = registry.endpoint
+      $0.client.quotaProject = clientQuota
+      $0.upload.quotaProject = uploadQuota
+    }
+    let client = try StorageClient(clientOptions, mock: registry)
+
+    let reqOptions = UploadOptions().with { $0.quotaProject = requestQuota }
+    _ = try await client.upload(source, to: bucket, as: objectName, options: reqOptions)
+    #expect(
+      registry.lastRequest(for: simpleUploadUrl)?.value(forHTTPHeaderField: "x-goog-user-project")
+        == expected)
+  }
 }

--- a/pkgs/swift-google-cloud-storage/Tests/UploadOptionsTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/UploadOptionsTests.swift
@@ -69,4 +69,35 @@ import Testing
     #expect(options.resumePolicy != nil)
     #expect(options.quotaProject == "upload-quota-project")
   }
+
+  @Test func uploadOptionsWithDefaults() {
+    let defaults = UploadOptions().with {
+      $0.resumableUploadThreshold = 16 * 1024 * 1024
+      $0.resumePolicy = NeverResume<UploadDetails>()
+      $0.backoffPolicy = ExponentialBackoff()
+      $0.quotaProject = "default-upload-quota"
+    }
+
+    // 1. Falls back to defaults when per-request options are nil
+    let emptyOptions = UploadOptions()
+    let resolvedFromEmpty = emptyOptions.withDefaults(defaults)
+    #expect(resolvedFromEmpty.resumableUploadThreshold == 16 * 1024 * 1024)
+    #expect(resolvedFromEmpty.resumePolicy is NeverResume<UploadDetails>)
+    #expect(resolvedFromEmpty.backoffPolicy is ExponentialBackoff)
+    #expect(resolvedFromEmpty.quotaProject == "default-upload-quota")
+    #expect(resolvedFromEmpty.requestOptions.quotaProject == "default-upload-quota")
+
+    // 2. Per-request options take precedence over defaults
+    let overrideOptions = UploadOptions().with {
+      $0.resumableUploadThreshold = 32 * 1024 * 1024
+      $0.resumePolicy = AlwaysResume<UploadDetails>()
+      $0.quotaProject = "override-upload-quota"
+    }
+    let resolvedFromOverride = overrideOptions.withDefaults(defaults)
+    #expect(resolvedFromOverride.resumableUploadThreshold == 32 * 1024 * 1024)
+    #expect(resolvedFromOverride.resumePolicy is AlwaysResume<UploadDetails>)
+    #expect(resolvedFromOverride.backoffPolicy is ExponentialBackoff)
+    #expect(resolvedFromOverride.quotaProject == "override-upload-quota")
+    #expect(resolvedFromOverride.requestOptions.quotaProject == "override-upload-quota")
+  }
 }

--- a/pkgs/swift-google-cloud-storage/Tests/UploadOptionsTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/UploadOptionsTests.swift
@@ -33,6 +33,7 @@ import Testing
     #expect(options.predefinedAcl == nil)
     #expect(options.resumePolicy == nil)
     #expect(options.backoffPolicy == nil)
+    #expect(options.quotaProject == nil)
   }
 
   @Test func uploadOptionsWithBuilder() throws {
@@ -54,6 +55,7 @@ import Testing
       $0.metadata = metadata
       $0.predefinedAcl = .publicRead
       $0.resumePolicy = NeverResume<UploadDetails>()
+      $0.quotaProject = "upload-quota-project"
     }
 
     #expect(options.resumableUploadThreshold == 4 * 1024 * 1024)
@@ -65,5 +67,6 @@ import Testing
     #expect(options.metadata?.contentType == "application/json")
     #expect(options.predefinedAcl == .publicRead)
     #expect(options.resumePolicy != nil)
+    #expect(options.quotaProject == "upload-quota-project")
   }
 }

--- a/pkgs/swift-google-cloud-storage/Tests/UploadOptionsTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/UploadOptionsTests.swift
@@ -70,7 +70,32 @@ import Testing
     #expect(options.quotaProject == "upload-quota-project")
   }
 
-  @Test func uploadOptionsWithDefaults() {
+  @Test(
+    arguments: [
+      (
+        options: UploadOptions(),
+        expectedThreshold: 16 * 1024 * 1024,
+        expectedIsAlwaysResume: false,
+        expectedQuotaProject: "default-upload-quota"
+      ),
+      (
+        options: UploadOptions().with {
+          $0.resumableUploadThreshold = 32 * 1024 * 1024
+          $0.resumePolicy = AlwaysResume<UploadDetails>()
+          $0.quotaProject = "override-upload-quota"
+        },
+        expectedThreshold: 32 * 1024 * 1024,
+        expectedIsAlwaysResume: true,
+        expectedQuotaProject: "override-upload-quota"
+      ),
+    ]
+  )
+  func uploadOptionsWithDefaults(
+    options: UploadOptions,
+    expectedThreshold: Int,
+    expectedIsAlwaysResume: Bool,
+    expectedQuotaProject: String
+  ) {
     let defaults = UploadOptions().with {
       $0.resumableUploadThreshold = 16 * 1024 * 1024
       $0.resumePolicy = NeverResume<UploadDetails>()
@@ -78,26 +103,15 @@ import Testing
       $0.quotaProject = "default-upload-quota"
     }
 
-    // 1. Falls back to defaults when per-request options are nil
-    let emptyOptions = UploadOptions()
-    let resolvedFromEmpty = emptyOptions.withDefaults(defaults)
-    #expect(resolvedFromEmpty.resumableUploadThreshold == 16 * 1024 * 1024)
-    #expect(resolvedFromEmpty.resumePolicy is NeverResume<UploadDetails>)
-    #expect(resolvedFromEmpty.backoffPolicy is ExponentialBackoff)
-    #expect(resolvedFromEmpty.quotaProject == "default-upload-quota")
-    #expect(resolvedFromEmpty.requestOptions.quotaProject == "default-upload-quota")
-
-    // 2. Per-request options take precedence over defaults
-    let overrideOptions = UploadOptions().with {
-      $0.resumableUploadThreshold = 32 * 1024 * 1024
-      $0.resumePolicy = AlwaysResume<UploadDetails>()
-      $0.quotaProject = "override-upload-quota"
+    let resolved = options.withDefaults(defaults)
+    #expect(resolved.resumableUploadThreshold == expectedThreshold)
+    if expectedIsAlwaysResume {
+      #expect(resolved.resumePolicy is AlwaysResume<UploadDetails>)
+    } else {
+      #expect(resolved.resumePolicy is NeverResume<UploadDetails>)
     }
-    let resolvedFromOverride = overrideOptions.withDefaults(defaults)
-    #expect(resolvedFromOverride.resumableUploadThreshold == 32 * 1024 * 1024)
-    #expect(resolvedFromOverride.resumePolicy is AlwaysResume<UploadDetails>)
-    #expect(resolvedFromOverride.backoffPolicy is ExponentialBackoff)
-    #expect(resolvedFromOverride.quotaProject == "override-upload-quota")
-    #expect(resolvedFromOverride.requestOptions.quotaProject == "override-upload-quota")
+    #expect(resolved.backoffPolicy is ExponentialBackoff)
+    #expect(resolved.quotaProject == expectedQuotaProject)
+    #expect(resolved.requestOptions.quotaProject == expectedQuotaProject)
   }
 }


### PR DESCRIPTION
Towards #785

We add internal helper methods for determining the effective options given the client configuration and per-request settings.