### PR TITLE
feat(wkt): ProtoJSON uses strings for 64-bit ints

### DIFF
--- a/Tests/ProtoJSON/FieldsBool.swift
+++ b/Tests/ProtoJSON/FieldsBool.swift
@@ -61,7 +61,7 @@ import Testing
       ),
     ])
   func roundtrip(want: String, input: T) throws {
-    let encoder = JSONEncoder()
+    let encoder = _ProtoJSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
     let data = try encoder.encode(input)
     let got = String(data: data, encoding: .utf8)!

--- a/Tests/ProtoJSON/FieldsBoolValue.swift
+++ b/Tests/ProtoJSON/FieldsBoolValue.swift
@@ -36,4 +36,26 @@ import Testing
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
+
+  @Test(
+    "BoolValue fields serialize",
+    arguments: [
+      (#"{"map":{},"repeated":[]}"#, T()),
+      (#"{"map":{},"repeated":[],"singular":true}"#, T().with { $0.singular = true }),
+      (#"{"map":{},"repeated":[],"singular":false}"#, T().with { $0.singular = false }),
+      (#"{"map":{},"repeated":[true,false]}"#, T().with { $0.repeated = [true, false] }),
+      (#"{"map":{"a":false},"repeated":[]}"#, T().with { $0.map = ["a": false] }),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    #expect(input == roundtrip)
+  }
 }

--- a/Tests/ProtoJSON/FieldsBytes.swift
+++ b/Tests/ProtoJSON/FieldsBytes.swift
@@ -39,4 +39,38 @@ import Testing
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
+
+  @Test(
+    "bytes fields serialize",
+    arguments: [
+      (#"{"map":{},"repeated":[],"singular":""}"#, T()),
+      (
+        #"{"map":{},"repeated":[],"singular":"NDI="}"#,
+        T().with { $0.singular = Data("42".utf8) }
+      ),
+      (
+        #"{"map":{},"option":"NDI=","repeated":[],"singular":""}"#,
+        T().with { $0.option = Data("42".utf8) }
+      ),
+      (
+        #"{"map":{},"repeated":["NDI="],"singular":""}"#,
+        T().with { $0.repeated = [Data("42".utf8)] }
+      ),
+      (
+        #"{"map":{"a":"NDI="},"repeated":[],"singular":""}"#,
+        T().with { $0.map = ["a": Data("42".utf8)] }
+      ),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    #expect(input == roundtrip)
+  }
 }

--- a/Tests/ProtoJSON/FieldsBytesValue.swift
+++ b/Tests/ProtoJSON/FieldsBytesValue.swift
@@ -34,4 +34,34 @@ import Testing
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
+
+  @Test(
+    "BytesValue fields serialize",
+    arguments: [
+      (#"{"map":{},"repeated":[]}"#, T()),
+      (
+        #"{"map":{},"repeated":[],"singular":"NDI="}"#,
+        T().with { $0.singular = Data("42".utf8) }
+      ),
+      (
+        #"{"map":{},"repeated":["NDI="]}"#,
+        T().with { $0.repeated = [Data("42".utf8)] }
+      ),
+      (
+        #"{"map":{"a":"NDI="},"repeated":[]}"#,
+        T().with { $0.map = ["a": Data("42".utf8)] }
+      ),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    #expect(input == roundtrip)
+  }
 }

--- a/Tests/ProtoJSON/FieldsEnum.swift
+++ b/Tests/ProtoJSON/FieldsEnum.swift
@@ -106,7 +106,7 @@ import Testing
       ),
     ])
   func serialize(want: String, input: MessageWithEnum) throws {
-    let encoder = JSONEncoder()
+    let encoder = _ProtoJSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
     let data = try encoder.encode(input)
     let jsonString = String(data: data, encoding: .utf8)!

--- a/Tests/ProtoJSON/FieldsFieldMask.swift
+++ b/Tests/ProtoJSON/FieldsFieldMask.swift
@@ -49,4 +49,38 @@ import Testing
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
+
+  @Test(
+    "FieldMask fields serialize",
+    arguments: [
+      (#"{"map":{},"optional":null,"repeated":[],"singular":null}"#, T()),
+      (
+        #"{"map":{},"optional":null,"repeated":[],"singular":"userDisplayName,photo"}"#,
+        T().with { $0.singular = mask(["user_display_name", "photo"]) }
+      ),
+      (
+        #"{"map":{},"optional":"userDisplayName,photo","repeated":[],"singular":null}"#,
+        T().with { $0.optional = mask(["user_display_name", "photo"]) }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":["userDisplayName,photo"],"singular":null}"#,
+        T().with { $0.repeated = [mask(["user_display_name", "photo"])] }
+      ),
+      (
+        #"{"map":{"a":"userDisplayName,photo"},"optional":null,"repeated":[],"singular":null}"#,
+        T().with { $0.map = ["a": mask(["user_display_name", "photo"])] }
+      ),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    #expect(input == roundtrip)
+  }
 }

--- a/Tests/ProtoJSON/FieldsInt32.swift
+++ b/Tests/ProtoJSON/FieldsInt32.swift
@@ -64,7 +64,7 @@ import Testing
       ),
     ])
   func roundtrip(want: String, input: T) throws {
-    let encoder = JSONEncoder()
+    let encoder = _ProtoJSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
     let data = try encoder.encode(input)
     let got = String(data: data, encoding: .utf8)!

--- a/Tests/ProtoJSON/FieldsInt32Value.swift
+++ b/Tests/ProtoJSON/FieldsInt32Value.swift
@@ -36,4 +36,33 @@ import Testing
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
+
+  @Test(
+    "Int32Value fields serialize",
+    arguments: [
+      (#"{"map":{},"repeated":[]}"#, T()),
+      (#"{"map":{},"repeated":[],"singular":42}"#, T().with { $0.singular = 42 }),
+      (
+        #"{"map":{},"repeated":[],"singular":-2147483648}"#,
+        T().with { $0.singular = Int32.min }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":2147483647}"#,
+        T().with { $0.singular = Int32.max }
+      ),
+      (#"{"map":{},"repeated":[42]}"#, T().with { $0.repeated = [42] }),
+      (#"{"map":{"a":42},"repeated":[]}"#, T().with { $0.map = ["a": 42] }),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    #expect(input == roundtrip)
+  }
 }

--- a/Tests/ProtoJSON/FieldsInt64.swift
+++ b/Tests/ProtoJSON/FieldsInt64.swift
@@ -41,6 +41,8 @@ import Testing
       (#"{"mapValue"   : {}                }"#, T()),
       (#"{"mapValue"   : {"a": 42}         }"#, T().with { $0.mapValue = ["a": 42] }),
       (#"{"mapValue"   : {"a": "42"}       }"#, T().with { $0.mapValue = ["a": 42] }),
+      (#"{"singular"   : "-9223372036854775808"}"#, T().with { $0.singular = Int64.min }),
+      (#"{"singular"   : "9223372036854775807" }"#, T().with { $0.singular = Int64.max }),
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
@@ -51,20 +53,44 @@ import Testing
   @Test(
     arguments: [
       (
-        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":[],"singular":0}"#,
+        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":[],"singular":"0"}"#,
         T()
       ),
       (
-        #"{"mapKey":{"42":"a"},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":[],"singular":0}"#,
+        #"{"mapKey":{"42":"a"},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":[],"singular":"0"}"#,
         T().with { $0.mapKey = [42: "a"] }
       ),
       (
-        #"{"mapKey":{},"mapKeyValue":{"42":7},"mapValue":{},"option":null,"repeated":[],"singular":0}"#,
+        #"{"mapKey":{},"mapKeyValue":{"42":"7"},"mapValue":{},"option":null,"repeated":[],"singular":"0"}"#,
         T().with { $0.mapKeyValue = [42: 7] }
+      ),
+      (
+        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{},"option":"42","repeated":[],"singular":"0"}"#,
+        T().with { $0.option = 42 }
+      ),
+      (
+        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":["4","2"],"singular":"0"}"#,
+        T().with { $0.repeated = [4, 2] }
+      ),
+      (
+        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{"a":"42"},"option":null,"repeated":[],"singular":"0"}"#,
+        T().with { $0.mapValue = ["a": 42] }
+      ),
+      (
+        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":[],"singular":"42"}"#,
+        T().with { $0.singular = 42 }
+      ),
+      (
+        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":[],"singular":"-9223372036854775808"}"#,
+        T().with { $0.singular = Int64.min }
+      ),
+      (
+        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":[],"singular":"9223372036854775807"}"#,
+        T().with { $0.singular = Int64.max }
       ),
     ])
   func roundtrip(want: String, input: T) throws {
-    let encoder = JSONEncoder()
+    let encoder = _ProtoJSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
     let data = try encoder.encode(input)
     let got = String(data: data, encoding: .utf8)!

--- a/Tests/ProtoJSON/FieldsInt64Value.swift
+++ b/Tests/ProtoJSON/FieldsInt64Value.swift
@@ -30,10 +30,41 @@ import Testing
       (#"{"repeated": [42]         }"#, T().with { $0.repeated = [42] }),
       (#"{"map":      {}           }"#, T()),
       (#"{"map":      {"a": 42 }   }"#, T().with { $0.map = ["a": 42] }),
+      (#"{"singular": "-9223372036854775808"}"#, T().with { $0.singular = Int64.min }),
+      (#"{"singular": "9223372036854775807" }"#, T().with { $0.singular = Int64.max }),
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
+  }
+
+  @Test(
+    "Int64Value fields serialize",
+    arguments: [
+      (#"{"map":{},"repeated":[]}"#, T()),
+      (#"{"map":{},"repeated":[],"singular":"42"}"#, T().with { $0.singular = 42 }),
+      (#"{"map":{},"repeated":["42"]}"#, T().with { $0.repeated = [42] }),
+      (#"{"map":{"a":"42"},"repeated":[]}"#, T().with { $0.map = ["a": 42] }),
+      (
+        #"{"map":{},"repeated":[],"singular":"-9223372036854775808"}"#,
+        T().with { $0.singular = Int64.min }
+      ),
+      (
+        #"{"map":{},"repeated":[],"singular":"9223372036854775807"}"#,
+        T().with { $0.singular = Int64.max }
+      ),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    #expect(input == roundtrip)
   }
 }

--- a/Tests/ProtoJSON/FieldsListValue.swift
+++ b/Tests/ProtoJSON/FieldsListValue.swift
@@ -41,4 +41,50 @@ import Testing
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
+
+  @Test(
+    "ListValue fields serialize",
+    arguments: [
+      (#"{"map":{},"optional":null,"repeated":[],"singular":null}"#, T()),
+      (
+        #"{"map":{},"optional":null,"repeated":[],"singular":[]}"#,
+        T().with { $0.singular = [] }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[],"singular":[42]}"#,
+        T().with { $0.singular = [.number(42)] }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[],"singular":["hello"]}"#,
+        T().with { $0.singular = [.string("hello")] }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[],"singular":[42,"hello"]}"#,
+        T().with { $0.singular = [.number(42), .string("hello")] }
+      ),
+      (
+        #"{"map":{},"optional":[42],"repeated":[],"singular":null}"#,
+        T().with { $0.optional = [.number(42)] }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[[42]],"singular":null}"#,
+        T().with { $0.repeated = [[.number(42)]] }
+      ),
+      (
+        #"{"map":{"a":[42]},"optional":null,"repeated":[],"singular":null}"#,
+        T().with { $0.map = ["a": [.number(42)]] }
+      ),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    #expect(input == roundtrip)
+  }
 }

--- a/Tests/ProtoJSON/FieldsNullValue.swift
+++ b/Tests/ProtoJSON/FieldsNullValue.swift
@@ -35,4 +35,30 @@ import Testing
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
+
+  @Test(
+    "NullValue fields serialize",
+    arguments: [
+      (#"{"map":{},"optional":null,"repeated":[],"singular":null}"#, T()),
+      (
+        #"{"map":{},"optional":null,"repeated":[null],"singular":null}"#,
+        T().with { $0.repeated = [NullValue()] }
+      ),
+      (
+        #"{"map":{"a":null},"optional":null,"repeated":[],"singular":null}"#,
+        T().with { $0.map = ["a": NullValue()] }
+      ),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    #expect(input == roundtrip)
+  }
 }

--- a/Tests/ProtoJSON/FieldsRecursion.swift
+++ b/Tests/ProtoJSON/FieldsRecursion.swift
@@ -133,7 +133,7 @@ import Testing
       ]
     }
 
-    let data = try JSONEncoder().encode(input)
+    let data = try _ProtoJSONEncoder().encode(input)
     let decoded = try _ProtoJSONDecoder().decode(MessageWithRecursion.self, from: data)
     #expect(decoded == input)
   }

--- a/Tests/ProtoJSON/FieldsString.swift
+++ b/Tests/ProtoJSON/FieldsString.swift
@@ -61,7 +61,7 @@ import Testing
       ),
     ])
   func roundtrip(want: String, input: T) throws {
-    let encoder = JSONEncoder()
+    let encoder = _ProtoJSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
     let data = try encoder.encode(input)
     let got = String(data: data, encoding: .utf8)!

--- a/Tests/ProtoJSON/FieldsStringValue.swift
+++ b/Tests/ProtoJSON/FieldsStringValue.swift
@@ -33,4 +33,25 @@ import Testing
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
+
+  @Test(
+    "StringValue fields serialize",
+    arguments: [
+      (#"{"map":{},"repeated":[]}"#, T()),
+      (#"{"map":{},"repeated":[],"singular":"42"}"#, T().with { $0.singular = "42" }),
+      (#"{"map":{},"repeated":["42"]}"#, T().with { $0.repeated = ["42"] }),
+      (#"{"map":{"a":"42"},"repeated":[]}"#, T().with { $0.map = ["a": "42"] }),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    #expect(input == roundtrip)
+  }
 }

--- a/Tests/ProtoJSON/FieldsStruct.swift
+++ b/Tests/ProtoJSON/FieldsStruct.swift
@@ -39,4 +39,50 @@ import Testing
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
+
+  @Test(
+    "Struct fields serialize",
+    arguments: [
+      (#"{"map":{},"optional":null,"repeated":[],"singular":null}"#, T()),
+      (
+        #"{"map":{},"optional":null,"repeated":[],"singular":{}}"#,
+        T().with { $0.singular = [:] }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[],"singular":{"a":42}}"#,
+        T().with { $0.singular = ["a": .number(42)] }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[],"singular":{"a":"hello"}}"#,
+        T().with { $0.singular = ["a": .string("hello")] }
+      ),
+      (
+        #"{"map":{},"optional":{"a":42},"repeated":[],"singular":null}"#,
+        T().with { $0.optional = ["a": .number(42)] }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[{}],"singular":null}"#,
+        T().with { $0.repeated = [[:]] }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[{"a":42}],"singular":null}"#,
+        T().with { $0.repeated = [["a": .number(42)]] }
+      ),
+      (
+        #"{"map":{"a":{"b":42}},"optional":null,"repeated":[],"singular":null}"#,
+        T().with { $0.map = ["a": ["b": .number(42)]] }
+      ),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    #expect(input == roundtrip)
+  }
 }

--- a/Tests/ProtoJSON/FieldsUInt32.swift
+++ b/Tests/ProtoJSON/FieldsUInt32.swift
@@ -64,7 +64,7 @@ import Testing
       ),
     ])
   func roundtrip(want: String, input: T) throws {
-    let encoder = JSONEncoder()
+    let encoder = _ProtoJSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
     let data = try encoder.encode(input)
     let got = String(data: data, encoding: .utf8)!

--- a/Tests/ProtoJSON/FieldsUInt32Value.swift
+++ b/Tests/ProtoJSON/FieldsUInt32Value.swift
@@ -36,4 +36,29 @@ import Testing
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
+
+  @Test(
+    "UInt32Value fields serialize",
+    arguments: [
+      (#"{"map":{},"repeated":[]}"#, T()),
+      (#"{"map":{},"repeated":[],"singular":42}"#, T().with { $0.singular = 42 }),
+      (
+        #"{"map":{},"repeated":[],"singular":4294967295}"#,
+        T().with { $0.singular = UInt32.max }
+      ),
+      (#"{"map":{},"repeated":[42]}"#, T().with { $0.repeated = [42] }),
+      (#"{"map":{"a":42},"repeated":[]}"#, T().with { $0.map = ["a": 42] }),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    #expect(input == roundtrip)
+  }
 }

--- a/Tests/ProtoJSON/FieldsUInt64.swift
+++ b/Tests/ProtoJSON/FieldsUInt64.swift
@@ -41,6 +41,7 @@ import Testing
       (#"{"mapValue"   : {}                }"#, T()),
       (#"{"mapValue"   : {"a": 42}         }"#, T().with { $0.mapValue = ["a": 42] }),
       (#"{"mapValue"   : {"a": "42"}       }"#, T().with { $0.mapValue = ["a": 42] }),
+      (#"{"singular"   : "18446744073709551615"}"#, T().with { $0.singular = UInt64.max }),
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
@@ -51,20 +52,40 @@ import Testing
   @Test(
     arguments: [
       (
-        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":[],"singular":0}"#,
+        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":[],"singular":"0"}"#,
         T()
       ),
       (
-        #"{"mapKey":{"42":"a"},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":[],"singular":0}"#,
+        #"{"mapKey":{"42":"a"},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":[],"singular":"0"}"#,
         T().with { $0.mapKey = [42: "a"] }
       ),
       (
-        #"{"mapKey":{},"mapKeyValue":{"42":7},"mapValue":{},"option":null,"repeated":[],"singular":0}"#,
+        #"{"mapKey":{},"mapKeyValue":{"42":"7"},"mapValue":{},"option":null,"repeated":[],"singular":"0"}"#,
         T().with { $0.mapKeyValue = [42: 7] }
+      ),
+      (
+        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{},"option":"42","repeated":[],"singular":"0"}"#,
+        T().with { $0.option = 42 }
+      ),
+      (
+        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":["4","2"],"singular":"0"}"#,
+        T().with { $0.repeated = [4, 2] }
+      ),
+      (
+        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{"a":"42"},"option":null,"repeated":[],"singular":"0"}"#,
+        T().with { $0.mapValue = ["a": 42] }
+      ),
+      (
+        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":[],"singular":"42"}"#,
+        T().with { $0.singular = 42 }
+      ),
+      (
+        #"{"mapKey":{},"mapKeyValue":{},"mapValue":{},"option":null,"repeated":[],"singular":"18446744073709551615"}"#,
+        T().with { $0.singular = UInt64.max }
       ),
     ])
   func roundtrip(want: String, input: T) throws {
-    let encoder = JSONEncoder()
+    let encoder = _ProtoJSONEncoder()
     encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
     let data = try encoder.encode(input)
     let got = String(data: data, encoding: .utf8)!

--- a/Tests/ProtoJSON/FieldsUInt64Value.swift
+++ b/Tests/ProtoJSON/FieldsUInt64Value.swift
@@ -20,7 +20,7 @@ import Testing
   typealias T = MessageWithUInt64Value
 
   @Test(
-    "UInt32Value fields deserialize",
+    "UInt64Value fields deserialize",
     arguments: [
       (#"{}"#, T()),
       (#"{"singular": null         }"#, T()),
@@ -30,10 +30,36 @@ import Testing
       (#"{"repeated": [42]         }"#, T().with { $0.repeated = [42] }),
       (#"{"map":      {}           }"#, T()),
       (#"{"map":      {"a": 42 }   }"#, T().with { $0.map = ["a": 42] }),
+      (#"{"singular": "18446744073709551615"}"#, T().with { $0.singular = UInt64.max }),
     ])
   func deserialize(input: String, want: T) throws {
     let decoder = _ProtoJSONDecoder()
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
+  }
+
+  @Test(
+    "UInt64Value fields serialize",
+    arguments: [
+      (#"{"map":{},"repeated":[]}"#, T()),
+      (#"{"map":{},"repeated":[],"singular":"42"}"#, T().with { $0.singular = 42 }),
+      (#"{"map":{},"repeated":["42"]}"#, T().with { $0.repeated = [42] }),
+      (#"{"map":{"a":"42"},"repeated":[]}"#, T().with { $0.map = ["a": 42] }),
+      (
+        #"{"map":{},"repeated":[],"singular":"18446744073709551615"}"#,
+        T().with { $0.singular = UInt64.max }
+      ),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    #expect(input == roundtrip)
   }
 }

--- a/Tests/ProtoJSON/FieldsValue.swift
+++ b/Tests/ProtoJSON/FieldsValue.swift
@@ -45,4 +45,62 @@ import Testing
     let got = try decoder.decode(T.self, from: Data(input.utf8))
     #expect(got == want)
   }
+
+  @Test(
+    "Value fields serialize",
+    arguments: [
+      (#"{"map":{},"optional":null,"repeated":[],"singular":null}"#, T()),
+      (
+        #"{"map":{},"optional":null,"repeated":[],"singular":42}"#,
+        T().with { $0.singular = .number(42) }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[],"singular":"hello"}"#,
+        T().with { $0.singular = .string("hello") }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[],"singular":true}"#,
+        T().with { $0.singular = .bool(true) }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[],"singular":{}}"#,
+        T().with { $0.singular = .object([:]) }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[],"singular":[]}"#,
+        T().with { $0.singular = .array([]) }
+      ),
+      (
+        #"{"map":{},"optional":42,"repeated":[],"singular":null}"#,
+        T().with { $0.optional = .number(42) }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[null],"singular":null}"#,
+        T().with { $0.repeated = [.null(NullValue())] }
+      ),
+      (
+        #"{"map":{},"optional":null,"repeated":[42,"hello"],"singular":null}"#,
+        T().with { $0.repeated = [.number(42), .string("hello")] }
+      ),
+      (
+        #"{"map":{"a":42},"optional":null,"repeated":[],"singular":null}"#,
+        T().with { $0.map = ["a": .number(42)] }
+      ),
+      (
+        #"{"map":{"a":null},"optional":null,"repeated":[],"singular":null}"#,
+        T().with { $0.map = ["a": .null(NullValue())] }
+      ),
+    ]
+  )
+  func serialize(want: String, input: T) throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(input)
+    let got = String(data: data, encoding: .utf8)!
+    #expect(got == want)
+
+    let decoder = _ProtoJSONDecoder()
+    let roundtrip = try decoder.decode(T.self, from: data)
+    #expect(input == roundtrip)
+  }
 }

--- a/Tests/ProtoJSON/generated/MessageWithUInt64Value.swift
+++ b/Tests/ProtoJSON/generated/MessageWithUInt64Value.swift
@@ -17,18 +17,18 @@
 import Foundation
 @_spi(GoogleCloudInternal) import GoogleCloudWKT
 
-/// A test message for google.protobuf.Int64Value.
+/// A test message for google.protobuf.UInt64Value.
 public struct MessageWithUInt64Value: Codable, Equatable, GoogleCloudWKT._AnyPackable,
   Sendable
 {
   /// A singular field.
-  public var singular: GoogleCloudWKT.Int64Value? = nil
+  public var singular: GoogleCloudWKT.UInt64Value? = nil
 
   /// A repeated field.
-  public var repeated: [GoogleCloudWKT.Int64Value] = []
+  public var repeated: [GoogleCloudWKT.UInt64Value] = []
 
-  /// Test google.protobuf.Int64Value as values.
-  public var map: [Swift.String: GoogleCloudWKT.Int64Value] = [:]
+  /// Test google.protobuf.UInt64Value as values.
+  public var map: [Swift.String: GoogleCloudWKT.UInt64Value] = [:]
 
   /// Initialize a new instance of `MessageWithUInt64Value`.
   public init() {}

--- a/Tests/ProtoJSON/protos/well_known_types.proto
+++ b/Tests/ProtoJSON/protos/well_known_types.proto
@@ -80,14 +80,14 @@ message MessageWithInt64Value {
   map<string, google.protobuf.Int64Value> map = 4;
 }
 
-// A test message for google.protobuf.Int64Value.
+// A test message for google.protobuf.UInt64Value.
 message MessageWithUInt64Value {
   // A singular field.
-  google.protobuf.Int64Value singular = 1;
+  google.protobuf.UInt64Value singular = 1;
   // A repeated field.
-  repeated google.protobuf.Int64Value repeated = 3;
-  // Test google.protobuf.Int64Value as values.
-  map<string, google.protobuf.Int64Value> map = 4;
+  repeated google.protobuf.UInt64Value repeated = 3;
+  // Test google.protobuf.UInt64Value as values.
+  map<string, google.protobuf.UInt64Value> map = 4;
 }
 
 // A test message for google.protobuf.BytesValue.

--- a/pkgs/swift-google-wkt/Sources/GoogleCloudWKT/ProtoJSONEncoder.swift
+++ b/pkgs/swift-google-wkt/Sources/GoogleCloudWKT/ProtoJSONEncoder.swift
@@ -19,6 +19,7 @@ import Foundation
 /// The Google Cloud client libraries for Swift use HTTP+JSON as their primary transport.
 /// The ProtoJSON encoding differs from typical JSON in a number of ways, including:
 /// - Non-number floating point values (NaN, +Inf, -Inf) are represented as strings.
+/// - 64-bit integers (Int64, UInt64) are represented as strings.
 ///
 /// This encoder configures the native Swift JSON encoder to implement ProtoJSON rules.
 @_spi(GoogleCloudInternal) final public class _ProtoJSONEncoder {
@@ -34,6 +35,445 @@ import Foundation
       negativeInfinity: "-Infinity",
       nan: "NaN"
     )
-    return try encoder.encode(value)
+    return try encoder.encode(Interceptor(inner: value))
+  }
+}
+
+fileprivate protocol _OptionalProtocol {
+  var _isNil: Bool { get }
+  var _unwrappedValue: Any? { get }
+}
+
+extension Optional: _OptionalProtocol {
+  var _isNil: Bool { self == nil }
+  var _unwrappedValue: Any? {
+    switch self {
+    case .some(let val): return val
+    case .none: return nil
+    }
+  }
+}
+
+fileprivate struct Interceptor<T: Encodable>: Encodable {
+  let inner: T
+
+  func encode(to encoder: any Encoder) throws {
+    try self.inner.encode(to: InternalEncoder(impl: encoder))
+  }
+}
+
+fileprivate struct InternalEncoder {
+  let impl: any Encoder
+
+  init(impl: any Encoder) { self.impl = impl }
+}
+
+extension InternalEncoder: Encoder {
+  var codingPath: [any CodingKey] { self.impl.codingPath }
+  var userInfo: [CodingUserInfoKey: Any] { self.impl.userInfo }
+
+  func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
+    let impl = self.impl.container(keyedBy: type)
+    return KeyedEncodingContainer(InternalKeyedContainer(impl))
+  }
+
+  func unkeyedContainer() -> any UnkeyedEncodingContainer {
+    let impl = self.impl.unkeyedContainer()
+    return InternalUnkeyedEncodingContainer(impl)
+  }
+
+  func singleValueContainer() -> any SingleValueEncodingContainer {
+    let impl = self.impl.singleValueContainer()
+    return InternalSingleValueEncodingContainer(impl)
+  }
+}
+
+fileprivate struct InternalKeyedContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
+  typealias Key = K
+  var impl: KeyedEncodingContainer<K>
+
+  init(_ impl: KeyedEncodingContainer<K>) { self.impl = impl }
+
+  var codingPath: [any CodingKey] { self.impl.codingPath }
+
+  mutating func encodeNil(forKey key: K) throws {
+    try self.impl.encodeNil(forKey: key)
+  }
+
+  mutating func encode(_ value: Bool, forKey key: K) throws {
+    try self.impl.encode(value, forKey: key)
+  }
+
+  mutating func encode(_ value: String, forKey key: K) throws {
+    try self.impl.encode(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Double, forKey key: K) throws {
+    try self.impl.encode(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Float, forKey key: K) throws {
+    try self.impl.encode(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Int, forKey key: K) throws {
+    try self.impl.encode(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Int8, forKey key: K) throws {
+    try self.impl.encode(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Int16, forKey key: K) throws {
+    try self.impl.encode(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Int32, forKey key: K) throws {
+    try self.impl.encode(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Int64, forKey key: K) throws {
+    try self.impl.encode(String(value), forKey: key)
+  }
+
+  mutating func encode(_ value: UInt, forKey key: K) throws {
+    try self.impl.encode(value, forKey: key)
+  }
+
+  mutating func encode(_ value: UInt8, forKey key: K) throws {
+    try self.impl.encode(value, forKey: key)
+  }
+
+  mutating func encode(_ value: UInt16, forKey key: K) throws {
+    try self.impl.encode(value, forKey: key)
+  }
+
+  mutating func encode(_ value: UInt32, forKey key: K) throws {
+    try self.impl.encode(value, forKey: key)
+  }
+
+  mutating func encode(_ value: UInt64, forKey key: K) throws {
+    try self.impl.encode(String(value), forKey: key)
+  }
+
+  mutating func encode<T>(_ value: T, forKey key: K) throws where T: Encodable {
+    if let opt = value as? _OptionalProtocol, opt._isNil {
+      try self.impl.encodeNil(forKey: key)
+    } else if let opt = value as? _OptionalProtocol, let unwrapped = opt._unwrappedValue {
+      if let v = unwrapped as? Int64 {
+        try self.impl.encode(String(v), forKey: key)
+      } else if let v = unwrapped as? UInt64 {
+        try self.impl.encode(String(v), forKey: key)
+      } else {
+        try self.impl.encode(Interceptor(inner: value), forKey: key)
+      }
+    } else if let v = value as? Int64 {
+      try self.impl.encode(String(v), forKey: key)
+    } else if let v = value as? UInt64 {
+      try self.impl.encode(String(v), forKey: key)
+    } else if let v = value as? String {
+      try self.impl.encode(v, forKey: key)
+    } else if let v = value as? Bool {
+      try self.impl.encode(v, forKey: key)
+    } else if let v = value as? Double {
+      try self.impl.encode(v, forKey: key)
+    } else if let v = value as? Float {
+      try self.impl.encode(v, forKey: key)
+    } else if let v = value as? Int {
+      try self.impl.encode(v, forKey: key)
+    } else if let v = value as? Int8 {
+      try self.impl.encode(v, forKey: key)
+    } else if let v = value as? Int16 {
+      try self.impl.encode(v, forKey: key)
+    } else if let v = value as? Int32 {
+      try self.impl.encode(v, forKey: key)
+    } else if let v = value as? UInt {
+      try self.impl.encode(v, forKey: key)
+    } else if let v = value as? UInt8 {
+      try self.impl.encode(v, forKey: key)
+    } else if let v = value as? UInt16 {
+      try self.impl.encode(v, forKey: key)
+    } else if let v = value as? UInt32 {
+      try self.impl.encode(v, forKey: key)
+    } else if let v = value as? Data {
+      try self.impl.encode(v, forKey: key)
+    } else {
+      try self.impl.encode(Interceptor(inner: value), forKey: key)
+    }
+  }
+
+  mutating func encodeConditional<T>(_ object: T, forKey key: K) throws
+  where T: AnyObject, T: Encodable {
+    try self.impl.encodeConditional(object, forKey: key)
+  }
+
+  mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: K)
+    -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey
+  {
+    let nested = self.impl.nestedContainer(keyedBy: keyType, forKey: key)
+    return KeyedEncodingContainer(InternalKeyedContainer<NestedKey>(nested))
+  }
+
+  mutating func nestedUnkeyedContainer(forKey key: K) -> any UnkeyedEncodingContainer {
+    let nested = self.impl.nestedUnkeyedContainer(forKey: key)
+    return InternalUnkeyedEncodingContainer(nested)
+  }
+
+  mutating func superEncoder() -> any Encoder {
+    return InternalEncoder(impl: self.impl.superEncoder())
+  }
+
+  mutating func superEncoder(forKey key: K) -> any Encoder {
+    return InternalEncoder(impl: self.impl.superEncoder(forKey: key))
+  }
+}
+
+fileprivate struct InternalUnkeyedEncodingContainer: UnkeyedEncodingContainer {
+  var impl: any UnkeyedEncodingContainer
+
+  init(_ impl: any UnkeyedEncodingContainer) { self.impl = impl }
+
+  var codingPath: [any CodingKey] { self.impl.codingPath }
+  var count: Int { self.impl.count }
+
+  mutating func encodeNil() throws {
+    try self.impl.encodeNil()
+  }
+
+  mutating func encode(_ value: Bool) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: String) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Double) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Float) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Int) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Int8) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Int16) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Int32) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Int64) throws {
+    try self.impl.encode(String(value))
+  }
+
+  mutating func encode(_ value: UInt) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: UInt8) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: UInt16) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: UInt32) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: UInt64) throws {
+    try self.impl.encode(String(value))
+  }
+
+  mutating func encode<T>(_ value: T) throws where T: Encodable {
+    if let opt = value as? _OptionalProtocol, opt._isNil {
+      try self.impl.encodeNil()
+    } else if let opt = value as? _OptionalProtocol, let unwrapped = opt._unwrappedValue {
+      if let v = unwrapped as? Int64 {
+        try self.impl.encode(String(v))
+      } else if let v = unwrapped as? UInt64 {
+        try self.impl.encode(String(v))
+      } else {
+        try self.impl.encode(Interceptor(inner: value))
+      }
+    } else if let v = value as? Int64 {
+      try self.impl.encode(String(v))
+    } else if let v = value as? UInt64 {
+      try self.impl.encode(String(v))
+    } else if let v = value as? String {
+      try self.impl.encode(v)
+    } else if let v = value as? Bool {
+      try self.impl.encode(v)
+    } else if let v = value as? Double {
+      try self.impl.encode(v)
+    } else if let v = value as? Float {
+      try self.impl.encode(v)
+    } else if let v = value as? Int {
+      try self.impl.encode(v)
+    } else if let v = value as? Int8 {
+      try self.impl.encode(v)
+    } else if let v = value as? Int16 {
+      try self.impl.encode(v)
+    } else if let v = value as? Int32 {
+      try self.impl.encode(v)
+    } else if let v = value as? UInt {
+      try self.impl.encode(v)
+    } else if let v = value as? UInt8 {
+      try self.impl.encode(v)
+    } else if let v = value as? UInt16 {
+      try self.impl.encode(v)
+    } else if let v = value as? UInt32 {
+      try self.impl.encode(v)
+    } else if let v = value as? Data {
+      try self.impl.encode(v)
+    } else {
+      try self.impl.encode(Interceptor(inner: value))
+    }
+  }
+
+  mutating func encodeConditional<T>(_ object: T) throws
+  where T: AnyObject, T: Encodable {
+    try self.impl.encodeConditional(object)
+  }
+
+  mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type)
+    -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey
+  {
+    let nested = self.impl.nestedContainer(keyedBy: keyType)
+    return KeyedEncodingContainer(InternalKeyedContainer<NestedKey>(nested))
+  }
+
+  mutating func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
+    let nested = self.impl.nestedUnkeyedContainer()
+    return InternalUnkeyedEncodingContainer(nested)
+  }
+
+  mutating func superEncoder() -> any Encoder {
+    return InternalEncoder(impl: self.impl.superEncoder())
+  }
+}
+
+fileprivate struct InternalSingleValueEncodingContainer: SingleValueEncodingContainer {
+  var impl: any SingleValueEncodingContainer
+
+  init(_ impl: any SingleValueEncodingContainer) { self.impl = impl }
+
+  var codingPath: [any CodingKey] { self.impl.codingPath }
+
+  mutating func encodeNil() throws {
+    try self.impl.encodeNil()
+  }
+
+  mutating func encode(_ value: Bool) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: String) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Double) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Float) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Int) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Int8) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Int16) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Int32) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: Int64) throws {
+    try self.impl.encode(String(value))
+  }
+
+  mutating func encode(_ value: UInt) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: UInt8) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: UInt16) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: UInt32) throws {
+    try self.impl.encode(value)
+  }
+
+  mutating func encode(_ value: UInt64) throws {
+    try self.impl.encode(String(value))
+  }
+
+  mutating func encode<T>(_ value: T) throws where T: Encodable {
+    if let opt = value as? _OptionalProtocol, opt._isNil {
+      try self.impl.encodeNil()
+    } else if let opt = value as? _OptionalProtocol, let unwrapped = opt._unwrappedValue {
+      if let v = unwrapped as? Int64 {
+        try self.impl.encode(String(v))
+      } else if let v = unwrapped as? UInt64 {
+        try self.impl.encode(String(v))
+      } else {
+        try self.impl.encode(Interceptor(inner: value))
+      }
+    } else if let v = value as? Int64 {
+      try self.impl.encode(String(v))
+    } else if let v = value as? UInt64 {
+      try self.impl.encode(String(v))
+    } else if let v = value as? String {
+      try self.impl.encode(v)
+    } else if let v = value as? Bool {
+      try self.impl.encode(v)
+    } else if let v = value as? Double {
+      try self.impl.encode(v)
+    } else if let v = value as? Float {
+      try self.impl.encode(v)
+    } else if let v = value as? Int {
+      try self.impl.encode(v)
+    } else if let v = value as? Int8 {
+      try self.impl.encode(v)
+    } else if let v = value as? Int16 {
+      try self.impl.encode(v)
+    } else if let v = value as? Int32 {
+      try self.impl.encode(v)
+    } else if let v = value as? UInt {
+      try self.impl.encode(v)
+    } else if let v = value as? UInt8 {
+      try self.impl.encode(v)
+    } else if let v = value as? UInt16 {
+      try self.impl.encode(v)
+    } else if let v = value as? UInt32 {
+      try self.impl.encode(v)
+    } else if let v = value as? Data {
+      try self.impl.encode(v)
+    } else {
+      try self.impl.encode(Interceptor(inner: value))
+    }
   }
 }

--- a/pkgs/swift-google-wkt/Tests/ProtoJSONEncoderTest.swift
+++ b/pkgs/swift-google-wkt/Tests/ProtoJSONEncoderTest.swift
@@ -66,4 +66,67 @@ import Testing
     let decoded = try decoder.decode(FloatModel.self, from: data)
     #expect(decoded == model)
   }
+
+  struct Int64Model: Codable, Equatable {
+    var singular: Int64
+    var option: Int64?
+    var repeated: [Int64]
+    var mapValue: [String: Int64]
+    var uint64Val: UInt64
+    var uint64Option: UInt64?
+    var uint64Repeated: [UInt64]
+    var uint64Map: [String: UInt64]
+  }
+
+  @Test func encode64BitIntegers() throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+
+    let model = Int64Model(
+      singular: 42,
+      option: 123,
+      repeated: [1, 2, 3],
+      mapValue: ["key": 99],
+      uint64Val: 42,
+      uint64Option: 123,
+      uint64Repeated: [1, 2, 3],
+      uint64Map: ["key": 99]
+    )
+    let data = try encoder.encode(model)
+    let jsonString = try #require(String(data: data, encoding: .utf8))
+    #expect(
+      jsonString
+        == #"{"mapValue":{"key":"99"},"option":"123","repeated":["1","2","3"],"singular":"42","uint64Map":{"key":"99"},"uint64Option":"123","uint64Repeated":["1","2","3"],"uint64Val":"42"}"#
+    )
+
+    let decoder = _ProtoJSONDecoder()
+    let decoded = try decoder.decode(Int64Model.self, from: data)
+    #expect(decoded == model)
+  }
+
+  @Test func encode64BitIntegersMinMax() throws {
+    let encoder = _ProtoJSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+
+    let model = Int64Model(
+      singular: Int64.min,
+      option: Int64.max,
+      repeated: [Int64.min, 0, Int64.max],
+      mapValue: ["min": Int64.min, "max": Int64.max],
+      uint64Val: UInt64.min,
+      uint64Option: UInt64.max,
+      uint64Repeated: [UInt64.min, UInt64.max],
+      uint64Map: ["min": UInt64.min, "max": UInt64.max]
+    )
+    let data = try encoder.encode(model)
+    let jsonString = try #require(String(data: data, encoding: .utf8))
+    #expect(
+      jsonString
+        == #"{"mapValue":{"max":"9223372036854775807","min":"-9223372036854775808"},"option":"9223372036854775807","repeated":["-9223372036854775808","0","9223372036854775807"],"singular":"-9223372036854775808","uint64Map":{"max":"18446744073709551615","min":"0"},"uint64Option":"18446744073709551615","uint64Repeated":["0","18446744073709551615"],"uint64Val":"0"}"#
+    )
+
+    let decoder = _ProtoJSONDecoder()
+    let decoded = try decoder.decode(Int64Model.self, from: data)
+    #expect(decoded == model)
+  }
 }


### PR DESCRIPTION
Change _ProtoJSONEncoder to use strings for 64-bit integers (Int64, UInt64, and the wrappers for them).

Updarte the integration tests to use _ProtoJSONEncoder, for all types (in case I introduced a bug for some other type). Expand the tests to better cover 64-bit integers, including extreme values.

Fix `MessageWithUInt64Value` to actually use UInt64 values, ooops.

Fixes #784