### PR TITLE
fix(wkt): integer serialization into `Any`

### DIFF
--- a/pkgs/swift-google-wkt/Sources/GoogleCloudWKT/Int32Value.swift
+++ b/pkgs/swift-google-wkt/Sources/GoogleCloudWKT/Int32Value.swift
@@ -29,10 +29,20 @@ extension Swift.Int32: _AnyPackable {
     guard let v = any.fields[`Any`.valueField] else {
       throw AnyError.missingValueField
     }
-    guard case let .number(n) = v else {
+    switch v {
+    case .number(let n):
+      guard let n = Int32(exactly: n) else {
+        throw AnyError.invalidValueField
+      }
+      self = n
+    case .string(let s):
+      guard let n = Int32(s) else {
+        throw AnyError.invalidValueField
+      }
+      self = n
+    default:
       throw AnyError.invalidValueField
     }
-    self = Int32(n)
   }
 
   public func _pack() throws -> Struct {

--- a/pkgs/swift-google-wkt/Sources/GoogleCloudWKT/Int64Value.swift
+++ b/pkgs/swift-google-wkt/Sources/GoogleCloudWKT/Int64Value.swift
@@ -14,7 +14,7 @@
 
 /// Wrapper message for int64.
 ///
-/// The JSON representation for Int64Value is JSON number.
+/// The JSON representation for Int64Value is decimal string.
 public typealias Int64Value = Swift.Int64
 
 extension Swift.Int64: _AnyPackable {
@@ -29,13 +29,23 @@ extension Swift.Int64: _AnyPackable {
     guard let v = any.fields[`Any`.valueField] else {
       throw AnyError.missingValueField
     }
-    guard case let .number(n) = v else {
+    switch v {
+    case .string(let s):
+      guard let n = Int64(s) else {
+        throw AnyError.invalidValueField
+      }
+      self = n
+    case .number(let n):
+      guard let n = Int64(exactly: n) else {
+        throw AnyError.invalidValueField
+      }
+      self = n
+    default:
       throw AnyError.invalidValueField
     }
-    self = Int64(n)
   }
 
   public func _pack() throws -> Struct {
-    return [`Any`.valueField: Value(number: Double(self))]
+    return [`Any`.valueField: Value(string: String(self))]
   }
 }

--- a/pkgs/swift-google-wkt/Sources/GoogleCloudWKT/UInt32Value.swift
+++ b/pkgs/swift-google-wkt/Sources/GoogleCloudWKT/UInt32Value.swift
@@ -29,10 +29,20 @@ extension Swift.UInt32: _AnyPackable {
     guard let v = any.fields[`Any`.valueField] else {
       throw AnyError.missingValueField
     }
-    guard case let .number(n) = v else {
+    switch v {
+    case .number(let n):
+      guard let n = UInt32(exactly: n) else {
+        throw AnyError.invalidValueField
+      }
+      self = n
+    case .string(let s):
+      guard let n = UInt32(s) else {
+        throw AnyError.invalidValueField
+      }
+      self = n
+    default:
       throw AnyError.invalidValueField
     }
-    self = UInt32(n)
   }
 
   public func _pack() throws -> Struct {

--- a/pkgs/swift-google-wkt/Sources/GoogleCloudWKT/UInt64Value.swift
+++ b/pkgs/swift-google-wkt/Sources/GoogleCloudWKT/UInt64Value.swift
@@ -14,7 +14,7 @@
 
 /// Wrapper message for uint64.
 ///
-/// The JSON representation for UInt64Value is JSON number.
+/// The JSON representation for UInt64Value is decimal string.
 public typealias UInt64Value = Swift.UInt64
 
 extension Swift.UInt64: _AnyPackable {
@@ -29,13 +29,23 @@ extension Swift.UInt64: _AnyPackable {
     guard let v = any.fields[`Any`.valueField] else {
       throw AnyError.missingValueField
     }
-    guard case let .number(n) = v else {
+    switch v {
+    case .string(let s):
+      guard let n = UInt64(s) else {
+        throw AnyError.invalidValueField
+      }
+      self = n
+    case .number(let n):
+      guard let n = UInt64(exactly: n) else {
+        throw AnyError.invalidValueField
+      }
+      self = n
+    default:
       throw AnyError.invalidValueField
     }
-    self = UInt64(n)
   }
 
   public func _pack() throws -> Struct {
-    return [`Any`.valueField: Value(number: Double(self))]
+    return [`Any`.valueField: Value(string: String(self))]
   }
 }

--- a/pkgs/swift-google-wkt/Tests/Int32ValueTests.swift
+++ b/pkgs/swift-google-wkt/Tests/Int32ValueTests.swift
@@ -73,10 +73,25 @@ import Testing
     let content: GoogleCloudWKT.`Any`
   }
 
-  @Test("Unpack Int32Value from Any")
-  func int32ValueAnyUnpack() throws {
+  @Test("Unpack Int32Value from Any with number")
+  func int32ValueAnyUnpackNumber() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":123}}"#
+    let data = Data(jsonString.utf8)
+    let decoder = JSONDecoder()
+    let wrapped = try decoder.decode(Int32ValueTests.WrappedAny.self, from: data)
+    let any = wrapped.content
+    #expect(any.typeUrl == "type.googleapis.com/google.protobuf.Int32Value")
+
+    let got = try Int32Value(fromAny: any)
+    let want = Int32(123)
+    #expect(got == want)
+  }
+
+  @Test("Unpack Int32Value from Any with string")
+  func int32ValueAnyUnpackString() throws {
+    let jsonString =
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":"123"}}"#
     let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(Int32ValueTests.WrappedAny.self, from: data)
@@ -112,5 +127,49 @@ import Testing
     let want =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":123}}"#
     #expect(got == want)
+  }
+
+  @Test(
+    "Pack and Unpack Int32Value boundaries in Any",
+    arguments: [
+      Int32.min,
+      Int32.max,
+      0,
+    ])
+  func int32ValueBoundaries(_ value: Int32) throws {
+    let any = try `Any`(fromMessage: value)
+    let wrapped = Int32ValueTests.WrappedAny(content: any)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(wrapped)
+    let gotJson = String(data: data, encoding: .utf8)!
+    let wantJson =
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":\#(value)}}"#
+    #expect(gotJson == wantJson)
+
+    let decoder = JSONDecoder()
+    let decodedWrapped = try decoder.decode(Int32ValueTests.WrappedAny.self, from: data)
+    let unpacked = try Int32(fromAny: decodedWrapped.content)
+    #expect(unpacked == value)
+  }
+
+  @Test(
+    "Unpack Int32Value invalid value field in Any",
+    arguments: [
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":"not-a-number"}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":"2147483648"}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":1e20}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":123.45}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":true}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":{}}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":[]}}"#,
+    ])
+  func int32ValueInvalidValue(_ json: String) throws {
+    let data = Data(json.utf8)
+    let decoder = JSONDecoder()
+    let wrapped = try decoder.decode(Int32ValueTests.WrappedAny.self, from: data)
+    #expect(throws: AnyError.invalidValueField) {
+      let _ = try Int32(fromAny: wrapped.content)
+    }
   }
 }

--- a/pkgs/swift-google-wkt/Tests/Int64ValueTests.swift
+++ b/pkgs/swift-google-wkt/Tests/Int64ValueTests.swift
@@ -73,8 +73,23 @@ import Testing
     let content: GoogleCloudWKT.`Any`
   }
 
-  @Test("Unpack Int64Value from Any")
-  func int64ValueAnyUnpack() throws {
+  @Test("Unpack Int64Value from Any with string")
+  func int64ValueAnyUnpackString() throws {
+    let jsonString =
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int64Value","value":"123"}}"#
+    let data = Data(jsonString.utf8)
+    let decoder = JSONDecoder()
+    let wrapped = try decoder.decode(Int64ValueTests.WrappedAny.self, from: data)
+    let any = wrapped.content
+    #expect(any.typeUrl == "type.googleapis.com/google.protobuf.Int64Value")
+
+    let got = try Int64Value(fromAny: any)
+    let want = Int64(123)
+    #expect(got == want)
+  }
+
+  @Test("Unpack Int64Value from Any with number")
+  func int64ValueAnyUnpackNumber() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int64Value","value":123}}"#
     let data = Data(jsonString.utf8)
@@ -90,7 +105,7 @@ import Testing
 
   @Test func int64ValueAnyUnpackMismatchedUrl() throws {
     let jsonString =
-      #"{"content":{"@type":"bad","value":123}}"#
+      #"{"content":{"@type":"bad","value":"123"}}"#
     let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(Int64ValueTests.WrappedAny.self, from: data)
@@ -110,7 +125,50 @@ import Testing
     let got = String(data: data, encoding: .utf8)!
 
     let want =
-      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int64Value","value":123}}"#
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int64Value","value":"123"}}"#
     #expect(got == want)
+  }
+
+  @Test(
+    "Pack and Unpack Int64Value boundaries in Any",
+    arguments: [
+      Int64.min,
+      Int64.max,
+      0,
+    ])
+  func int64ValueBoundaries(_ value: Int64) throws {
+    let any = try `Any`(fromMessage: value)
+    let wrapped = Int64ValueTests.WrappedAny(content: any)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(wrapped)
+    let gotJson = String(data: data, encoding: .utf8)!
+    let wantJson =
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int64Value","value":"\#(value)"}}"#
+    #expect(gotJson == wantJson)
+
+    let decoder = JSONDecoder()
+    let decodedWrapped = try decoder.decode(Int64ValueTests.WrappedAny.self, from: data)
+    let unpacked = try Int64(fromAny: decodedWrapped.content)
+    #expect(unpacked == value)
+  }
+
+  @Test(
+    "Unpack Int64Value invalid value field in Any",
+    arguments: [
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int64Value","value":"not-a-number"}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int64Value","value":"9223372036854775808"}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int64Value","value":123.45}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int64Value","value":true}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int64Value","value":{}}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.Int64Value","value":[]}}"#,
+    ])
+  func int64ValueInvalidValue(_ json: String) throws {
+    let data = Data(json.utf8)
+    let decoder = JSONDecoder()
+    let wrapped = try decoder.decode(Int64ValueTests.WrappedAny.self, from: data)
+    #expect(throws: AnyError.invalidValueField) {
+      let _ = try Int64(fromAny: wrapped.content)
+    }
   }
 }

--- a/pkgs/swift-google-wkt/Tests/UInt32ValueTests.swift
+++ b/pkgs/swift-google-wkt/Tests/UInt32ValueTests.swift
@@ -73,10 +73,25 @@ import Testing
     let content: GoogleCloudWKT.`Any`
   }
 
-  @Test("Unpack UInt32Value from Any")
-  func uint32ValueAnyUnpack() throws {
+  @Test("Unpack UInt32Value from Any with number")
+  func uint32ValueAnyUnpackNumber() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":123}}"#
+    let data = Data(jsonString.utf8)
+    let decoder = JSONDecoder()
+    let wrapped = try decoder.decode(UInt32ValueTests.WrappedAny.self, from: data)
+    let any = wrapped.content
+    #expect(any.typeUrl == "type.googleapis.com/google.protobuf.UInt32Value")
+
+    let got = try UInt32Value(fromAny: any)
+    let want = UInt32(123)
+    #expect(got == want)
+  }
+
+  @Test("Unpack UInt32Value from Any with string")
+  func uint32ValueAnyUnpackString() throws {
+    let jsonString =
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":"123"}}"#
     let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(UInt32ValueTests.WrappedAny.self, from: data)
@@ -112,5 +127,51 @@ import Testing
     let want =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":123}}"#
     #expect(got == want)
+  }
+
+  @Test(
+    "Pack and Unpack UInt32Value boundaries in Any",
+    arguments: [
+      UInt32.min,
+      UInt32.max,
+      0,
+    ])
+  func uint32ValueBoundaries(_ value: UInt32) throws {
+    let any = try `Any`(fromMessage: value)
+    let wrapped = UInt32ValueTests.WrappedAny(content: any)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(wrapped)
+    let gotJson = String(data: data, encoding: .utf8)!
+    let wantJson =
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":\#(value)}}"#
+    #expect(gotJson == wantJson)
+
+    let decoder = JSONDecoder()
+    let decodedWrapped = try decoder.decode(UInt32ValueTests.WrappedAny.self, from: data)
+    let unpacked = try UInt32(fromAny: decodedWrapped.content)
+    #expect(unpacked == value)
+  }
+
+  @Test(
+    "Unpack UInt32Value invalid value field in Any",
+    arguments: [
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":"not-a-number"}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":"4294967296"}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":"-1"}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":-1}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":1e20}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":123.45}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":true}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":{}}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt32Value","value":[]}}"#,
+    ])
+  func uint32ValueInvalidValue(_ json: String) throws {
+    let data = Data(json.utf8)
+    let decoder = JSONDecoder()
+    let wrapped = try decoder.decode(UInt32ValueTests.WrappedAny.self, from: data)
+    #expect(throws: AnyError.invalidValueField) {
+      let _ = try UInt32(fromAny: wrapped.content)
+    }
   }
 }

--- a/pkgs/swift-google-wkt/Tests/UInt64ValueTests.swift
+++ b/pkgs/swift-google-wkt/Tests/UInt64ValueTests.swift
@@ -73,8 +73,23 @@ import Testing
     let content: GoogleCloudWKT.`Any`
   }
 
-  @Test("Unpack UInt64Value from Any")
-  func uint64ValueAnyUnpack() throws {
+  @Test("Unpack UInt64Value from Any with string")
+  func uint64ValueAnyUnpackString() throws {
+    let jsonString =
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":"123"}}"#
+    let data = Data(jsonString.utf8)
+    let decoder = JSONDecoder()
+    let wrapped = try decoder.decode(UInt64ValueTests.WrappedAny.self, from: data)
+    let any = wrapped.content
+    #expect(any.typeUrl == "type.googleapis.com/google.protobuf.UInt64Value")
+
+    let got = try UInt64Value(fromAny: any)
+    let want = UInt64(123)
+    #expect(got == want)
+  }
+
+  @Test("Unpack UInt64Value from Any with number")
+  func uint64ValueAnyUnpackNumber() throws {
     let jsonString =
       #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":123}}"#
     let data = Data(jsonString.utf8)
@@ -90,7 +105,7 @@ import Testing
 
   @Test func uint64ValueAnyUnpackMismatchedUrl() throws {
     let jsonString =
-      #"{"content":{"@type":"bad","value":123}}"#
+      #"{"content":{"@type":"bad","value":"123"}}"#
     let data = Data(jsonString.utf8)
     let decoder = JSONDecoder()
     let wrapped = try decoder.decode(UInt64ValueTests.WrappedAny.self, from: data)
@@ -110,7 +125,52 @@ import Testing
     let got = String(data: data, encoding: .utf8)!
 
     let want =
-      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":123}}"#
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":"123"}}"#
     #expect(got == want)
+  }
+
+  @Test(
+    "Pack and Unpack UInt64Value boundaries in Any",
+    arguments: [
+      UInt64.min,
+      UInt64.max,
+      0,
+    ])
+  func uint64ValueBoundaries(_ value: UInt64) throws {
+    let any = try `Any`(fromMessage: value)
+    let wrapped = UInt64ValueTests.WrappedAny(content: any)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let data = try encoder.encode(wrapped)
+    let gotJson = String(data: data, encoding: .utf8)!
+    let wantJson =
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":"\#(value)"}}"#
+    #expect(gotJson == wantJson)
+
+    let decoder = JSONDecoder()
+    let decodedWrapped = try decoder.decode(UInt64ValueTests.WrappedAny.self, from: data)
+    let unpacked = try UInt64(fromAny: decodedWrapped.content)
+    #expect(unpacked == value)
+  }
+
+  @Test(
+    "Unpack UInt64Value invalid value field in Any",
+    arguments: [
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":"not-a-number"}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":"-1"}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":"18446744073709551616"}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":-1}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":123.45}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":true}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":{}}}"#,
+      #"{"content":{"@type":"type.googleapis.com/google.protobuf.UInt64Value","value":[]}}"#,
+    ])
+  func uint64ValueInvalidValue(_ json: String) throws {
+    let data = Data(json.utf8)
+    let decoder = JSONDecoder()
+    let wrapped = try decoder.decode(UInt64ValueTests.WrappedAny.self, from: data)
+    #expect(throws: AnyError.invalidValueField) {
+      let _ = try UInt64(fromAny: wrapped.content)
+    }
   }
 }


### PR DESCRIPTION
ProtoJSON requires serializing `Int64Value` and `UInt64Value` as decimal
strings when packed into `Any`.

Deserializing 32-bit and 64-bit integers should accept both integers and
strings.

Fixes #825
