### PR TITLE
test(auth): deflake `retryObeysMaxDelayCap`

### DIFF
--- a/pkgs/swift-google-auth/Tests/Http/RetryEngineTests.swift
+++ b/pkgs/swift-google-auth/Tests/Http/RetryEngineTests.swift
@@ -141,18 +141,18 @@ import struct AsyncHTTPClient.HTTPClientResponse
 
   @Test func retryObeysMaxDelayCap() async throws {
     let attempts = CallCounter()
+    let clock = TestClock()
     let config = RetryConfiguration(
       maxAttempts: 4,
-      initialDelay: .seconds(0.01),
+      initialDelay: .seconds(1),
       multiplier: 2.0,
-      maxDelay: .seconds(0.02)
+      maxDelay: .seconds(2)
     )
 
-    let startTime = Date()
-
-    await #expect(throws: URLError.self) {
+    let task = Task {
       try await RetryEngine.retry(
         configuration: config,
+        clock: clock,
         isRetryable: { _ in true }
       ) {
         attempts.increment()
@@ -160,12 +160,32 @@ import struct AsyncHTTPClient.HTTPClientResponse
       }
     }
 
-    let duration = Date().timeIntervalSince(startTime)
+    // 1st retry: delay is bounded by initialDelay (1s).
+    await clock.sleeperWaiting()
+    #expect(attempts.getCount() == 1)
+    let firstSleep = try #require(clock.nextSleepDuration)
+    #expect(firstSleep <= config.initialDelay)
+    clock.advance(by: firstSleep)
 
+    // 2nd retry: delay is bounded by min(initialDelay * multiplier, maxDelay) = 2s.
+    await clock.sleeperWaiting()
+    #expect(attempts.getCount() == 2)
+    let secondSleep = try #require(clock.nextSleepDuration)
+    #expect(secondSleep <= config.maxDelay)
+    clock.advance(by: secondSleep)
+
+    // 3rd retry: delay is capped at maxDelay = 2s.
+    await clock.sleeperWaiting()
+    #expect(attempts.getCount() == 3)
+    let thirdSleep = try #require(clock.nextSleepDuration)
+    #expect(thirdSleep <= config.maxDelay)
+    clock.advance(by: thirdSleep)
+
+    // 4th attempt fails and exhausts maxAttempts (4).
+    await #expect(throws: URLError.self) {
+      try await task.value
+    }
     #expect(attempts.getCount() == 4)
-    // Delays should be: ~0.01, ~0.02, ~0.02 (capped)
-    // With full jitter, total duration can be very short, so we only check upper bound.
-    #expect(duration <= 0.1)
   }
 
   @Test func retryCancelledDuringSleep() async throws {

--- a/pkgs/swift-google-auth/Tests/TestClock.swift
+++ b/pkgs/swift-google-auth/Tests/TestClock.swift
@@ -170,6 +170,20 @@ final class TestClock: Clock, Sendable {
     state.withLock { $0.hasSleepers }
   }
 
+  /// The deadline of the earliest sleeping task, if any.
+  var nextDeadline: Instant? {
+    state.withLock { state in
+      state.sleepers.values.map(\.deadline).min()
+    }
+  }
+
+  /// The duration remaining from current simulated time until the earliest sleeper deadline, if any.
+  var nextSleepDuration: Duration? {
+    state.withLock { state in
+      state.sleepers.values.map(\.deadline).min().map { state.now.duration(to: $0) }
+    }
+  }
+
   /// The minimum resolution of the clock. Always returns .zero as it has infinite resolution.
   var minimumResolution: Duration { .zero }
 

--- a/pkgs/swift-google-auth/Tests/TestClockTests.swift
+++ b/pkgs/swift-google-auth/Tests/TestClockTests.swift
@@ -85,4 +85,27 @@ private actor Counter {
       try await task.value
     }
   }
+
+  @Test func nextSleepDuration() async throws {
+    let clock = TestClock()
+    #expect(clock.nextDeadline == nil)
+    #expect(clock.nextSleepDuration == nil)
+
+    let task = Task {
+      try await clock.sleep(for: .seconds(5))
+    }
+
+    await clock.sleeperWaiting()
+    #expect(clock.nextDeadline == clock.now.advanced(by: .seconds(5)))
+    #expect(clock.nextSleepDuration == .seconds(5))
+
+    clock.advance(by: .seconds(2))
+    #expect(clock.nextSleepDuration == .seconds(3))
+
+    clock.advance(by: .seconds(3))
+    try await task.value
+
+    #expect(clock.nextDeadline == nil)
+    #expect(clock.nextSleepDuration == nil)
+  }
 }


### PR DESCRIPTION
This test was flaky because it expected the execution time to be "close" to the sleep time. On CI machines, under load, the test may take longer than expected for scheduling reasons. Using a mock clock deflakes the test.

Fixes #838 