### PR TITLE
cleanup: follow swift style guide

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -20,6 +20,8 @@
   },
   "maximumBlankLines": 1,
   "rules": {
-    "NoEmptyLinesOpeningClosingBraces": true
+    "AlwaysUseLowerCamelCase": true,
+    "NoEmptyLinesOpeningClosingBraces": true,
+    "TypeNamesShouldBeCapitalized": true
   }
 }

--- a/Sources/GoogleCloudTestHelpers/ReportError.swift
+++ b/Sources/GoogleCloudTestHelpers/ReportError.swift
@@ -19,7 +19,7 @@ import Logging
 
 public func runLoggedTest(_ name: String, _ test: (Logger) async throws -> Void) async throws {
   let handler = InMemoryLogHandler()
-  let logger = Logger(label: "logging.test", factory: { (String) in handler })
+  let logger = Logger(label: "logging.test", factory: { (_: String) in handler })
   do {
     try await test(logger)
   } catch let e as GoogleCloudGax.RequestError {

--- a/Tests/ProtoBasedClient/Logging.swift
+++ b/Tests/ProtoBasedClient/Logging.swift
@@ -25,7 +25,7 @@ public enum Logging {
   static public func run(_ logger: Logger) async throws {
     let projectId = try projectId()
     let handler = InMemoryLogHandler()
-    var clientLogger = Logger(label: "logging.test", factory: { (String) in handler })
+    var clientLogger = Logger(label: "logging.test", factory: { (_: String) in handler })
     clientLogger.logLevel = .debug
     let client = try SecretManagerServiceClient(
       ClientOptions().with { $0.logger = clientLogger })

--- a/Tests/StorageW1R3/StorageOperations.swift
+++ b/Tests/StorageW1R3/StorageOperations.swift
@@ -50,7 +50,7 @@ enum StorageOperations {
       // If precondition failed (412), check if object already exists
       if let reqError = error as? RequestError,
         case .http(let details) = reqError,
-        details.http_status_code == 412
+        details.httpStatusCode == 412
       {
         logToStderr("Precondition failed for \(objectName), fetching object details")
         let getReq = GetObjectRequest().with {
@@ -111,7 +111,7 @@ enum StorageOperations {
           } catch {
             // Ignore 404 / NOT_FOUND as it may be due to retry
             if let reqError = error as? RequestError {
-              if case .http(let details) = reqError, details.http_status_code == 404 {
+              if case .http(let details) = reqError, details.httpStatusCode == 404 {
                 return
               }
               if case .service(let details) = reqError, details.code == .notFound {

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -67,7 +67,7 @@ for dir in "${packages[@]}"; do
 
     # For local packages, we run swift-format directly on the Sources and Tests directories
     # to avoid the SPM plugin forcefully feeding the generated Rust bridge files.
-    if swift-format lint -r "${dir}/Sources" "${dir}/Tests"; then
+    if swift-format lint --strict -r "${dir}/Sources" "${dir}/Tests"; then
         echo "::notice:: ✓ ${dir} passed"
         echo "::endgroup::"
     else

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/DownloadOptions.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/DownloadOptions.swift
@@ -557,7 +557,7 @@ package final class ReadObjectCoordinator: @unchecked Sendable {
           if case .http(let details) = err {
             let message = String(data: details.payload, encoding: .utf8) ?? ""
             throw DownloadError.unexpectedServerResponse(
-              statusCode: details.http_status_code, message: message)
+              statusCode: details.httpStatusCode, message: message)
           } else if case .service(let details) = err {
             let statusCode = details.httpStatusCode ?? details.code.httpStatusCode
             throw DownloadError.unexpectedServerResponse(
@@ -699,7 +699,7 @@ package final class ReadObjectCoordinator: @unchecked Sendable {
         if case .http(let details) = reqError {
           let message = String(data: details.payload, encoding: .utf8) ?? ""
           throw DownloadError.unexpectedServerResponse(
-            statusCode: details.http_status_code, message: message)
+            statusCode: details.httpStatusCode, message: message)
         } else if case .service(let details) = reqError {
           let statusCode = details.httpStatusCode ?? details.code.httpStatusCode
           throw DownloadError.unexpectedServerResponse(
@@ -756,7 +756,7 @@ package final class ReadObjectCoordinator: @unchecked Sendable {
       if case .http(let details) = error {
         let message = String(data: details.payload, encoding: .utf8) ?? ""
         throw DownloadError.unexpectedServerResponse(
-          statusCode: details.http_status_code, message: message)
+          statusCode: details.httpStatusCode, message: message)
       } else if case .service(let details) = error {
         let statusCode = details.httpStatusCode ?? details.code.httpStatusCode
         throw DownloadError.unexpectedServerResponse(

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageResumePolicy.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageResumePolicy.swift
@@ -48,7 +48,7 @@ public struct StorageResumePolicy<Details: Sendable>: ResumePolicy, Sendable, Eq
     case .io:
       return true
     case .http(let details):
-      let code = details.http_status_code
+      let code = details.httpStatusCode
       return code == 408 || code == 429 || (500...599).contains(code)
     case .service(let details):
       let code = details.code

--- a/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageRetryErrors.swift
+++ b/pkgs/swift-google-cloud-storage/Sources/GoogleCloudStorage/StorageRetryErrors.swift
@@ -32,7 +32,7 @@ final class StorageRetryErrors: RetryPolicy, Sendable {
   func isRetryable(_ error: RequestError) -> Bool {
     switch error {
     case .http(let details):
-      let code = details.http_status_code
+      let code = details.httpStatusCode
       return code == 408 || code == 429 || (500...599).contains(code)
     case .service(let details):
       let code = details.code

--- a/pkgs/swift-google-cloud-storage/Tests/AlwaysResumeTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/AlwaysResumeTests.swift
@@ -21,8 +21,8 @@ import Testing
   @Test func alwaysResume() {
     let policy = AlwaysResume<Void>()
     var state = ResumeState()
-    let error503 = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
-    let error400 = RequestError.http(HTTPDetails(http_status_code: 400, headers: [:]))
+    let error503 = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
+    let error400 = RequestError.http(HTTPDetails(httpStatusCode: 400, headers: [:]))
     let errorBinding = RequestError.binding("test error")
 
     #expect(policy.onError(state: state, error: error400) == .resume(error400))
@@ -37,7 +37,7 @@ import Testing
   @Test func staticFactory() {
     let policy: AlwaysResume<Void> = .always()
     let state = ResumeState()
-    let transient503 = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
+    let transient503 = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
     #expect(policy.onError(state: state, error: transient503) == .resume(transient503))
   }
 }

--- a/pkgs/swift-google-cloud-storage/Tests/ChecksumTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/ChecksumTests.swift
@@ -104,7 +104,7 @@ import Testing
       try await client.upload(source, to: bucket, as: objectName, options: uploadOptions)
     }
     if case .http(let details) = error {
-      #expect(details.http_status_code == 400)
+      #expect(details.httpStatusCode == 400)
       #expect(String(data: details.payload, encoding: .utf8) == errorMessage)
     } else {
       Issue.record("Expected .http RequestError, got \(String(describing: error))")
@@ -149,7 +149,7 @@ import Testing
       try await client.upload(source, to: bucket, as: objectName, options: uploadOptions)
     }
     if case .http(let details) = error {
-      #expect(details.http_status_code == 400)
+      #expect(details.httpStatusCode == 400)
       #expect(String(data: details.payload, encoding: .utf8) == errorMessage)
     } else {
       Issue.record("Expected .http RequestError, got \(String(describing: error))")

--- a/pkgs/swift-google-cloud-storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/IntegrationTests/StorageClientIntegrationTests.swift
@@ -269,7 +269,7 @@ struct StorageClientIntegrationTests {
       #expect(serviceError.message.contains("doesn't match"))
       print("GCS correctly rejected bad checksum: \(serviceError.message)")
     } catch RequestError.http(let details) {
-      #expect(details.http_status_code == 400)
+      #expect(details.httpStatusCode == 400)
       print(
         "GCS correctly rejected bad checksum: \(String(data: details.payload, encoding: .utf8) ?? "")"
       )

--- a/pkgs/swift-google-cloud-storage/Tests/LimitedTotalResumesTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/LimitedTotalResumesTests.swift
@@ -29,7 +29,7 @@ import Testing
     let mock = MockResumePolicy<Void>(onError: { _, e in .resume(e) })
     let policy = mock.withTotalResumeLimit(2)
     var state = ResumeState()
-    let error = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
+    let error = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
 
     // 0 resumes
     #expect(policy.onError(state: state, error: error) == .resume(error))
@@ -52,7 +52,7 @@ import Testing
   }
 
   @Test func innerPermanentPassesThrough() {
-    let permanentError = RequestError.http(HTTPDetails(http_status_code: 403, headers: [:]))
+    let permanentError = RequestError.http(HTTPDetails(httpStatusCode: 403, headers: [:]))
     let mock = MockResumePolicy<Void>(onError: { _, e in .permanent(e) })
     let policy = mock.withTotalResumeLimit(5)
     let state = ResumeState()
@@ -61,7 +61,7 @@ import Testing
   }
 
   @Test func innerExhaustedPassesThrough() {
-    let exhaustedError = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
+    let exhaustedError = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
     let mock = MockResumePolicy<Void>(onError: { _, e in .exhausted(e) })
     let policy = mock.withTotalResumeLimit(5)
     let state = ResumeState()

--- a/pkgs/swift-google-cloud-storage/Tests/NeverResumeTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/NeverResumeTests.swift
@@ -21,7 +21,7 @@ import Testing
   @Test func neverResume() {
     let policy = NeverResume<Void>()
     let state = ResumeState()
-    let transient503 = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
+    let transient503 = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
 
     #expect(policy.onError(state: state, error: transient503) == .permanent(transient503))
     #expect(policy.remainingTime(state: state) == nil)
@@ -30,7 +30,7 @@ import Testing
   @Test func staticFactory() {
     let policy: NeverResume<Void> = .never()
     let state = ResumeState()
-    let transient503 = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
+    let transient503 = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
     #expect(policy.onError(state: state, error: transient503) == .permanent(transient503))
   }
 }

--- a/pkgs/swift-google-cloud-storage/Tests/ResumableUploadTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/ResumableUploadTests.swift
@@ -194,7 +194,7 @@ import Testing
       try await client.upload(source, to: bucket, as: objectName)
     }
     if case .http(let details) = error {
-      #expect(details.http_status_code == 400)
+      #expect(details.httpStatusCode == 400)
     } else {
       Issue.record("Expected .http RequestError, got \(String(describing: error))")
     }
@@ -438,7 +438,7 @@ import Testing
       try await client.resumeUpload(source, uploadId: queryUrl.absoluteString)
     }
     if case .http(let details) = error {
-      #expect(details.http_status_code == 404)
+      #expect(details.httpStatusCode == 404)
     } else {
       Issue.record("Expected .http RequestError, got \(String(describing: error))")
     }
@@ -495,7 +495,7 @@ import Testing
       try await client.resumeUpload(source, uploadId: queryUrl.absoluteString)
     }
     if case .http(let details) = error {
-      #expect(details.http_status_code == 499)
+      #expect(details.httpStatusCode == 499)
     } else {
       Issue.record("Expected .http RequestError, got \(String(describing: error))")
     }

--- a/pkgs/swift-google-cloud-storage/Tests/ResumeLoopTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/ResumeLoopTests.swift
@@ -30,7 +30,7 @@ private struct MockBackoff: BackoffPolicy {
   }
 
   private func transientError() -> RequestError {
-    RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
+    RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
   }
 
   @Test func immediateSuccess() async throws {

--- a/pkgs/swift-google-cloud-storage/Tests/ResumePolicyTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/ResumePolicyTests.swift
@@ -109,12 +109,12 @@ import Testing
     let state = ResumeState()
 
     // Recoverable HTTP status codes
-    let err408 = RequestError.http(HTTPDetails(http_status_code: 408, headers: [:]))
-    let err429 = RequestError.http(HTTPDetails(http_status_code: 429, headers: [:]))
-    let err500 = RequestError.http(HTTPDetails(http_status_code: 500, headers: [:]))
-    let err502 = RequestError.http(HTTPDetails(http_status_code: 502, headers: [:]))
-    let err503 = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
-    let err504 = RequestError.http(HTTPDetails(http_status_code: 504, headers: [:]))
+    let err408 = RequestError.http(HTTPDetails(httpStatusCode: 408, headers: [:]))
+    let err429 = RequestError.http(HTTPDetails(httpStatusCode: 429, headers: [:]))
+    let err500 = RequestError.http(HTTPDetails(httpStatusCode: 500, headers: [:]))
+    let err502 = RequestError.http(HTTPDetails(httpStatusCode: 502, headers: [:]))
+    let err503 = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
+    let err504 = RequestError.http(HTTPDetails(httpStatusCode: 504, headers: [:]))
     let errIO = RequestError.io(NSError(domain: "test", code: -1))
 
     #expect(isResume(policy.onError(state: state, error: err408)))
@@ -141,11 +141,11 @@ import Testing
     #expect(isResume(policy.onError(state: state, error: rpcInternal)))
 
     // Permanent HTTP status codes
-    let err400 = RequestError.http(HTTPDetails(http_status_code: 400, headers: [:]))
-    let err401 = RequestError.http(HTTPDetails(http_status_code: 401, headers: [:]))
-    let err403 = RequestError.http(HTTPDetails(http_status_code: 403, headers: [:]))
-    let err404 = RequestError.http(HTTPDetails(http_status_code: 404, headers: [:]))
-    let err412 = RequestError.http(HTTPDetails(http_status_code: 412, headers: [:]))
+    let err400 = RequestError.http(HTTPDetails(httpStatusCode: 400, headers: [:]))
+    let err401 = RequestError.http(HTTPDetails(httpStatusCode: 401, headers: [:]))
+    let err403 = RequestError.http(HTTPDetails(httpStatusCode: 403, headers: [:]))
+    let err404 = RequestError.http(HTTPDetails(httpStatusCode: 404, headers: [:]))
+    let err412 = RequestError.http(HTTPDetails(httpStatusCode: 412, headers: [:]))
 
     #expect(isPermanent(policy.onError(state: state, error: err400)))
     #expect(isPermanent(policy.onError(state: state, error: err401)))
@@ -169,8 +169,8 @@ import Testing
     let policy = StorageResumePolicy<Void>()
     let state = ResumeState(idempotent: false)
 
-    let err503 = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
-    let err429 = RequestError.http(HTTPDetails(http_status_code: 429, headers: [:]))
+    let err503 = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
+    let err429 = RequestError.http(HTTPDetails(httpStatusCode: 429, headers: [:]))
     let errIO = RequestError.io(NSError(domain: "test", code: -1))
     let rpcUnavailable = RequestError.service(
       ServiceError(code: Code.unavailable, message: "unavailable"))
@@ -188,9 +188,9 @@ import Testing
     let policy = StorageResumePolicy<Void>().stopOnConsecutiveErrors(2)
     var state = ResumeState()
 
-    let transientError = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
-    let permanentError = RequestError.http(HTTPDetails(http_status_code: 404, headers: [:]))
-    let authError = RequestError.http(HTTPDetails(http_status_code: 401, headers: [:]))
+    let transientError = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
+    let permanentError = RequestError.http(HTTPDetails(httpStatusCode: 404, headers: [:]))
+    let authError = RequestError.http(HTTPDetails(httpStatusCode: 401, headers: [:]))
     let ioError = RequestError.io(NSError(domain: "test", code: -1))
 
     // Permanent errors halt immediately
@@ -219,8 +219,8 @@ import Testing
     let policy = StorageResumePolicy<Void>().withTotalResumeLimit(2)
     var state = ResumeState()
 
-    let transientError = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
-    let permanentError = RequestError.http(HTTPDetails(http_status_code: 403, headers: [:]))
+    let transientError = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
+    let permanentError = RequestError.http(HTTPDetails(httpStatusCode: 403, headers: [:]))
 
     // Permanent error
     #expect(isPermanent(policy.onError(state: state, error: permanentError)))
@@ -241,7 +241,7 @@ import Testing
   @Test func neverResumePolicy() {
     let policy = NeverResume<Void>()
     let state = ResumeState()
-    let transientError = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
+    let transientError = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
     let ioError = RequestError.io(NSError(domain: "test", code: -1))
 
     #expect(isPermanent(policy.onError(state: state, error: transientError)))
@@ -251,8 +251,8 @@ import Testing
   @Test func alwaysResumePolicy() {
     let policy = AlwaysResume<Void>()
     var state = ResumeState()
-    let transientError = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
-    let permanentError = RequestError.http(HTTPDetails(http_status_code: 400, headers: [:]))
+    let transientError = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
+    let permanentError = RequestError.http(HTTPDetails(httpStatusCode: 400, headers: [:]))
 
     #expect(isResume(policy.onError(state: state, error: permanentError)))
 
@@ -301,7 +301,7 @@ import Testing
       try await client.upload(source, to: bucket, as: objectName, options: uploadOptions)
     }
     if case .http(let details) = error {
-      #expect(details.http_status_code == 503)
+      #expect(details.httpStatusCode == 503)
     } else {
       Issue.record("Expected .http 503 RequestError, got \(String(describing: error))")
     }

--- a/pkgs/swift-google-cloud-storage/Tests/ResumeResult+Additions.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/ResumeResult+Additions.swift
@@ -29,7 +29,7 @@ extension ResumeResult: Equatable {
   private static func isEquivalent(_ lhs: RequestError, _ rhs: RequestError) -> Bool {
     switch (lhs, rhs) {
     case (.http(let l), .http(let r)):
-      return l.http_status_code == r.http_status_code
+      return l.httpStatusCode == r.httpStatusCode
     case (.service(let l), .service(let r)):
       return l.code == r.code
     case (.io(let l), .io(let r)):

--- a/pkgs/swift-google-cloud-storage/Tests/SimpleUploadTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/SimpleUploadTests.swift
@@ -145,7 +145,7 @@ import Testing
       try await client.upload(source, to: bucket, as: objectName)
     }
     if case .http(let details) = error {
-      #expect(details.http_status_code == 400)
+      #expect(details.httpStatusCode == 400)
     } else {
       Issue.record("Expected .http RequestError, got \(String(describing: error))")
     }
@@ -420,7 +420,7 @@ import Testing
       try await client.upload(source, to: bucket, as: objectName)
     }
     if case .http(let details) = error {
-      #expect(details.http_status_code == 503)
+      #expect(details.httpStatusCode == 503)
     } else {
       Issue.record("Expected .http 503 RequestError, got \(String(describing: error))")
     }
@@ -563,7 +563,7 @@ import Testing
       try await client.upload(source, to: bucket, as: objectName, options: options)
     }
     if case .http(let details) = error {
-      #expect(details.http_status_code == 503)
+      #expect(details.httpStatusCode == 503)
     } else {
       Issue.record("Expected .http 503 RequestError, got \(String(describing: error))")
     }

--- a/pkgs/swift-google-cloud-storage/Tests/StopOnConsecutiveErrorsTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/StopOnConsecutiveErrorsTests.swift
@@ -29,7 +29,7 @@ import Testing
     let mock = MockResumePolicy<Void>(onError: { _, e in .resume(e) })
     let policy = mock.stopOnConsecutiveErrors(2)
     var state = ResumeState()
-    let error = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
+    let error = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
 
     // 0 errors -> resumes
     #expect(policy.onError(state: state, error: error) == .resume(error))
@@ -48,7 +48,7 @@ import Testing
   }
 
   @Test func innerPermanentPassesThrough() {
-    let permanentError = RequestError.http(HTTPDetails(http_status_code: 400, headers: [:]))
+    let permanentError = RequestError.http(HTTPDetails(httpStatusCode: 400, headers: [:]))
     let mock = MockResumePolicy<Void>(onError: { _, e in .permanent(e) })
     let policy = mock.stopOnConsecutiveErrors(5)
     let state = ResumeState()
@@ -57,7 +57,7 @@ import Testing
   }
 
   @Test func innerExhaustedPassesThrough() {
-    let exhaustedError = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
+    let exhaustedError = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
     let mock = MockResumePolicy<Void>(onError: { _, e in .exhausted(e) })
     let policy = mock.stopOnConsecutiveErrors(5)
     let state = ResumeState()

--- a/pkgs/swift-google-cloud-storage/Tests/StorageBaseRetryPolicyTests.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/StorageBaseRetryPolicyTests.swift
@@ -47,7 +47,7 @@ import Testing
     // Retryable HTTP codes: 408, 429, and 500...599
     let retryableCodes = [408, 429, 500, 502, 503, 504, 599]
     for code in retryableCodes {
-      let error = RequestError.http(HTTPDetails(http_status_code: code, headers: [:]))
+      let error = RequestError.http(HTTPDetails(httpStatusCode: code, headers: [:]))
       #expect(
         isRetry(policy.onError(state: state, error: error)), "Expected code \(code) to be retryable"
       )
@@ -56,7 +56,7 @@ import Testing
     // Non-retryable HTTP codes
     let nonRetryableCodes = [400, 401, 403, 404, 409, 412]
     for code in nonRetryableCodes {
-      let error = RequestError.http(HTTPDetails(http_status_code: code, headers: [:]))
+      let error = RequestError.http(HTTPDetails(httpStatusCode: code, headers: [:]))
       #expect(
         isPermanent(policy.onError(state: state, error: error)),
         "Expected code \(code) to be permanent")
@@ -108,11 +108,11 @@ import Testing
   @Test func storageBaseRetryPolicyIdempotency() {
     let policy = StorageBaseRetryPolicy()
 
-    let transientHttp = RequestError.http(HTTPDetails(http_status_code: 500, headers: [:]))
+    let transientHttp = RequestError.http(HTTPDetails(httpStatusCode: 500, headers: [:]))
     let transientRpc = RequestError.service(
       ServiceError(code: Code.`internal`, message: "internal error"))
     let ioError = RequestError.io(NSError(domain: "test", code: -1))
-    let permanentHttp = RequestError.http(HTTPDetails(http_status_code: 400, headers: [:]))
+    let permanentHttp = RequestError.http(HTTPDetails(httpStatusCode: 400, headers: [:]))
 
     // Idempotent: retries transient HTTP, transient RPC, and I/O
     #expect(isRetry(policy.onError(state: idempotentState(), error: transientHttp)))
@@ -138,13 +138,13 @@ import Testing
       ServiceError(code: Code.unavailable, message: "unavailable"))
     #expect(isRetry(policy.onError(state: state, error: unavailableError)))
 
-    let err503 = RequestError.http(HTTPDetails(http_status_code: 503, headers: [:]))
+    let err503 = RequestError.http(HTTPDetails(httpStatusCode: 503, headers: [:]))
     #expect(isRetry(policy.onError(state: state, error: err503)))
 
-    let err500 = RequestError.http(HTTPDetails(http_status_code: 500, headers: [:]))
+    let err500 = RequestError.http(HTTPDetails(httpStatusCode: 500, headers: [:]))
     #expect(isRetry(policy.onError(state: state, error: err500)))
 
-    let permanent = RequestError.http(HTTPDetails(http_status_code: 404, headers: [:]))
+    let permanent = RequestError.http(HTTPDetails(httpStatusCode: 404, headers: [:]))
     #expect(isPermanent(policy.onError(state: state, error: permanent)))
   }
 }

--- a/pkgs/swift-google-cloud-storage/Tests/UrlMocks.swift
+++ b/pkgs/swift-google-cloud-storage/Tests/UrlMocks.swift
@@ -232,7 +232,7 @@ final class MockRegistry: _HTTPClientProtocol, @unchecked Sendable {
     guard let mock = mockResponse else {
       throw GoogleCloudGax.RequestError.http(
         GoogleCloudGax.HTTPDetails(
-          http_status_code: 404,
+          httpStatusCode: 404,
           headers: [:],
           payload: Data("Mock not found for \(request.url)".utf8)
         )

--- a/pkgs/swift-google-gax/README.md
+++ b/pkgs/swift-google-gax/README.md
@@ -144,7 +144,7 @@ do {
             print("Status detail: \(detail)")
         }
     case .http(let httpDetails):
-        print("HTTP error with status code: \(httpDetails.http_status_code)")
+        print("HTTP error with status code: \(httpDetails.httpStatusCode)")
     case .io(let ioError):
         print("Transport I/O error: \(ioError)")
     case .exhausted(let exhausted):

--- a/pkgs/swift-google-gax/Sources/GoogleCloudGax/Aip194.swift
+++ b/pkgs/swift-google-gax/Sources/GoogleCloudGax/Aip194.swift
@@ -45,7 +45,7 @@ final public class Aip194: Sendable {
 extension RequestError {
   fileprivate var httpStatusCode: Int? {
     if case .http(let details) = self {
-      return details.http_status_code
+      return details.httpStatusCode
     }
     return nil
   }

--- a/pkgs/swift-google-gax/Sources/GoogleCloudGax/HTTPClientResponse.swift
+++ b/pkgs/swift-google-gax/Sources/GoogleCloudGax/HTTPClientResponse.swift
@@ -88,7 +88,7 @@ import struct NIOCore.ByteBuffer
     .mapValues { values in values.joined(separator: ";") }
     return .http(
       GoogleCloudGax.HTTPDetails(
-        http_status_code: Int(response.status.code),
+        httpStatusCode: Int(response.status.code),
         headers: headers,
         payload: data,
       ))

--- a/pkgs/swift-google-gax/Sources/GoogleCloudGax/RequestError.swift
+++ b/pkgs/swift-google-gax/Sources/GoogleCloudGax/RequestError.swift
@@ -104,7 +104,7 @@ public enum RequestError: Error {
 /// The details for ``RequestError/http(_:)``.
 public struct HTTPDetails: Sendable {
   /// The HTTP status code.
-  public let http_status_code: Int
+  public let httpStatusCode: Int
 
   /// The HTTP headers.
   public let headers: [String: String]
@@ -114,11 +114,11 @@ public struct HTTPDetails: Sendable {
 
   /// Create a a new `HTTPDetails`.
   public init(
-    http_status_code: Int,
+    httpStatusCode: Int,
     headers: [String: String],
     payload: Data = Data()
   ) {
-    self.http_status_code = http_status_code
+    self.httpStatusCode = httpStatusCode
     self.headers = headers
     self.payload = payload
   }

--- a/pkgs/swift-google-gax/Sources/GoogleCloudGax/TooManyRequests.swift
+++ b/pkgs/swift-google-gax/Sources/GoogleCloudGax/TooManyRequests.swift
@@ -32,7 +32,7 @@ public struct TooManyRequests<P: Sendable>: Sendable {
       return details.code == GoogleRpc.Code.resourceExhausted
     }
     if case .http(let details) = error {
-      return details.http_status_code == 429
+      return details.httpStatusCode == 429
     }
     return false
   }

--- a/pkgs/swift-google-gax/Tests/Aip194PollingErrorPolicyTests.swift
+++ b/pkgs/swift-google-gax/Tests/Aip194PollingErrorPolicyTests.swift
@@ -54,7 +54,7 @@ import Testing
 
   static func unknownAnd503() -> RequestError {
     // Some services return a status of "Unknown" and a http status code of 503
-    .http(HTTPDetails(http_status_code: 503, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 503, headers: [:], payload: Data()))
   }
 
   static func permissionDenied() -> RequestError {
@@ -63,10 +63,10 @@ import Testing
   }
 
   static func httpUnavailable() -> RequestError {
-    .http(HTTPDetails(http_status_code: 503, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 503, headers: [:], payload: Data()))
   }
 
   static func httpPermissionDenied() -> RequestError {
-    .http(HTTPDetails(http_status_code: 403, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 403, headers: [:], payload: Data()))
   }
 }

--- a/pkgs/swift-google-gax/Tests/Aip194RetryPolicyTests.swift
+++ b/pkgs/swift-google-gax/Tests/Aip194RetryPolicyTests.swift
@@ -54,7 +54,7 @@ import Testing
 
   static func unknownAnd503() -> RequestError {
     // Some services return a status of "Unknown" and a http status code of 503
-    .http(HTTPDetails(http_status_code: 503, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 503, headers: [:], payload: Data()))
   }
 
   static func permissionDenied() -> RequestError {
@@ -63,10 +63,10 @@ import Testing
   }
 
   static func httpUnavailable() -> RequestError {
-    .http(HTTPDetails(http_status_code: 503, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 503, headers: [:], payload: Data()))
   }
 
   static func httpPermissionDenied() -> RequestError {
-    .http(HTTPDetails(http_status_code: 403, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 403, headers: [:], payload: Data()))
   }
 }

--- a/pkgs/swift-google-gax/Tests/AlwaysPollTests.swift
+++ b/pkgs/swift-google-gax/Tests/AlwaysPollTests.swift
@@ -38,6 +38,6 @@ import Testing
   // Helper functions
 
   private func httpUnavailable() -> RequestError {
-    .http(HTTPDetails(http_status_code: 503, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 503, headers: [:], payload: Data()))
   }
 }

--- a/pkgs/swift-google-gax/Tests/AlwaysRetryTests.swift
+++ b/pkgs/swift-google-gax/Tests/AlwaysRetryTests.swift
@@ -40,6 +40,6 @@ import Testing
   // Helper functions
 
   private func httpUnavailable() -> RequestError {
-    .http(HTTPDetails(http_status_code: 503, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 503, headers: [:], payload: Data()))
   }
 }

--- a/pkgs/swift-google-gax/Tests/BaseRetryPolicyTests.swift
+++ b/pkgs/swift-google-gax/Tests/BaseRetryPolicyTests.swift
@@ -58,7 +58,7 @@ import Testing
 
   static func unknownAnd503() -> RequestError {
     // Some services return a status of "Unknown" and a http status code of 503
-    .http(HTTPDetails(http_status_code: 503, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 503, headers: [:], payload: Data()))
   }
 
   static func permissionDenied() -> RequestError {
@@ -67,10 +67,10 @@ import Testing
   }
 
   static func httpUnavailable() -> RequestError {
-    .http(HTTPDetails(http_status_code: 503, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 503, headers: [:], payload: Data()))
   }
 
   static func httpPermissionDenied() -> RequestError {
-    .http(HTTPDetails(http_status_code: 403, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 403, headers: [:], payload: Data()))
   }
 }

--- a/pkgs/swift-google-gax/Tests/HTTPClientTests.swift
+++ b/pkgs/swift-google-gax/Tests/HTTPClientTests.swift
@@ -330,7 +330,7 @@ import NIOHTTP1
       Issue.record("expected an http error response, got=\(response)")
       return
     }
-    #expect(httpError.http_status_code == 404)
+    #expect(httpError.httpStatusCode == 404)
   }
 
   @Test("verify the client when used as GAPICs do for Create-like operations")
@@ -612,7 +612,7 @@ import NIOHTTP1
       Issue.record("expected service error , got \(e)")
       return
     }
-    #expect(httpError.http_status_code == HTTPResponseStatus.forbidden.code)
+    #expect(httpError.httpStatusCode == HTTPResponseStatus.forbidden.code)
     #expect(httpError.payload == Data(responsePayload.utf8))
     #expect(httpError.headers["x-goog-test-only"] == "test-header")
   }

--- a/pkgs/swift-google-gax/Tests/LimitedAttemptCountPollingErrorPolicyTests.swift
+++ b/pkgs/swift-google-gax/Tests/LimitedAttemptCountPollingErrorPolicyTests.swift
@@ -62,9 +62,9 @@ import Testing
   }
 
   func transient() -> RequestError {
-    RequestError.http(HTTPDetails(http_status_code: 429, headers: [:]))
+    RequestError.http(HTTPDetails(httpStatusCode: 429, headers: [:]))
   }
   func permanent() -> RequestError {
-    RequestError.http(HTTPDetails(http_status_code: 403, headers: [:]))
+    RequestError.http(HTTPDetails(httpStatusCode: 403, headers: [:]))
   }
 }

--- a/pkgs/swift-google-gax/Tests/LimitedAttemptCountRetryPolicyTests.swift
+++ b/pkgs/swift-google-gax/Tests/LimitedAttemptCountRetryPolicyTests.swift
@@ -85,9 +85,9 @@ import Testing
   }
 
   func transient() -> RequestError {
-    RequestError.http(HTTPDetails(http_status_code: 429, headers: [:]))
+    RequestError.http(HTTPDetails(httpStatusCode: 429, headers: [:]))
   }
   func permanent() -> RequestError {
-    RequestError.http(HTTPDetails(http_status_code: 403, headers: [:]))
+    RequestError.http(HTTPDetails(httpStatusCode: 403, headers: [:]))
   }
 }

--- a/pkgs/swift-google-gax/Tests/LongRunningOperationsTests.swift
+++ b/pkgs/swift-google-gax/Tests/LongRunningOperationsTests.swift
@@ -47,7 +47,7 @@ import GoogleRpc
   }
 
   static func httpError() -> RequestError {
-    .http(HTTPDetails(http_status_code: 404, headers: [:]))
+    .http(HTTPDetails(httpStatusCode: 404, headers: [:]))
   }
 
   static func pendingState() -> _PollableOperationImpl<String>.State {

--- a/pkgs/swift-google-gax/Tests/NeverRetryTests.swift
+++ b/pkgs/swift-google-gax/Tests/NeverRetryTests.swift
@@ -54,10 +54,10 @@ import Testing
   // Helper functions
 
   private func httpUnavailable() -> RequestError {
-    .http(HTTPDetails(http_status_code: 503, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 503, headers: [:], payload: Data()))
   }
 
   private func httpPermissionDenied() -> RequestError {
-    .http(HTTPDetails(http_status_code: 403, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 403, headers: [:], payload: Data()))
   }
 }

--- a/pkgs/swift-google-gax/Tests/RequestError+Additions.swift
+++ b/pkgs/swift-google-gax/Tests/RequestError+Additions.swift
@@ -36,7 +36,7 @@ extension RequestError: Equatable {
 
 extension HTTPDetails: Equatable {
   public static func == (lhs: HTTPDetails, rhs: HTTPDetails) -> Bool {
-    return lhs.http_status_code == rhs.http_status_code && lhs.headers == rhs.headers
+    return lhs.httpStatusCode == rhs.httpStatusCode && lhs.headers == rhs.headers
       && lhs.payload == rhs.payload
   }
 }

--- a/pkgs/swift-google-gax/Tests/StrictIdempotencyTests.swift
+++ b/pkgs/swift-google-gax/Tests/StrictIdempotencyTests.swift
@@ -18,7 +18,7 @@ import Testing
 
 @Suite struct StrictIdempotencyTest {
   private func transient() -> RequestError {
-    .http(HTTPDetails(http_status_code: 503, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 503, headers: [:], payload: Data()))
   }
 
   @Test func strictIdempotency() {

--- a/pkgs/swift-google-gax/Tests/TooManyRequestsPollingErrorPolicyTests.swift
+++ b/pkgs/swift-google-gax/Tests/TooManyRequestsPollingErrorPolicyTests.swift
@@ -51,7 +51,7 @@ import Testing
   }
 
   private func tooManyRequestsHttp() -> RequestError {
-    .http(HTTPDetails(http_status_code: 429, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 429, headers: [:], payload: Data()))
   }
 
   private func permanent() -> RequestError {

--- a/pkgs/swift-google-gax/Tests/TooManyRequestsRetryPolicyTests.swift
+++ b/pkgs/swift-google-gax/Tests/TooManyRequestsRetryPolicyTests.swift
@@ -67,7 +67,7 @@ import Testing
   }
 
   private func tooManyRequestsHttp() -> RequestError {
-    .http(HTTPDetails(http_status_code: 429, headers: [:], payload: Data()))
+    .http(HTTPDetails(httpStatusCode: 429, headers: [:], payload: Data()))
   }
 
   private func permanent() -> RequestError {


### PR DESCRIPTION
Follow the Swift style guide for symbol names, and enable the right magic commands to enforce these in CI.

Fixes #843 