### PR TITLE
feat(auth): jitter on MDS refresh

### DIFF
--- a/pkgs/swift-google-auth/Sources/GoogleCloudAuth/Providers/MDSCredentials.swift
+++ b/pkgs/swift-google-auth/Sources/GoogleCloudAuth/Providers/MDSCredentials.swift
@@ -31,7 +31,8 @@ struct MDSCredentials: CredentialsProvider, Sendable {
     retryConfiguration: RetryConfiguration? = nil,
     client: AuthHTTPClient = AuthHTTPClient(),
     fromADC: Bool = false,
-    environment: [String: String] = ProcessInfo.processInfo.environment
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    jitter: TokenCache<ContinuousClock>.JitterGenerator? = TokenCache<ContinuousClock>.defaultJitter
   ) {
     let provider = MDSAccessTokenProvider(
       endpoint: endpoint,
@@ -46,6 +47,7 @@ struct MDSCredentials: CredentialsProvider, Sendable {
 
     self.cache = TokenCache(
       provider: provider,
+      jitter: jitter,
       isRetryable: MDSAccessTokenProvider.isRetryable
     )
   }

--- a/pkgs/swift-google-auth/Sources/GoogleCloudAuth/TokenCache.swift
+++ b/pkgs/swift-google-auth/Sources/GoogleCloudAuth/TokenCache.swift
@@ -52,6 +52,8 @@ struct SystemTimeSource: TimeSource {
   var now: Date { Date() }
 }
 
+package let attosecondsPerSecond: Double = 1e18
+
 private let defaultNormalRefreshSlack: Duration = .seconds(240)
 private let defaultShortRefreshSlack: Duration = .seconds(10)
 
@@ -75,6 +77,23 @@ private let defaultShortRefreshSlack: Duration = .seconds(10)
 /// ### Memory Safety
 /// The background task captures `self` weakly. It only holds a strong reference during state evaluation and releases it before sleeping on the `Clock`. This guarantees `TokenCache` can `deinit` cleanly when out of scope, which automatically cancels the background task.
 actor TokenCache<C: Clock> where C.Instant.Duration == Duration {
+  typealias JitterGenerator = @Sendable (ClosedRange<Duration>) -> Duration
+
+  static var defaultJitter: JitterGenerator {
+    return { range in
+      let lower = range.lowerBound
+      let upper = range.upperBound
+      guard upper > lower else { return lower }
+      let delta = upper - lower
+      let deltaSeconds =
+        Double(delta.components.seconds)
+        + Double(delta.components.attoseconds) / attosecondsPerSecond
+      guard deltaSeconds > 0 else { return lower }
+      let randomSeconds = Double.random(in: 0...deltaSeconds)
+      return min(max(lower + .seconds(randomSeconds), lower), upper)
+    }
+  }
+
   private let provider: any TokenProvider
   private var cachedToken: Token?
   private var activeRefreshTask: Task<Token, Error>?
@@ -83,6 +102,7 @@ actor TokenCache<C: Clock> where C.Instant.Duration == Duration {
 
   private let normalRefreshSlack: Duration
   private let shortRefreshSlack: Duration
+  private let jitter: JitterGenerator?
   private let isRetryable: @Sendable (Error) -> Bool
   private var permanentError: Error?
 
@@ -99,6 +119,7 @@ actor TokenCache<C: Clock> where C.Instant.Duration == Duration {
     timeSource: any TimeSource = SystemTimeSource(),
     normalRefreshSlack: Duration = defaultNormalRefreshSlack,
     shortRefreshSlack: Duration = defaultShortRefreshSlack,
+    jitter: JitterGenerator? = nil,
     isRetryable: @Sendable @escaping (Error) -> Bool = { _ in true }
   ) {
     self.provider = provider
@@ -106,6 +127,7 @@ actor TokenCache<C: Clock> where C.Instant.Duration == Duration {
     self.timeSource = timeSource
     self.normalRefreshSlack = normalRefreshSlack
     self.shortRefreshSlack = shortRefreshSlack
+    self.jitter = jitter
     self.isRetryable = isRetryable
 
     let clock = self.clock
@@ -196,18 +218,49 @@ actor TokenCache<C: Clock> where C.Instant.Duration == Duration {
     self.activeRefreshTask = nil
   }
 
+  private func refreshSleepDuration(for token: Token) -> Duration {
+    let timeUntilExpiry = token.expirationDate.timeIntervalSince(timeSource.now)
+    let duration = Duration.seconds(timeUntilExpiry)
+
+    if duration > self.normalRefreshSlack {
+      let minSleep = duration - self.normalRefreshSlack
+      let maxSleep = duration - self.shortRefreshSlack
+      if maxSleep > minSleep, let jitter = self.jitter {
+        return min(max(jitter(minSleep...maxSleep), minSleep), maxSleep)
+      }
+      return minSleep
+    }
+
+    if duration > self.shortRefreshSlack {
+      if let jitter = self.jitter {
+        let maxSleep = min(self.shortRefreshSlack, duration)
+        if maxSleep > .zero {
+          return min(max(jitter(.zero...maxSleep), .zero), maxSleep)
+        }
+      }
+      return self.shortRefreshSlack
+    }
+
+    if let jitter = self.jitter {
+      let maxSleep: Duration =
+        duration > .zero ? min(self.shortRefreshSlack, duration) : .seconds(1)
+      if maxSleep > .zero {
+        return min(max(jitter(.zero...maxSleep), .zero), maxSleep)
+      }
+    }
+    return .seconds(1)
+  }
+
   private func checkStateAndTriggerRefresh(timeSource: any TimeSource) async -> RefreshAction {
     if let _ = self.permanentError {
       return .terminate
     }
 
-    // If we already have a valid, non-stale token, sleep until it becomes stale
+    // If we already have a valid, non-stale token, sleep until scheduled refresh
     if let cached = self.cachedToken, !self.isStale(cached) {
-      let timeUntilStale =
-        cached.expirationDate.timeIntervalSince(timeSource.now)
-        - Double(self.normalRefreshSlack.components.seconds)
-      if timeUntilStale > 0 {
-        return .sleep(.seconds(timeUntilStale))
+      let sleepDuration = self.refreshSleepDuration(for: cached)
+      if sleepDuration > .zero {
+        return .sleep(sleepDuration)
       }
     }
 
@@ -217,16 +270,7 @@ actor TokenCache<C: Clock> where C.Instant.Duration == Duration {
       let token = try await task.value
       self.updateCache(with: token)
 
-      let timeUntilExpiry = token.expirationDate.timeIntervalSince(timeSource.now)
-      let duration = Duration.seconds(timeUntilExpiry)
-
-      if duration > self.normalRefreshSlack {
-        return .sleep(duration - self.normalRefreshSlack)
-      } else if duration > self.shortRefreshSlack {
-        return .sleep(self.shortRefreshSlack)
-      } else {
-        return .sleep(.seconds(1))
-      }
+      return .sleep(self.refreshSleepDuration(for: token))
     } catch {
       if error is CancellationError {
         return .terminate
@@ -238,7 +282,12 @@ actor TokenCache<C: Clock> where C.Instant.Duration == Duration {
         self.permanentError = error
         return .terminate
       }
-      // Handle transient errors by sleeping and retrying
+      // Handle transient errors by sleeping with jitter and retrying
+      if let jitter = self.jitter {
+        let sleepDuration = min(
+          max(jitter(.zero...self.shortRefreshSlack), .zero), self.shortRefreshSlack)
+        return .sleep(sleepDuration)
+      }
       return .sleep(self.shortRefreshSlack)
     }
   }
@@ -250,6 +299,7 @@ extension TokenCache where C == ContinuousClock {
     provider: any TokenProvider,
     normalRefreshSlack: Duration = defaultNormalRefreshSlack,
     shortRefreshSlack: Duration = defaultShortRefreshSlack,
+    jitter: JitterGenerator? = nil,
     isRetryable: @Sendable @escaping (Error) -> Bool = { _ in true }
   ) {
     self.init(
@@ -257,6 +307,7 @@ extension TokenCache where C == ContinuousClock {
       clock: ContinuousClock(),
       normalRefreshSlack: normalRefreshSlack,
       shortRefreshSlack: shortRefreshSlack,
+      jitter: jitter,
       isRetryable: isRetryable
     )
   }

--- a/pkgs/swift-google-auth/Tests/MDSCredentialsTests.swift
+++ b/pkgs/swift-google-auth/Tests/MDSCredentialsTests.swift
@@ -489,6 +489,78 @@ import Testing
     )
   }
 
+  @Test func mdsCredentialsCustomJitter() async throws {
+    struct MockResponse: Encodable {
+      let accessToken: String
+      let expiresIn: Int
+      let tokenType: String
+    }
+    let encodedData = try JSONEncoder().encode(
+      MockResponse(accessToken: "mock-token", expiresIn: 3600, tokenType: "Bearer"))
+
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        Self.checkRequest(request)
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData))
+        )
+      }
+    ])
+
+    let client = AuthHTTPClient(mock: mock)
+    let provider = MDSCredentials(
+      client: client,
+      environment: [:],
+      jitter: { range in
+        return range.lowerBound
+      }
+    )
+    let headers = try await provider.headers()
+
+    #expect(
+      headers.contains { $0.0 == "Authorization" && $0.1 == "Bearer mock-token" },
+      "Missing authorization header in \(headers)"
+    )
+  }
+
+  @Test func mdsCredentialsNilJitter() async throws {
+    struct MockResponse: Encodable {
+      let accessToken: String
+      let expiresIn: Int
+      let tokenType: String
+    }
+    let encodedData = try JSONEncoder().encode(
+      MockResponse(accessToken: "mock-token", expiresIn: 3600, tokenType: "Bearer"))
+
+    let mock = MockHTTPClient([
+      { (request: HTTPClientRequest) in
+        Self.checkRequest(request)
+        return HTTPClientResponse(
+          version: .http2,
+          status: .ok,
+          headers: .init([("Content-Type", "application/json")]),
+          body: .bytes(.init(data: encodedData))
+        )
+      }
+    ])
+
+    let client = AuthHTTPClient(mock: mock)
+    let provider = MDSCredentials(
+      client: client,
+      environment: [:],
+      jitter: nil
+    )
+    let headers = try await provider.headers()
+
+    #expect(
+      headers.contains { $0.0 == "Authorization" && $0.1 == "Bearer mock-token" },
+      "Missing authorization header in \(headers)"
+    )
+  }
+
   static func checkRequest(
     _ request: HTTPClientRequest, sourceLocation: SourceLocation = #_sourceLocation
   ) {

--- a/pkgs/swift-google-auth/Tests/TokenCacheJitterTests.swift
+++ b/pkgs/swift-google-auth/Tests/TokenCacheJitterTests.swift
@@ -1,0 +1,463 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Synchronization
+import Testing
+
+@testable import GoogleCloudAuth
+
+// MARK: - Mock Concurrency-Safe Token Provider Actor
+
+private actor JitterMockTokenProvider: TokenProvider {
+  private var fetchCount = 0
+  private var nextToken: Token?
+  private var nextError: Error?
+  private var fetchContinuations: [CheckedContinuation<Void, Never>] = []
+  private var fetchIsStarted = false
+
+  func configure(token: Token?, error: Error? = nil) {
+    self.nextToken = token
+    self.nextError = error
+  }
+
+  func fetchToken() async throws -> Token {
+    self.fetchCount += 1
+
+    let continuationsToResume = self.fetchContinuations
+    self.fetchContinuations.removeAll()
+
+    if continuationsToResume.isEmpty {
+      self.fetchIsStarted = true
+    } else {
+      self.fetchIsStarted = false
+      for continuation in continuationsToResume {
+        continuation.resume()
+      }
+    }
+
+    if let error = self.nextError {
+      throw error
+    }
+    guard let token = self.nextToken else {
+      throw URLError(.unknown)
+    }
+    return token
+  }
+
+  func fetcherWaiting() async {
+    if fetchIsStarted {
+      fetchIsStarted = false
+      return
+    }
+
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      if fetchIsStarted {
+        fetchIsStarted = false
+        continuation.resume()
+      } else {
+        self.fetchContinuations.append(continuation)
+      }
+    }
+  }
+
+  var count: Int {
+    self.fetchCount
+  }
+}
+
+// MARK: - Suite: TokenCache Jitter Tests
+
+@Suite struct TokenCacheJitterTest {
+  @Test func defaultJitterWithinRange() {
+    let lower = Duration.seconds(10)
+    let upper = Duration.seconds(240)
+    let range = lower...upper
+
+    for _ in 0..<100 {
+      let result = TokenCache<ContinuousClock>.defaultJitter(range)
+      #expect(result >= lower, "Result \(result) must be >= lowerBound \(lower)")
+      #expect(result <= upper, "Result \(result) must be <= upperBound \(upper)")
+    }
+  }
+
+  @Test func defaultJitterZeroWidthRange() {
+    let exact = Duration.seconds(42)
+    let result = TokenCache<ContinuousClock>.defaultJitter(exact...exact)
+    #expect(result == exact)
+  }
+
+  @Test func defaultJitterSubsecondRange() {
+    let lower = Duration.milliseconds(100)
+    let upper = Duration.milliseconds(900)
+    let range = lower...upper
+
+    for _ in 0..<50 {
+      let result = TokenCache<ContinuousClock>.defaultJitter(range)
+      #expect(result >= lower)
+      #expect(result <= upper)
+    }
+  }
+
+  @Test func defaultJitterProducesVariedValues() {
+    let lower = Duration.seconds(1)
+    let upper = Duration.seconds(100)
+    let range = lower...upper
+
+    var uniqueResults = Set<Duration>()
+    for _ in 0..<20 {
+      uniqueResults.insert(TokenCache<ContinuousClock>.defaultJitter(range))
+    }
+    #expect(uniqueResults.count > 1, "defaultJitter should generate distinct random values")
+  }
+
+  @Test func normalRangeDeterministicJitterUpper() async throws {
+    let provider = JitterMockTokenProvider()
+    let clock = TestClock()
+    let now = Date()
+    let timeSource = MockTimeSource(currentDate: now)
+
+    // Token expires in 10 seconds.
+    // normalRefreshSlack = 2s, shortRefreshSlack = 1s.
+    // minSleep = 10 - 2 = 8s (D).
+    // maxSleep = 10 - 1 = 9s (T - shortRefreshSlack).
+    let initialToken = Token(
+      accessToken: "initial", expirationDate: now.addingTimeInterval(10.0))
+    await provider.configure(token: initialToken)
+
+    let cache = TokenCache(
+      provider: provider,
+      clock: clock,
+      timeSource: timeSource,
+      normalRefreshSlack: .seconds(2),
+      shortRefreshSlack: .seconds(1),
+      jitter: { range in range.upperBound }
+    )
+
+    // Wait for initial fetch to finish and background loop to sleep
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 1)
+
+    // Prepare next token
+    let refreshedToken = Token(
+      accessToken: "refreshed", expirationDate: now.addingTimeInterval(3600.0))
+    await provider.configure(token: refreshedToken)
+
+    // Advance by 8.5 seconds (past D = 8.0s, but before upper bound = 9.0s)
+    timeSource.advance(by: 8.5)
+    clock.advance(by: .seconds(8.5))
+
+    // Because jitter chose upperBound (9s), the background loop is STILL asleep at 8.5s!
+    #expect(clock.hasSleepers)
+    #expect(await provider.count == 1)
+
+    // Advance past the 9.0s mark (0.6s more => total 9.1s)
+    timeSource.advance(by: 0.6)
+    clock.advance(by: .seconds(0.6))
+
+    // Background loop wakes up, refreshes token, and sleeps for the new token's duration
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 2)
+
+    let token = try await cache.token()
+    #expect(token.accessToken == "refreshed")
+  }
+
+  @Test func normalRangeDeterministicJitterLower() async throws {
+    let provider = JitterMockTokenProvider()
+    let clock = TestClock()
+    let now = Date()
+    let timeSource = MockTimeSource(currentDate: now)
+
+    let initialToken = Token(
+      accessToken: "initial", expirationDate: now.addingTimeInterval(10.0))
+    await provider.configure(token: initialToken)
+
+    let cache = TokenCache(
+      provider: provider,
+      clock: clock,
+      timeSource: timeSource,
+      normalRefreshSlack: .seconds(2),
+      shortRefreshSlack: .seconds(1),
+      jitter: { range in range.lowerBound }
+    )
+
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 1)
+
+    let refreshedToken = Token(
+      accessToken: "refreshed", expirationDate: now.addingTimeInterval(3600.0))
+    await provider.configure(token: refreshedToken)
+
+    // lowerBound is minSleep = 10 - 2 = 8.0s (D)
+    timeSource.advance(by: 8.1)
+    clock.advance(by: .seconds(8.1))
+
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 2)
+
+    let token = try await cache.token()
+    #expect(token.accessToken == "refreshed")
+  }
+
+  @Test func normalRangeDeterministicJitterClamping() async throws {
+    let provider = JitterMockTokenProvider()
+    let clock = TestClock()
+    let now = Date()
+    let timeSource = MockTimeSource(currentDate: now)
+
+    let initialToken = Token(
+      accessToken: "initial", expirationDate: now.addingTimeInterval(10.0))
+    await provider.configure(token: initialToken)
+
+    // Jitter returns a value far beyond upperBound (e.g. 100 seconds)
+    // TokenCache should clamp it to maxSleep = 9.0s
+    let cache = TokenCache(
+      provider: provider,
+      clock: clock,
+      timeSource: timeSource,
+      normalRefreshSlack: .seconds(2),
+      shortRefreshSlack: .seconds(1),
+      jitter: { _ in .seconds(100) }
+    )
+
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 1)
+
+    let refreshedToken = Token(
+      accessToken: "refreshed", expirationDate: now.addingTimeInterval(3600.0))
+    await provider.configure(token: refreshedToken)
+
+    // At 8.9s, it should still be sleeping (clamped to 9.0s)
+    timeSource.advance(by: 8.9)
+    clock.advance(by: .seconds(8.9))
+    #expect(clock.hasSleepers)
+    #expect(await provider.count == 1)
+
+    // At 9.1s, it should have awakened and refreshed
+    timeSource.advance(by: 0.2)
+    clock.advance(by: .seconds(0.2))
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 2)
+
+    let token = try await cache.token()
+    #expect(token.accessToken == "refreshed")
+  }
+
+  @Test func normalRangeDefaultJitterSleepsWithinExpectedRange() async throws {
+    let provider = JitterMockTokenProvider()
+    let clock = TestClock()
+    let now = Date()
+    let timeSource = MockTimeSource(currentDate: now)
+
+    // Token expires in 10s. normalSlack = 4s (D = 6s), shortSlack = 1s (T - 1s = 9s).
+    let initialToken = Token(
+      accessToken: "initial", expirationDate: now.addingTimeInterval(10.0))
+    await provider.configure(token: initialToken)
+
+    let cache = TokenCache(
+      provider: provider,
+      clock: clock,
+      timeSource: timeSource,
+      normalRefreshSlack: .seconds(4),
+      shortRefreshSlack: .seconds(1),
+      jitter: TokenCache<TestClock>.defaultJitter
+    )
+
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 1)
+
+    let refreshedToken = Token(
+      accessToken: "refreshed", expirationDate: now.addingTimeInterval(3600.0))
+    await provider.configure(token: refreshedToken)
+
+    // At 5.9s (before D = 6.0s), sleeper must ALWAYS still be sleeping
+    timeSource.advance(by: 5.9)
+    clock.advance(by: .seconds(5.9))
+    #expect(clock.hasSleepers)
+    #expect(await provider.count == 1)
+
+    // Advancing past 9.0s (total 9.1s) must ALWAYS have awakened the sleeper
+    timeSource.advance(by: 3.2)
+    clock.advance(by: .seconds(3.2))
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 2)
+
+    let token = try await cache.token()
+    #expect(token.accessToken == "refreshed")
+  }
+
+  @Test func shortSlackRangeJitter() async throws {
+    let provider = JitterMockTokenProvider()
+    let clock = TestClock()
+    let now = Date()
+    let timeSource = MockTimeSource(currentDate: now)
+
+    // Token expires in 3 seconds.
+    // normalSlack = 4s, shortSlack = 1s.
+    // Since duration (3s) <= normalSlack (4s) and duration (3s) > shortSlack (1s),
+    // it enters the short-slack range with range 0...shortSlack (0...1s).
+    let initialToken = Token(
+      accessToken: "stale-initial", expirationDate: now.addingTimeInterval(3.0))
+    await provider.configure(token: initialToken)
+
+    let recordedRanges = Mutex<[ClosedRange<Duration>]>([])
+    let cache = TokenCache(
+      provider: provider,
+      clock: clock,
+      timeSource: timeSource,
+      normalRefreshSlack: .seconds(4),
+      shortRefreshSlack: .seconds(1),
+      jitter: { range in
+        recordedRanges.withLock { $0.append(range) }
+        return range.upperBound
+      }
+    )
+
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 1)
+    let ranges = recordedRanges.withLock { $0 }
+    #expect(!ranges.isEmpty)
+    #expect(ranges[0].lowerBound == .zero)
+    #expect(ranges[0].upperBound == .seconds(1))
+
+    _ = cache
+  }
+
+  @Test func nearExpiryRangeJitter() async throws {
+    let provider = JitterMockTokenProvider()
+    let clock = TestClock()
+    let now = Date()
+    let timeSource = MockTimeSource(currentDate: now)
+
+    // Token expires in 0.5s (< shortRefreshSlack = 1.0s).
+    // It enters the near-expiry range [T - shortSlack, T].
+    let initialToken = Token(
+      accessToken: "about-to-expire", expirationDate: now.addingTimeInterval(0.5))
+    await provider.configure(token: initialToken)
+
+    let recordedRanges = Mutex<[ClosedRange<Duration>]>([])
+    let cache = TokenCache(
+      provider: provider,
+      clock: clock,
+      timeSource: timeSource,
+      normalRefreshSlack: .seconds(4),
+      shortRefreshSlack: .seconds(1),
+      jitter: { range in
+        recordedRanges.withLock { $0.append(range) }
+        return range.upperBound
+      }
+    )
+
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 1)
+    let ranges = recordedRanges.withLock { $0 }
+    #expect(!ranges.isEmpty)
+    #expect(ranges[0].lowerBound == .zero)
+    #expect(ranges[0].upperBound <= .seconds(1))
+
+    _ = cache
+  }
+
+  @Test func transientRetryJitter() async throws {
+    let provider = JitterMockTokenProvider()
+    let clock = TestClock()
+    let now = Date()
+    let timeSource = MockTimeSource(currentDate: now)
+
+    let initialToken = Token(
+      accessToken: "valid", expirationDate: now.addingTimeInterval(10.0))
+    await provider.configure(token: initialToken)
+
+    let retryJitterRanges = Mutex<[ClosedRange<Duration>]>([])
+    let cache = TokenCache(
+      provider: provider,
+      clock: clock,
+      timeSource: timeSource,
+      normalRefreshSlack: .seconds(2),
+      shortRefreshSlack: .seconds(1),
+      jitter: { range in
+        if range.lowerBound == .zero && range.upperBound == .seconds(1) {
+          retryJitterRanges.withLock { $0.append(range) }
+        }
+        return range.upperBound
+      },
+      isRetryable: { _ in true }
+    )
+
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 1)
+
+    // Configure a transient failure for the upcoming refresh
+    await provider.configure(token: nil, error: URLError(.timedOut))
+
+    // Advance clock to trigger refresh (minSleep = 8s, maxSleep = 9s; with upperBound jitter, sleep is 9s)
+    timeSource.advance(by: 9.1)
+    clock.advance(by: .seconds(9.1))
+
+    // Background loop wakes up, calls fetchToken, hits transient error,
+    // and sleeps with retry jitter (upperBound = 1s)
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 2)
+    #expect(
+      retryJitterRanges.withLock { !$0.isEmpty },
+      "Transient retry must invoke jitter with 0...shortSlack")
+
+    _ = cache
+  }
+
+  @Test func nilJitterPreservesExactDurations() async throws {
+    let provider = JitterMockTokenProvider()
+    let clock = TestClock()
+    let now = Date()
+    let timeSource = MockTimeSource(currentDate: now)
+
+    // Initial token expires in 10 seconds.
+    let initialToken = Token(
+      accessToken: "valid", expirationDate: now.addingTimeInterval(10.0))
+    await provider.configure(token: initialToken)
+
+    let cache = TokenCache(
+      provider: provider,
+      clock: clock,
+      timeSource: timeSource,
+      normalRefreshSlack: .seconds(2),
+      shortRefreshSlack: .seconds(1),
+      jitter: nil  // Explicit nil jitter
+    )
+
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 1)
+
+    // Configure next token
+    let refreshedToken = Token(
+      accessToken: "refreshed", expirationDate: now.addingTimeInterval(3600.0))
+    await provider.configure(token: refreshedToken)
+
+    // Advance to 7.9s (before D = 8.0s) -> still sleeping
+    timeSource.advance(by: 7.9)
+    clock.advance(by: .seconds(7.9))
+    #expect(clock.hasSleepers)
+    #expect(await provider.count == 1)
+
+    // Advance by 0.2s (total 8.1s) -> woke up at exactly 8.0s and refreshed!
+    timeSource.advance(by: 0.2)
+    clock.advance(by: .seconds(0.2))
+    await clock.sleeperWaiting()
+    #expect(await provider.count == 2)
+
+    let token = try await cache.token()
+    #expect(token.accessToken == "refreshed")
+  }
+}

--- a/pkgs/swift-google-auth/docs/DESIGN.md
+++ b/pkgs/swift-google-auth/docs/DESIGN.md
@@ -292,18 +292,23 @@ background-refresh model**:
 -   **Refresh Logic**:
     -   If the token has an expiration and it is **more than 4 minutes** in the
         future, the background task sleeps until 4 minutes before expiration
-        (`expiry - 4 minutes`).
+        (`expiry - 4 minutes`), optionally randomized via full jitter across
+        `[expiry - 4 minutes, expiry - 10 seconds]` when jitter is enabled.
     -   If the token expires in **less than 4 minutes** but more than 10
-        seconds, it sleeps for 10 seconds and tries again. This handles Metadata
-        Server edge cases where short-lived tokens are repeatedly returned.
+        seconds, it sleeps for 10 seconds (with jitter when enabled) and tries again.
+        This handles Metadata Server edge cases where short-lived tokens are repeatedly returned.
     -   If a fetch fails with a **transient error**, it sleeps for 10 seconds
-        and retries.
+        (with jitter when enabled) and retries.
     -   If the error is **permanent**, the loop terminates to prevent endless
         useless polling.
--   **Thundering Herd Protection**: Callers calling `token()` return the cached
-    token if valid and not expired. If missing or expired, they await a shared
-    active refresh task, ensuring only one network request is executed even
-    under heavy concurrent load.
+-   **Thundering Herd Protection**:
+    -   **Intra-Process**: Callers calling `token()` return the cached token if
+        valid and not expired. If missing or expired, they await a shared active
+        refresh task, ensuring only one network request is executed even under heavy
+        concurrent load.
+    -   **Cross-Process / Node-Level (MDS)**: `MDSCredentials` enables token refresh
+        jitter by default on `TokenCache`, desynchronizing refresh requests across
+        multiple credentials and processes sharing the same VM metadata server.
 
 --------------------------------------------------------------------------------
 

--- a/pkgs/swift-google-auth/docs/MDS_DESIGN.md
+++ b/pkgs/swift-google-auth/docs/MDS_DESIGN.md
@@ -159,6 +159,12 @@ package struct MDSAccessTokenProvider: TokenProvider, Sendable {
     offline permanently.
     -   **Mitigation**: The `TokenCache` background refresh loop gracefully
         terminates on non-transient errors.
+-   **Risk**: Thundering herd of refresh requests from multiple `Credential`
+    instances on the same VM whose cached MDS tokens expire simultaneously.
+    -   **Mitigation**: `MDSCredentials` configures `TokenCache` with jitter
+        by default, desynchronizing proactive token refreshes across the
+        `[T - normalRefreshSlack, T - shortRefreshSlack]` window and applying
+        jitter to short-slack and transient retry delays.
 
 # Corpus of information
 


### PR DESCRIPTION
The metadata server returns the same access token to all the clients running on the same VM. That means they all expire at the same time, without jitter, they all refresh at the same time. Which is "no bueno", this PR introduces jitter on the refresh to avoid thundering herds.

Fixes #834