### PR TITLE
fix(wkt): `Value.number` and non-finite values

### DIFF
--- a/pkgs/swift-google-wkt/Sources/GoogleCloudWKT/Value.swift
+++ b/pkgs/swift-google-wkt/Sources/GoogleCloudWKT/Value.swift
@@ -93,7 +93,7 @@ public enum Value: Codable, Equatable, Sendable {
     } else if let v = try? container.decode(String.self) {
       // Try as a string first, because the decoder may treat some strings as numbers.
       self = .string(v)
-    } else if let v = try? container.decode(Double.self) {
+    } else if let v = try? container.decode(Double.self), v.isFinite {
       self = .number(v)
     } else if let v = try? container.decode(Struct.self) {
       self = .object(v)
@@ -118,6 +118,15 @@ public enum Value: Codable, Equatable, Sendable {
     case .null:
       try container.encodeNil()
     case .number(let v):
+      guard v.isFinite else {
+        throw EncodingError.invalidValue(
+          v,
+          EncodingError.Context(
+            codingPath: container.codingPath,
+            debugDescription: "Value.number cannot be NaN or Infinity."
+          )
+        )
+      }
       try container.encode(v)
     case .string(let v):
       try container.encode(v)

--- a/pkgs/swift-google-wkt/Tests/ValueTests.swift
+++ b/pkgs/swift-google-wkt/Tests/ValueTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import Foundation
-import GoogleCloudWKT
+@_spi(GoogleCloudInternal) import GoogleCloudWKT
 import Testing
 
 @Suite struct ValueTests {
@@ -322,5 +322,38 @@ import Testing
     let data = try encoder.encode(wrapped)
     let got = String(data: data, encoding: .utf8)!
     #expect(got == "{\"value\":null}")
+  }
+
+  @Test(
+    "Value encoding invalid numbers throws error",
+    arguments: [
+      Value.number(Double.infinity),
+      Value.number(-Double.infinity),
+      Value.number(Double.nan),
+    ])
+  func encodeValueInvalidNumbers(value: Value) throws {
+    let encoder = _ProtoJSONEncoder()
+    #expect(throws: EncodingError.self) {
+      _ = try encoder.encode(value)
+    }
+
+    let wrapped = WrappedValue(value: value)
+    #expect(throws: EncodingError.self) {
+      _ = try encoder.encode(wrapped)
+    }
+  }
+
+  @Test("Value nested invalid numbers throw error")
+  func encodeValueNestedInvalidNumbers() throws {
+    let encoder = _ProtoJSONEncoder()
+    let objectValue = Value.object(["test": .number(Double.infinity)])
+    #expect(throws: EncodingError.self) {
+      _ = try encoder.encode(objectValue)
+    }
+
+    let arrayValue = Value.array([.number(Double.nan)])
+    #expect(throws: EncodingError.self) {
+      _ = try encoder.encode(arrayValue)
+    }
   }
 }


### PR DESCRIPTION
Serializing a `Value` when it contains numbers (which are always doubles) requires special care around `Infinity`, `-Infinity` and `NaN`. Normally in ProtoJSON we serialize these as strings. Using that serialization inside a `Value` creates roundtrip problems.

It is better to throw an exception, indicating that the serialization failed, rather than create a JSON string that won't be decodable by the receiver.

Fixes #826 