### PR TITLE
feat(storage): idempotency for uploads

### DIFF
--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/ResumeState.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/ResumeState.swift
@@ -31,19 +31,24 @@ public struct ResumeState<Details: Sendable>: Sendable {
   /// Additional domain-specific details (e.g. byte offset, total bytes).
   public var details: Details
 
+  /// Whether the operation being resumed or retried is idempotent. Defaults to `true`.
+  public var idempotent: Bool
+
   /// Creates a new `ResumeState` instance.
   public init(
     details: Details,
     consecutiveErrorCount: UInt32 = 0,
     totalResumeCount: UInt32 = 0,
     start: ContinuousClock.Instant = .now,
-    lastProgressTime: ContinuousClock.Instant? = nil
+    lastProgressTime: ContinuousClock.Instant? = nil,
+    idempotent: Bool = true
   ) {
     self.details = details
     self.consecutiveErrorCount = consecutiveErrorCount
     self.totalResumeCount = totalResumeCount
     self.start = start
     self.lastProgressTime = lastProgressTime ?? start
+    self.idempotent = idempotent
   }
 
   /// Mutates `self` using a builder closure and returns the modified state.
@@ -60,14 +65,16 @@ extension ResumeState where Details == Void {
     consecutiveErrorCount: UInt32 = 0,
     totalResumeCount: UInt32 = 0,
     start: ContinuousClock.Instant = .now,
-    lastProgressTime: ContinuousClock.Instant? = nil
+    lastProgressTime: ContinuousClock.Instant? = nil,
+    idempotent: Bool = true
   ) {
     self.init(
       details: (),
       consecutiveErrorCount: consecutiveErrorCount,
       totalResumeCount: totalResumeCount,
       start: start,
-      lastProgressTime: lastProgressTime
+      lastProgressTime: lastProgressTime,
+      idempotent: idempotent
     )
   }
 }

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageClient+Upload.swift
@@ -184,8 +184,14 @@ extension StorageClient {
     var stream = prepared.stream
     let checksum = prepared.checksum
 
+    let isIdempotent =
+      options.idempotency
+      ?? (options.preconditions?.ifGenerationMatch != nil
+        || options.preconditions?.ifMetagenerationMatch != nil)
     let resumeState = ResumeState(
-      details: UploadDetails(bytesUploaded: 0, totalBytes: totalSize))
+      details: UploadDetails(bytesUploaded: 0, totalBytes: totalSize),
+      idempotent: isIdempotent
+    )
     return try await resumeLoop.run(state: resumeState) { _ in
       try await stream.rewind()
 

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageResumePolicy.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageResumePolicy.swift
@@ -18,9 +18,12 @@ import GoogleRpc
 
 /// Evaluates whether an error is considered resumable in Google Cloud Storage.
 ///
-/// In Google Cloud Storage, resumable data transfers (uploads and downloads) can be resumed
+/// In Google Cloud Storage, idempotent data transfers (most uploads and downloads) can be resumed
 /// on I/O errors, transient HTTP status codes (408, 429, and 5xx), and transient
 /// gRPC/service status codes (`unavailable`, `resourceExhausted`, `deadlineExceeded`, `internal`).
+///
+/// If the transfer operation is not idempotent (some single-shot uploads), errors are treated
+/// as permanent and will not be resumed or retried.
 ///
 /// This policy can be composed with decorators such as ``StopOnConsecutiveErrors`` or
 /// ``LimitedTotalResumes``:
@@ -31,6 +34,9 @@ public struct StorageResumePolicy<Details: Sendable>: ResumePolicy, Sendable, Eq
   public init() {}
 
   public func onError(state: ResumeState<Details>, error: RequestError) -> ResumeResult {
+    guard state.idempotent else {
+      return .permanent(error)
+    }
     if isResumable(error) {
       return .resume(error)
     }

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/UploadOptions.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/UploadOptions.swift
@@ -539,6 +539,20 @@ public struct UploadOptions: Sendable {
   /// [Service Usage Consumer]: https://cloud.google.com/service-usage/docs/access-control
   public var quotaProject: String? = nil
 
+  /// Overrides whether the upload operation is treated as idempotent.
+  ///
+  /// Resumable uploads are always idempotent (they can succeed at most once), and therefore
+  /// ignore this setting.
+  ///
+  /// Single-shot (multipart) uploads are idempotent by default only if preconditions are provided
+  /// (`ifGenerationMatch` or `ifMetagenerationMatch`). Without preconditions, single-shot
+  /// uploads are non-idempotent by default to prevent unintended overwrites or version
+  /// duplication on retried transient errors.
+  ///
+  /// Set this property to `true` to force single-shot uploads without preconditions to be
+  /// retried on transient errors, or `false` to suppress retries even when preconditions are present.
+  public var idempotency: Bool? = nil
+
   /// Legacy validation enum property for backward compatibility.
   public var validation: ChecksumValidation {
     get {
@@ -581,6 +595,7 @@ extension UploadOptions {
     copy.resumePolicy = self.resumePolicy ?? defaults.resumePolicy
     copy.backoffPolicy = self.backoffPolicy ?? defaults.backoffPolicy
     copy.quotaProject = self.quotaProject ?? defaults.quotaProject
+    copy.idempotency = self.idempotency ?? defaults.idempotency
     return copy
   }
 

--- a/pkgs/swift-google-cloud-storage/Tests/ResumableUploadTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/ResumableUploadTests.swift
@@ -2226,6 +2226,51 @@ import Testing
     #expect(requests.count == 2)
     #expect(requests.first?.url?.absoluteString == initUrl.absoluteString)
   }
+
+  /// Tests that resumable uploads are always idempotent and retry transient failures even if `options.idempotency = false`.
+  @Test func resumableUploadIgnoresIdempotencyFalseAndRetries() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-resumable-idempotency-false"
+    let data = Data(repeating: 1, count: 10 * 1024 * 1024)
+    let source = BytesSource(data: data)
+
+    let startUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=resumable&name=\(objectName)")
+    let chunkUrl = registry.url("/upload/storage/v1/b/\(bucket)/o?upload_id=test-upload-id-false")
+
+    // First attempt to start session fails with 503 Service Unavailable
+    registry.register(
+      response: .success(
+        statusCode: 503, data: Data("Service Unavailable".utf8),
+        headers: nil),
+      for: startUrl)
+
+    // Retry attempt to start session succeeds with 200 OK
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data(),
+        headers: ["Location": chunkUrl.absoluteString]),
+      for: startUrl)
+
+    // Chunk upload succeeds with 200 OK
+    registry.register(
+      response: .success(
+        statusCode: 200, data: Data("{\"name\":\"\(objectName)\"}".utf8),
+        headers: ["Content-Type": "application/json"]),
+      for: chunkUrl)
+
+    let client = try makeClient(registry: registry)
+    let options = UploadOptions().with {
+      $0.idempotency = false
+    }
+    let object = try await client.upload(source, to: bucket, as: objectName, options: options)
+
+    #expect(object.name == objectName)
+    let requests = registry.recordedRequests()
+    // 2 start requests (1 failure + 1 retry) + 1 chunk attempt = 3 requests
+    #expect(requests.count == 3)
+  }
 }
 
 // MARK: - Test Helper Sources

--- a/pkgs/swift-google-cloud-storage/Tests/ResumePolicyTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/ResumePolicyTests.swift
@@ -165,6 +165,25 @@ import Testing
     #expect(isPermanent(policy.onError(state: state, error: rpcInvalidArgument)))
   }
 
+  @Test func storageResumePolicyNonIdempotent() {
+    let policy = StorageResumePolicy<Void>()
+    let state = ResumeState(idempotent: false)
+
+    let err503 = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
+    let err429 = RequestError.http(HTTPDetails(http_status_code: 429, headers: [:]))
+    let errIO = RequestError.io(NSError(domain: "test", code: -1))
+    let rpcUnavailable = RequestError.service(
+      ServiceError(code: Code.unavailable, message: "unavailable"))
+
+    #expect(isPermanent(policy.onError(state: state, error: err503)))
+    #expect(isPermanent(policy.onError(state: state, error: err429)))
+    #expect(isPermanent(policy.onError(state: state, error: errIO)))
+    #expect(isPermanent(policy.onError(state: state, error: rpcUnavailable)))
+
+    let decoratedPolicy = policy.stopOnConsecutiveErrors(3)
+    #expect(isPermanent(decoratedPolicy.onError(state: state, error: err503)))
+  }
+
   @Test func storageResumePolicyConsecutiveErrors() {
     let policy = StorageResumePolicy<Void>().stopOnConsecutiveErrors(2)
     var state = ResumeState()

--- a/pkgs/swift-google-cloud-storage/Tests/SimpleUploadTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/SimpleUploadTests.swift
@@ -247,7 +247,7 @@ import Testing
       uploadReq?.value(forHTTPHeaderField: "x-goog-encryption-key-sha256") == sample.keyHashBase64)
   }
 
-  /// Tests that a 503 (unavailable) response during simple upload is retryable and automatically handled by the retry loop.
+  /// Tests that a 503 (unavailable) response during simple upload is retryable when idempotency is enabled.
   @Test func simpleUploadTransientFailureRetriesAndSucceeds() async throws {
     let registry = MockRegistry.create()
     let bucket = "test-bucket"
@@ -272,11 +272,9 @@ import Testing
         headers: nil),
       for: simpleUploadUrl)
 
-    let client = try makeClient(
-      registry: registry,
-      retryPolicy: BaseRetryPolicy().withAttemptLimit(3)
-    )
-    let object = try await client.upload(source, to: bucket, as: objectName)
+    let client = try makeClient(registry: registry)
+    let options = UploadOptions().with { $0.idempotency = true }
+    let object = try await client.upload(source, to: bucket, as: objectName, options: options)
 
     #expect(object.name == objectName)
     #expect(object.bucket == "projects/_/buckets/\(bucket)")
@@ -319,11 +317,9 @@ import Testing
         headers: nil),
       for: simpleUploadUrl)
 
-    let client = try makeClient(
-      registry: registry,
-      retryPolicy: BaseRetryPolicy().withAttemptLimit(3)
-    )
-    let object = try await client.upload(source, to: bucket, as: objectName)
+    let client = try makeClient(registry: registry)
+    let options = UploadOptions().with { $0.idempotency = true }
+    let object = try await client.upload(source, to: bucket, as: objectName, options: options)
 
     #expect(object.name == objectName)
     #expect(object.bucket == "projects/_/buckets/\(bucket)")
@@ -386,11 +382,9 @@ import Testing
         headers: nil),
       for: simpleUploadUrl)
 
-    let client = try makeClient(
-      registry: registry,
-      retryPolicy: BaseRetryPolicy().withAttemptLimit(3)
-    )
-    let object = try await client.upload(source, to: bucket, as: objectName)
+    let client = try makeClient(registry: registry)
+    let options = UploadOptions().with { $0.idempotency = true }
+    let object = try await client.upload(source, to: bucket, as: objectName, options: options)
 
     #expect(object.name == objectName)
     #expect(object.bucket == "projects/_/buckets/\(bucket)")
@@ -401,6 +395,181 @@ import Testing
     #expect(requests[0].body != nil)
     #expect(requests[1].body != nil)
     #expect(requests[0].body == requests[1].body)
+  }
+
+  /// Tests that a single-shot upload without preconditions is non-idempotent by default and fails without retrying on transient 503.
+  @Test func simpleUploadDefaultNonIdempotentDoesNotRetryOnTransientFailure() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-non-idempotent-fail"
+    let data = Data(repeating: 0x42, count: 1024)
+    let source = BytesSource(data: data)
+
+    let simpleUploadUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=multipart&name=\(objectName)")
+
+    registry.register(
+      response: .success(
+        statusCode: 503, data: Data("Service Unavailable".utf8),
+        headers: nil),
+      for: simpleUploadUrl)
+
+    let client = try makeClient(registry: registry)
+
+    let error = await expectError(RequestError.self) {
+      try await client.upload(source, to: bucket, as: objectName)
+    }
+    if case .http(let details) = error {
+      #expect(details.http_status_code == 503)
+    } else {
+      Issue.record("Expected .http 503 RequestError, got \(String(describing: error))")
+    }
+
+    let requests = registry.recordedRequests()
+    #expect(requests.count == 1)
+  }
+
+  /// Tests that a single-shot upload with `ifGenerationMatch` precondition is idempotent and retries transient 503 failures.
+  @Test func simpleUploadWithIfGenerationMatchPreconditionRetriesAndSucceeds() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-if-generation-match-retry"
+    let data = Data(repeating: 0x42, count: 1024)
+    let source = BytesSource(data: data)
+
+    let simpleUploadUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=multipart&name=\(objectName)&ifGenerationMatch=0"
+    )
+
+    // First attempt fails with 503 Service Unavailable
+    registry.register(
+      response: .success(
+        statusCode: 503, data: Data("Service Unavailable".utf8),
+        headers: nil),
+      for: simpleUploadUrl)
+
+    // Retry attempt succeeds with 200 OK
+    registry.register(
+      response: .success(
+        statusCode: 200, data: makeObjectJSON(name: objectName, bucket: bucket, size: data.count),
+        headers: nil),
+      for: simpleUploadUrl)
+
+    let client = try makeClient(registry: registry)
+    let options = UploadOptions().with {
+      $0.preconditions = StoragePreconditions().with { $0.ifGenerationMatch = 0 }
+    }
+    let object = try await client.upload(source, to: bucket, as: objectName, options: options)
+
+    #expect(object.name == objectName)
+    let requests = registry.recordedRequests()
+    #expect(requests.count == 2)
+  }
+
+  /// Tests that a single-shot upload with `ifMetagenerationMatch` precondition is idempotent and retries transient 503 failures.
+  @Test func simpleUploadWithIfMetagenerationMatchPreconditionRetriesAndSucceeds() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-if-metageneration-match-retry"
+    let data = Data(repeating: 0x42, count: 1024)
+    let source = BytesSource(data: data)
+
+    let simpleUploadUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=multipart&name=\(objectName)&ifMetagenerationMatch=1"
+    )
+
+    // First attempt fails with 503 Service Unavailable
+    registry.register(
+      response: .success(
+        statusCode: 503, data: Data("Service Unavailable".utf8),
+        headers: nil),
+      for: simpleUploadUrl)
+
+    // Retry attempt succeeds with 200 OK
+    registry.register(
+      response: .success(
+        statusCode: 200, data: makeObjectJSON(name: objectName, bucket: bucket, size: data.count),
+        headers: nil),
+      for: simpleUploadUrl)
+
+    let client = try makeClient(registry: registry)
+    let options = UploadOptions().with {
+      $0.preconditions = StoragePreconditions().with { $0.ifMetagenerationMatch = 1 }
+    }
+    let object = try await client.upload(source, to: bucket, as: objectName, options: options)
+
+    #expect(object.name == objectName)
+    let requests = registry.recordedRequests()
+    #expect(requests.count == 2)
+  }
+
+  /// Tests that a single-shot upload with `options.idempotency = true` retries without preconditions.
+  @Test func simpleUploadExplicitIdempotencyTrueRetriesWithoutPreconditions() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-override-idempotency-true"
+    let data = Data(repeating: 0x42, count: 1024)
+    let source = BytesSource(data: data)
+
+    let simpleUploadUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=multipart&name=\(objectName)")
+
+    registry.register(
+      response: .success(
+        statusCode: 503, data: Data("Service Unavailable".utf8),
+        headers: nil),
+      for: simpleUploadUrl)
+
+    registry.register(
+      response: .success(
+        statusCode: 200, data: makeObjectJSON(name: objectName, bucket: bucket, size: data.count),
+        headers: nil),
+      for: simpleUploadUrl)
+
+    let client = try makeClient(registry: registry)
+    let options = UploadOptions().with { $0.idempotency = true }
+    let object = try await client.upload(source, to: bucket, as: objectName, options: options)
+
+    #expect(object.name == objectName)
+    let requests = registry.recordedRequests()
+    #expect(requests.count == 2)
+  }
+
+  /// Tests that a single-shot upload with preconditions but `options.idempotency = false` fails immediately without retry.
+  @Test func simpleUploadExplicitIdempotencyFalseSuppressesRetryWithPreconditions() async throws {
+    let registry = MockRegistry.create()
+    let bucket = "test-bucket"
+    let objectName = "test-override-idempotency-false"
+    let data = Data(repeating: 0x42, count: 1024)
+    let source = BytesSource(data: data)
+
+    let simpleUploadUrl = registry.url(
+      "/upload/storage/v1/b/\(bucket)/o?uploadType=multipart&name=\(objectName)&ifGenerationMatch=0"
+    )
+
+    registry.register(
+      response: .success(
+        statusCode: 503, data: Data("Service Unavailable".utf8),
+        headers: nil),
+      for: simpleUploadUrl)
+
+    let client = try makeClient(registry: registry)
+    let options = UploadOptions().with {
+      $0.preconditions = StoragePreconditions().with { $0.ifGenerationMatch = 0 }
+      $0.idempotency = false
+    }
+
+    let error = await expectError(RequestError.self) {
+      try await client.upload(source, to: bucket, as: objectName, options: options)
+    }
+    if case .http(let details) = error {
+      #expect(details.http_status_code == 503)
+    } else {
+      Issue.record("Expected .http 503 RequestError, got \(String(describing: error))")
+    }
+
+    let requests = registry.recordedRequests()
+    #expect(requests.count == 1)
   }
 
   /// Tests that a 503 error with NeverResume policy throws immediately without retrying.
@@ -422,9 +591,10 @@ import Testing
 
     let client = try makeClient(
       registry: registry, uploadResumePolicy: NeverResume<UploadDetails>())
+    let options = UploadOptions().with { $0.idempotency = true }
 
     let error = await expectError(RequestError.self) {
-      try await client.upload(source, to: bucket, as: objectName)
+      try await client.upload(source, to: bucket, as: objectName, options: options)
     }
     #expect(error != nil)
     let requests = registry.recordedRequests()
@@ -450,6 +620,7 @@ import Testing
 
     let client = try makeClient(registry: registry)
     let uploadOptions = UploadOptions().with {
+      $0.idempotency = true
       $0.resumePolicy = NeverResume()
     }
 


### PR DESCRIPTION
Single-shot uploads are automatically idempotent if the right pre-conditions are set. The application may also override the idempotency. The default is treat these uploads as non-idempotent.

Resumable uploads are always idempotent, no change there.

Fixes #832