### PR TITLE
fix(gax): handle errors with missing gRPC status

### DIFF
--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/DownloadOptions.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/DownloadOptions.swift
@@ -558,6 +558,10 @@ package final class ReadObjectCoordinator: @unchecked Sendable {
             let message = String(data: details.payload, encoding: .utf8) ?? ""
             throw DownloadError.unexpectedServerResponse(
               statusCode: details.http_status_code, message: message)
+          } else if case .service(let details) = err {
+            let statusCode = details.httpStatusCode ?? details.code.httpStatusCode
+            throw DownloadError.unexpectedServerResponse(
+              statusCode: statusCode, message: details.message)
           }
           throw DownloadError.resumeFailed(
             bytesReceived: bytesReceived, message: err.localizedDescription)
@@ -696,6 +700,10 @@ package final class ReadObjectCoordinator: @unchecked Sendable {
           let message = String(data: details.payload, encoding: .utf8) ?? ""
           throw DownloadError.unexpectedServerResponse(
             statusCode: details.http_status_code, message: message)
+        } else if case .service(let details) = reqError {
+          let statusCode = details.httpStatusCode ?? details.code.httpStatusCode
+          throw DownloadError.unexpectedServerResponse(
+            statusCode: statusCode, message: details.message)
         }
       }
       throw DownloadError.resumeFailed(
@@ -750,8 +758,9 @@ package final class ReadObjectCoordinator: @unchecked Sendable {
         throw DownloadError.unexpectedServerResponse(
           statusCode: details.http_status_code, message: message)
       } else if case .service(let details) = error {
+        let statusCode = details.httpStatusCode ?? details.code.httpStatusCode
         throw DownloadError.unexpectedServerResponse(
-          statusCode: 500, message: details.message)
+          statusCode: statusCode, message: details.message)
       } else {
         throw error
       }

--- a/pkgs/swift-google-cloud-storage/Tests/WireErrorTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/WireErrorTests.swift
@@ -1,0 +1,138 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import GoogleCloudAuth
+@_spi(GoogleCloudInternal) import GoogleCloudGax
+@_spi(GoogleCloudInternal) @testable import GoogleCloudStorage
+import Testing
+
+@Suite struct StorageClientWireErrorTests {
+  // The actual JSON error format returned on the wire by Google Cloud Storage.
+  // Note that `error.code` is an HTTP status code (404), and `error.status` is omitted.
+  private static let rawWireErrorJson = """
+    {
+      "error": {
+        "code": 404,
+        "message": "The specified bucket does not exist.",
+        "errors": [
+          {
+            "message": "The specified bucket does not exist.",
+            "domain": "global",
+            "reason": "notFound"
+          }
+        ]
+      }
+    }
+    """
+
+  private func makeClient(registry: MockRegistry) throws -> StorageClient {
+    let options = StorageClientOptions().with {
+      $0.client = .init().with {
+        $0.endpoint = registry.endpoint
+        $0.credentials = try! Credentials(configuration: .anonymous)
+      }
+    }
+    return try StorageClient(options, mock: registry)
+  }
+
+  /// Tests that a simple upload to a non-existent bucket fails with a `.notFound` ServiceError.
+  @Test func simpleUploadWithWireErrorReturnsNotFound() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "non-existent-bucket"
+    let objectName = "test-object"
+    let uploadUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=multipart&name=\(objectName)")
+    registry.register(
+      response: .success(
+        statusCode: 404,
+        data: Data(Self.rawWireErrorJson.utf8),
+        headers: ["content-type": "application/json; charset=UTF-8"]
+      ),
+      for: uploadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    let data = Data("Hello World".utf8)
+    do {
+      _ = try await client.upload(data, to: bucket, as: objectName)
+      Issue.record("Expected upload to fail, but it succeeded")
+    } catch RequestError.service(let serviceError) {
+      #expect(serviceError.code == .notFound)
+      #expect(serviceError.message == "The specified bucket does not exist.")
+    } catch {
+      Issue.record("Expected RequestError.service, but got \(error)")
+    }
+  }
+
+  /// Tests that initiating a resumable upload to a non-existent bucket fails with a `.notFound` ServiceError.
+  @Test func resumableUploadWithWireErrorReturnsNotFound() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "non-existent-bucket"
+    let objectName = "test-object"
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    registry.register(
+      response: .success(
+        statusCode: 404,
+        data: Data(Self.rawWireErrorJson.utf8),
+        headers: ["content-type": "application/json; charset=UTF-8"]
+      ),
+      for: startUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    // 16MB payload triggers resumable upload path (> 8MB default threshold)
+    let data = Data(repeating: 0x42, count: 16 * 1024 * 1024)
+    do {
+      _ = try await client.upload(data, to: bucket, as: objectName)
+      Issue.record("Expected resumable upload to fail, but it succeeded")
+    } catch RequestError.service(let serviceError) {
+      #expect(serviceError.code == .notFound)
+      #expect(serviceError.message == "The specified bucket does not exist.")
+    } catch {
+      Issue.record("Expected RequestError.service, but got \(error)")
+    }
+  }
+
+  /// Tests that downloading a non-existent object fails with HTTP 404.
+  @Test func downloadWithWireErrorReturnsNotFound() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "nonexistent.txt"
+    let downloadUrl = registry.url(
+      "/storage/v1/b/\(bucket)/o/\(objectName)?alt=media")
+    registry.register(
+      response: .success(
+        statusCode: 404,
+        data: Data(Self.rawWireErrorJson.utf8),
+        headers: ["content-type": "application/json; charset=UTF-8"]
+      ),
+      for: downloadUrl
+    )
+
+    let client = try makeClient(registry: registry)
+    do {
+      _ = try await client.readObject(from: bucket, object: objectName).metadata
+      Issue.record("Expected download to fail, but it succeeded")
+    } catch DownloadError.unexpectedServerResponse(let statusCode, let message) {
+      #expect(statusCode == 404)
+      #expect(message == "The specified bucket does not exist.")
+    } catch RequestError.service(let serviceError) {
+      #expect(serviceError.code == .notFound)
+    } catch {
+      Issue.record("Expected 404 not found error, but got \(error)")
+    }
+  }
+}

--- a/pkgs/swift-google-gax/Sources/GoogleCloudGax/ErrorWrapper.swift
+++ b/pkgs/swift-google-gax/Sources/GoogleCloudGax/ErrorWrapper.swift
@@ -39,22 +39,29 @@ import GoogleRpc
     let status: String?
     /// The error message, if any.
     let message: String
-    /// The sequence of error details, wrapped as anys. May be empty or omitted.
+    /// The sequence of error details, wrapped as anys.
+    ///
+    /// Always use `_ProtoJSONDecoder` as the ProtoJSON encoding  may omit this field when empty.
     let details: [GoogleCloudWKT.`Any`]
   }
 }
 
 @_spi(GoogleCloudInternal) extension ServiceError {
-  /// Create a a new `ServiceDetails`.
+  /// Create a new `ServiceError` from an `_ErrorWrapper`.
   public init(
     wrapper: _ErrorWrapper,
+    httpStatusCode: Int? = nil,
   ) {
+    let resolvedHttpStatus = wrapper.error.code != 0 ? Int(wrapper.error.code) : httpStatusCode
     if let s = wrapper.error.status {
       self.code = GoogleRpc.Code.init(stringValue: s)
+    } else if let status = resolvedHttpStatus {
+      self.code = GoogleRpc.Code(httpStatusCode: status)
     } else {
       self.code = .unknown
     }
     self.message = wrapper.error.message
     self.details = wrapper.error.details.map { StatusDetail(from: $0) }
+    self.httpStatusCode = resolvedHttpStatus
   }
 }

--- a/pkgs/swift-google-gax/Sources/GoogleCloudGax/HTTPClientResponse.swift
+++ b/pkgs/swift-google-gax/Sources/GoogleCloudGax/HTTPClientResponse.swift
@@ -77,7 +77,7 @@ import struct NIOCore.ByteBuffer
     let values = response.headers["Content-Type"]
     if values.contains(where: { $0.contains("application/json") }) {
       if let w = _ErrorWrapper(data: data) {
-        return .service(ServiceError(wrapper: w))
+        return .service(ServiceError(wrapper: w, httpStatusCode: Int(response.status.code)))
       }
     }
     let headers = Dictionary(

--- a/pkgs/swift-google-gax/Sources/GoogleCloudGax/ServiceError.swift
+++ b/pkgs/swift-google-gax/Sources/GoogleCloudGax/ServiceError.swift
@@ -23,15 +23,88 @@ public struct ServiceError: Sendable {
   public let message: String
   /// The error details, if any
   public let details: [StatusDetail]
+  /// The HTTP status code, if known.
+  public let httpStatusCode: Int?
 
-  /// Create a a new `ServiceDetails`.
+  /// Create a new `ServiceError`.
+  public init(
+    code: GoogleRpc.Code,
+    message: String,
+    details: [StatusDetail] = []
+  ) {
+    self.init(code: code, message: message, details: details, httpStatusCode: nil)
+  }
+
+  /// Create a new `ServiceError`.
   public init(
     code: GoogleRpc.Code,
     message: String,
     details: [StatusDetail] = [],
+    httpStatusCode: Int?
   ) {
     self.code = code
     self.message = message
     self.details = details
+    self.httpStatusCode = httpStatusCode
+  }
+}
+
+extension GoogleRpc.Code {
+  /// Maps an HTTP status code to the corresponding canonical `GoogleRpc.Code`.
+  public init(httpStatusCode: Int) {
+    switch httpStatusCode {
+    case 200...299:
+      self = .ok
+    case 400:
+      self = .invalidArgument
+    case 401:
+      self = .unauthenticated
+    case 403:
+      self = .permissionDenied
+    case 404:
+      self = .notFound
+    case 409:
+      self = .alreadyExists
+    case 412:
+      self = .failedPrecondition
+    case 429:
+      self = .resourceExhausted
+    case 499:
+      self = .cancelled
+    case 500:
+      self = .internal
+    case 501:
+      self = .unimplemented
+    case 503:
+      self = .unavailable
+    case 504:
+      self = .deadlineExceeded
+    default:
+      self = .unknown
+    }
+  }
+
+  /// Maps a canonical `GoogleRpc.Code` to the corresponding HTTP status code.
+  public var httpStatusCode: Int {
+    switch self {
+    case .ok: return 200
+    case .cancelled: return 499
+    case .unknown: return 500
+    case .invalidArgument: return 400
+    case .deadlineExceeded: return 504
+    case .notFound: return 404
+    case .alreadyExists: return 409
+    case .permissionDenied: return 403
+    case .resourceExhausted: return 429
+    case .failedPrecondition: return 412
+    case .aborted: return 409
+    case .outOfRange: return 400
+    case .unimplemented: return 501
+    case .internal: return 500
+    case .unavailable: return 503
+    case .dataLoss: return 500
+    case .unauthenticated: return 401
+    default: return 500
+    }
   }
 }

--- a/pkgs/swift-google-gax/Tests/ErrorWrapperTests.swift
+++ b/pkgs/swift-google-gax/Tests/ErrorWrapperTests.swift
@@ -62,8 +62,50 @@ import GoogleRpc
     }
 
     let serviceError = ServiceError(wrapper: wrapper)
-    #expect(serviceError.code == .unknown)
+    #expect(serviceError.code == .internal)
+    #expect(serviceError.httpStatusCode == 500)
     #expect(serviceError.message == "internal error message")
+  }
+
+  @Test func httpStatusFallbackWithoutDetails() throws {
+    let cases: [(Int, GoogleRpc.Code)] = [
+      (400, .invalidArgument),
+      (401, .unauthenticated),
+      (403, .permissionDenied),
+      (404, .notFound),
+      (409, .alreadyExists),
+      (412, .failedPrecondition),
+      (429, .resourceExhausted),
+      (499, .cancelled),
+      (500, .internal),
+      (501, .unimplemented),
+      (503, .unavailable),
+      (504, .deadlineExceeded),
+      (418, .unknown),
+    ]
+
+    for (httpCode, expectedRpcCode) in cases {
+      let json = Data(
+        """
+        {
+          "error": {
+            "code": \(httpCode),
+            "message": "error message for \(httpCode)"
+          }
+        }
+        """.utf8)
+
+      guard let wrapper = _ErrorWrapper(data: json) else {
+        Issue.record("Failed to decode ErrorWrapper for httpCode \(httpCode)")
+        continue
+      }
+
+      let serviceError = ServiceError(wrapper: wrapper)
+      #expect(serviceError.code == expectedRpcCode)
+      #expect(serviceError.httpStatusCode == httpCode)
+      #expect(serviceError.message == "error message for \(httpCode)")
+      #expect(serviceError.details.isEmpty)
+    }
   }
 
   @Test func unknownStatus() throws {


### PR DESCRIPTION
Some services (e.g. Storage) return JSON error responses without a gRPC status. GAX used to return `ServiceError.code = .unknown`, which does not work with the retry loop and drops all kinds of useful information.

With this change, map the HTTP status code to canonical `GoogleRpc.Code` values, and capture as many of the error details as possible.

Fixes: #805