### PR TITLE
ci: parallelize post-merge full build

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -16,3 +16,12 @@
 
 # Ignore anything ignored by `git`:
 #!include:.gitignore
+
+# This is an attempt to ignore most worktrees. Those are big, and slow down the
+# upload for manual builds.
+worktree*/
+chore-*/
+fix-*/
+perf-*/
+pr[0-9]*/
+test-*/

--- a/ci/gcb/builds/build-resources/main.tf
+++ b/ci/gcb/builds/build-resources/main.tf
@@ -58,7 +58,7 @@ resource "google_cloudbuild_worker_pool" "pool" {
   name     = "swift-sdk-pool"
   location = "us-central1"
   worker_config {
-    disk_size_gb   = 256
+    disk_size_gb   = 1024
     machine_type   = "e2-standard-8"
     no_external_ip = false
   }

--- a/ci/gcb/builds/triggers/main.tf
+++ b/ci/gcb/builds/triggers/main.tf
@@ -34,11 +34,6 @@ locals {
       config = "scripted.yaml"
       script = "integration-tests"
     }
-    full = {
-      config  = "scripted.yaml"
-      script  = "full"
-      pool_id = "swift-sdk-pool-large"
-    }
     docs = {
       config  = "scripted.yaml"
       script  = "docs"
@@ -46,14 +41,62 @@ locals {
   }
 
   # These are builds that only run during Pull Requests.
-  pr_build_overrides = {}
+  # PR builds run as a single shard.
+  pr_build_overrides = {
+    full = {
+      config  = "scripted.yaml"
+      script  = "full"
+      pool_id = "swift-sdk-pool"
+    }
+  }
 
   # There are builds that only run Post Merge.
-  pm_build_overrides = {}
+  # The full build is sharded across 16 parallel jobs. To change shard count in the future,
+  # or to shard any other build, simply set `shards = <count>` on that build definition.
+  pm_build_overrides = {
+    full = {
+      config  = "scripted.yaml"
+      script  = "full"
+      pool_id = "swift-sdk-pool"
+      shards  = 16
+    }
+  }
 
-  # Compute the effective list of builds.
-  pr_builds = merge(local.common_builds, local.pr_build_overrides)
-  pm_builds = merge(local.common_builds, local.pm_build_overrides)
+  # Compute the effective list of builds before shard expansion.
+  raw_pr_builds = merge(local.common_builds, local.pr_build_overrides)
+  raw_pm_builds = merge(local.common_builds, local.pm_build_overrides)
+
+  # Expand any build where `shards > 1` into N individual builds named `${name}-${i}`.
+  # Builds without `shards` (or `shards = 1`) keep their original name and run as 1 shard.
+  pr_builds = {
+    for item in flatten([
+      for name, build in local.raw_pr_builds : [
+        for i in range(try(build.shards, 1)) : {
+          key = try(build.shards, 1) > 1 ? "${name}-${i}" : name
+          config = merge(build, {
+            script      = try(build.script, name)
+            shard_index = tostring(i)
+            shard_count = tostring(try(build.shards, 1))
+          })
+        }
+      ]
+    ]) : item.key => item.config
+  }
+
+  pm_builds = {
+    for item in flatten([
+      for name, build in local.raw_pm_builds : [
+        for i in range(try(build.shards, 1)) : {
+          key = try(build.shards, 1) > 1 ? "${name}-${i}" : name
+          config = merge(build, {
+            script      = try(build.script, name)
+            shard_index = tostring(i)
+            shard_count = tostring(try(build.shards, 1))
+          })
+        }
+      ]
+    ]) : item.key => item.config
+  }
 }
 
 # This is used to retrieve the project number. The project number is embedded in
@@ -88,7 +131,7 @@ resource "google_cloudbuildv2_repository" "main" {
 }
 
 resource "google_cloudbuild_trigger" "pull-request" {
-  for_each = tomap(local.pr_builds)
+  for_each = local.pr_builds
   location = var.region
   name     = "gcb-pr-${each.key}"
   filename = "ci/gcb/${each.value.config}"
@@ -105,28 +148,20 @@ resource "google_cloudbuild_trigger" "pull-request" {
   }
 
   substitutions = {
-    _SCRIPT  = lookup(each.value, "script", "")
-    _POOL_ID = lookup(each.value, "pool_id", null)
+    _SCRIPT      = lookup(each.value, "script", "")
+    _POOL_ID     = lookup(each.value, "pool_id", null)
+    _SHARD_INDEX = lookup(each.value, "shard_index", null)
+    _SHARD_COUNT = lookup(each.value, "shard_count", null)
   }
 }
 
 resource "google_cloudbuild_trigger" "post-merge" {
-  for_each = {
-    # `tomap` will not do because we need to normalize these as objects.
-    for k, v in local.pm_builds : k => {
-      config         = v.config,
-      script         = try(v.script, "")
-      pool_id        = try(v.pool_id, null)
-      flags          = try(v.flags, "")
-      swift_version  = try(v.swift_version, null)
-      included_files = try(v.included_files, [])
-    }
-  }
+  for_each       = local.pm_builds
   location       = var.region
   name           = "gcb-pm-${each.key}"
   filename       = "ci/gcb/${each.value.config}"
   tags           = ["post-merge", "push", "name:${each.key}"]
-  included_files = each.value.included_files
+  included_files = try(each.value.included_files, [])
 
   service_account = var.service_account
 
@@ -141,6 +176,8 @@ resource "google_cloudbuild_trigger" "post-merge" {
     _SCRIPT        = lookup(each.value, "script", "")
     _SWIFT_VERSION = lookup(each.value, "swift_version", null)
     _POOL_ID       = lookup(each.value, "pool_id", null)
+    _SHARD_INDEX   = lookup(each.value, "shard_index", null)
+    _SHARD_COUNT   = lookup(each.value, "shard_count", null)
   }
 }
 

--- a/ci/gcb/scripted.yaml
+++ b/ci/gcb/scripted.yaml
@@ -25,6 +25,9 @@ options:
     - GOOGLE_CLOUD_SWIFT_TEST_RUNNING_ON_GCB=1
     - PROJECT_ID=${PROJECT_ID}
     - GCB_TRIGGER_NAME=${TRIGGER_NAME}
+    - TRIGGER_NAME=${_TRIGGER_NAME}
+    - SHARD_INDEX=${_SHARD_INDEX}
+    - SHARD_COUNT=${_SHARD_COUNT}
   workerPool: 'projects/${PROJECT_ID}/locations/${_POOL_REGION}/workerPools/${_POOL_ID}'
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
@@ -34,6 +37,9 @@ substitutions:
   _POOL_REGION: us-central1
   _POOL_ID: swift-sdk-pool
   _SWIFT_VERSION: '6.3'
+  _TRIGGER_NAME: ''
+  _SHARD_INDEX: '0'
+  _SHARD_COUNT: '1'
 # Increase the default timeout. Building all the packages
 # takes about 2h30m, go with 4h for a reasonable margin.
 timeout: 14400s

--- a/ci/gcb/scripts/full.sh
+++ b/ci/gcb/scripts/full.sh
@@ -25,26 +25,60 @@ source "${SCRIPT_DIR}/build-flags.sh"
 errors=0
 count=0
 
+shard_index="${1:-${SHARD_INDEX:-0}}"
+shard_count="${2:-${SHARD_COUNT:-1}}"
+trigger_name="${TRIGGER_NAME:-${GCB_TRIGGER_NAME:-}}"
+
+if ! [[ "${shard_index}" =~ ^[0-9]+$ ]] || ! [[ "${shard_count}" =~ ^[0-9]+$ ]]; then
+    echo "✗ Invalid shard parameters: shard_index='${shard_index}', shard_count='${shard_count}'"
+    exit 1
+fi
+
+if (( shard_count <= 0 )); then
+    echo "✗ shard_count must be greater than 0, got ${shard_count}"
+    exit 1
+fi
+
+if (( shard_index >= shard_count )); then
+    echo "✗ shard_index (${shard_index}) must be less than shard_count (${shard_count})"
+    exit 1
+fi
+
 flags=("${build_flags[@]}")
 source "${REPO_ROOT}/ci/package-dependencies.sh"
 # By default, build all the packages. We search for `Package.swift` files
 mapfile -t packages < <(find . \( -name Sources -o -name .build -o -name .build-cache \) -prune -o -type f -name Package.swift -exec dirname {} \; | sort -u)
 # On PRs, detect any new libraries and compile their documentation. Without this
 # step the post-merge build may break, and we prefer to avoid this problem.
-if [[ "${GCB_TRIGGER_NAME:-}" != gcb-pm-* ]]; then
-    echo "--- Building a subset because this is a PR"
+if [[ "${trigger_name}" != gcb-pm-* && "${shard_count}" -le 1 ]]; then
+    echo "--- Building a subset because this is a PR (trigger: ${trigger_name:-none})"
     # Add some standard packages.
     packages=('.')
     mapfile -t always < <(find pkgs -type f -name 'Package.swift' | xargs -I{} dirname {} | sort)
     packages+=("${always[@]}")
     if [[ -d .git ]]; then
-        git fetch --unshallow
-        mapfile -t new < <(git diff "origin/main...HEAD" --name-only --diff-filter=A | grep '/Package.swift' | grep -v /Sources/ | xargs -I{} dirname {})
+        git fetch --unshallow || true
+        mapfile -t new < <(git diff "origin/main...HEAD" --name-only --diff-filter=A 2>/dev/null | grep '/Package.swift' | grep -v /Sources/ | xargs -I{} dirname {})
         packages+=("${new[@]}")
-        echo "--- Discovered new directories in this PR: ${new[@]}"
+        echo "--- Discovered new directories in this PR: ${new[*]}"
     fi
 fi
-echo "--- Building ${#packages[@]} packages"
+
+if (( shard_count > 1 )); then
+    echo "--- Total packages before sharding: ${#packages[@]}"
+    shard_packages=()
+    for i in "${!packages[@]}"; do
+        if (( i % shard_count == shard_index )); then
+            shard_packages+=("${packages[i]}")
+        fi
+    done
+    packages=("${shard_packages[@]}")
+fi
+
+echo "--- Building shard ${shard_index} of ${shard_count} (${#packages[@]} packages)"
+for p in "${packages[@]}"; do
+    echo "  ${p}"
+done
 for dir in "${packages[@]}"; do
     [[ -f "${dir}/Package.swift" ]] || continue
     count=$((count + 1))


### PR DESCRIPTION
Use multiple shards to run the build. The shards can run on smaller VMs, and more shards with lower CPU each yields better elapsed time (under 1 hour). We do need larger disks on the 8-core VMs though, but disk is easy to get.

Fixes #844 and fixes #853 