### PR TITLE
ci(gha): minimal build on Windows

### DIFF
--- a/.github/actions/install-swift/action.yml
+++ b/.github/actions/install-swift/action.yml
@@ -24,6 +24,6 @@ runs:
         sudo apt -o Acquire::Retries=3 update -y
         sudo apt -o Acquire::Retries=3 install -y libncurses6
     - name: Set up Swift
-      uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # ratchet:swift-actions/setup-swift@v2.4
+      uses: SwiftyLab/setup-swift@38f54a76b70d989321de9dc7c840618c08cf56e9 # ratchet:SwiftyLab/setup-swift@v2.4
       with:
         swift-version: "6.2"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,13 @@ jobs:
           # swift-package-edit needed.
           echo ==== wkt ====
           swift test "${flags[@]}" --package-path pkgs/swift-google-wkt
+          if [[ "${RUNNER_OS}" = "Windows" ]]; then
+            # The remaining targets won't compile on Windows because
+            # async-http-client and grpc-swift-2 depend on swift-nio-extras,
+            # which does not support Windows.
+            exit 0
+          fi
+
           echo ==== auth ====
           swift test "${flags[@]}" --package-path pkgs/swift-google-auth
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository == 'googleapis/google-cloud-swift'
     strategy:
       matrix:
-        os: ['macos-26', 'ubuntu-24.04'] # , 'macos-26', 'windows-2025']
+        os: ['macos-26', 'ubuntu-24.04', 'windows-2025']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Fixes #803

I think this build is still useful. It stops us from adding file names with paths that are too long, and if / when the SwiftNIO ecosystem starts supporting Windows we won't have to do as much work.
