### PR TITLE
feat(gax): simplify ProtoJSON serialization

### DIFF
--- a/pkgs/swift-google-gax/Sources/GoogleCloudGax/HTTPClientRequest.swift
+++ b/pkgs/swift-google-gax/Sources/GoogleCloudGax/HTTPClientRequest.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+@_spi(GoogleCloudInternal) import class GoogleCloudWKT._ProtoJSONEncoder
 import struct AsyncHTTPClient.HTTPClientRequest
 import struct NIOCore.ByteBuffer
 import struct NIOHTTP1.HTTPHeaders
@@ -68,6 +69,15 @@ enum _RequestBody: Sendable {
   public mutating func setBody(data: Data, ofContentType: String) {
     self.body = .data(data)
     self.headers.replaceOrAdd(name: "Content-Type", value: ofContentType)
+  }
+
+  public mutating func setBody<T: Encodable>(
+    json: T,
+    ofContentType contentType: String = "application/json"
+  ) throws {
+    let encoder = _ProtoJSONEncoder()
+    let data = try encoder.encode(json)
+    self.setBody(data: data, ofContentType: contentType)
   }
 
   public mutating func setBody(buffer: NIOCore.ByteBuffer) {

--- a/pkgs/swift-google-gax/Tests/HTTPClientTests.swift
+++ b/pkgs/swift-google-gax/Tests/HTTPClientTests.swift
@@ -179,6 +179,73 @@ import NIOHTTP1
     #expect(data == .init("{}".utf8))
   }
 
+  @Test func postRequestBodyJSON() async throws {
+    struct TestPayload: Encodable {
+      var name: String
+      var floatVal: Float32
+      var doubleVal: Float64
+    }
+
+    let mock = MockHTTPClient { (request, timeout) in
+      #expect(timeout == .seconds(1))
+      #expect(request.method == .POST)
+      #expect(request.url == "http://localhost:8080/v1/projects/my-project/secrets?$alt=json")
+      #expect(request.headers["Content-Type"] == ["application/json"])
+
+      let body = try #require(request.body)
+      let collected = try await body.collect(upTo: 1024)
+      let bodyString = String(buffer: collected)
+      #expect(bodyString.contains(#""floatVal":"NaN""#))
+      #expect(bodyString.contains(#""doubleVal":"Infinity""#))
+      #expect(bodyString.contains(#""name":"test""#))
+
+      return HTTPClientResponse(
+        version: .http1_1,
+        status: .ok,
+        body: .bytes(.init(string: "{}"))
+      )
+    }
+
+    let endpoint = "http://localhost:8080"
+    let path = "/v1/projects/my-project/secrets"
+    let client = try _HTTPClient(mock, endpoint: endpoint)
+    var request = try await client.newRequest(
+      path: path,
+      query: [URLQueryItem(name: "$alt", value: "json")],
+    )
+    request.setMethod(.POST)
+    try request.setBody(
+      json: TestPayload(name: "test", floatVal: .nan, doubleVal: .infinity)
+    )
+    let response = try await request.execute(timeout: .seconds(1))
+    #expect(response.status == .ok)
+  }
+
+  @Test func postRequestBodyJSONCustomContentType() async throws {
+    struct TestPayload: Encodable {
+      var name: String
+    }
+
+    let mock = MockHTTPClient { (request, _) in
+      #expect(request.headers["Content-Type"] == ["application/merge-patch+json"])
+
+      return HTTPClientResponse(
+        version: .http1_1,
+        status: .ok,
+        body: .bytes(.init(string: "{}"))
+      )
+    }
+
+    let client = try _HTTPClient(mock, endpoint: "http://localhost:8080")
+    var request = try await client.newRequest(path: "/v1/test", query: [])
+    try request.setBody(
+      json: TestPayload(name: "patch"),
+      ofContentType: "application/merge-patch+json"
+    )
+    let response = try await request.execute(timeout: .seconds(1))
+    #expect(response.status == .ok)
+  }
+
   @Test func rpcNoTimeout() async throws {
     let mock = MockHTTPClient { (request, timeout) in
       #expect(timeout == _HTTPClientRequest.defaultTimeout)


### PR DESCRIPTION
Add `setBody(json:ofContentType:)` on `_HTTPClientRequest`. This function serializes the `json` parameter using
`GoogleCloudWKT._ProtoJSONEncoder`, which will follow all the ProtoJSON special rules.

Towards #796